### PR TITLE
Fix the failure when building frontend project in Windows platform caused used by the "*.html" file generated by the generic route.

### DIFF
--- a/frontend/ice.config.mts
+++ b/frontend/ice.config.mts
@@ -7,6 +7,11 @@ import auth from '@ice/plugin-auth';
 export default defineConfig(() => ({
   ssr: false,
   ssg: false,
+  routes: {
+    defineRoutes: (route) => {
+      route('*', '404.tsx');
+    },
+  },
   proxy: {
     '/api': {
       target: 'http://47.117.68.79/',

--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -11,7 +11,7 @@ const NoFoundPage: React.FC = () => {
     title={t('error.404.title')}
     subTitle={t('error.404.subTitle')}
     extra={
-      <Button type="primary" onClick={() => history?.push('/dashboard')}>
+      <Button type="primary" onClick={() => history?.push('/')}>
         {t('misc.return')}
       </Button>
     }


### PR DESCRIPTION
The original usage of generic route for handling 404 errors will cause a "*.html" file being generated by the build process. And Windows platform doesn't support any file name containing a "*" character, but Linux does.

This PR replaces the implicit wildcard route definition using file name with an explicit route definition in the ice.config.mts file. Problem solved.