### PR TITLE
Fix bugs in TLS certificate management function

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,11 +68,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.nimbusds</groupId>
-			<artifactId>nimbus-jose-jwt</artifactId>
-			<version>9.30.1</version>
-		</dependency>
-		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk16</artifactId>
 			<version>1.46</version>

--- a/backend/src/main/java/com/alibaba/higress/console/aop/ApiStandardizationAspect.java
+++ b/backend/src/main/java/com/alibaba/higress/console/aop/ApiStandardizationAspect.java
@@ -20,6 +20,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -72,7 +73,12 @@ public class ApiStandardizationAspect {
                 }
                 SessionUserHelper.setCurrentUser(user);
             }
-            return point.proceed();
+            Object result = point.proceed();
+            if (requestAttributes != null && requestAttributes.getResponse() != null
+                && HttpMethod.DELETE.name().equals(requestAttributes.getRequest().getMethod())) {
+                requestAttributes.getResponse().setStatus(HttpStatus.NO_CONTENT.value());
+            }
+            return result;
         } catch (Throwable t) {
             Signature signature = point.getSignature();
             String objectName = signature.getDeclaringTypeName();

--- a/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesClientService.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesClientService.java
@@ -361,7 +361,7 @@ public class KubernetesClientService {
         CoreV1Api coreV1Api = new CoreV1Api(client);
         V1Status status;
         try {
-            status = coreV1Api.deleteNamespacedConfigMap(name, controllerNamespace, null, null, null, null, null, null);
+            status = coreV1Api.deleteNamespacedSecret(name, controllerNamespace, null, null, null, null, null, null);
         } catch (ApiException ae) {
             if (ae.getCode() == HttpStatus.NOT_FOUND.value()) {
                 // The Secret to be deleted is already gone or never existed.


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix bugs in TLS certificate management function
1. Unable to delete certificates.
2. Delete APIs return 200 status instead of 204.
3. No error log when failed to parse certificate data

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
