### PR TITLE
fix: Set the name of admin secret in the deployment

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
               value: /usr/local/openjdk-18
             - name: LANG
               value: C.UTF-8
+            - name: HIGRESS_CONSOLE_ADMIN_SECRET
+              value: {{ include "higress-console.fullname" . }}
             - name: HIGRESS_CONSOLE_CONFIG_MAP_NAME
               value: {{ include "higress-console.fullname" . }}
             {{- if .Values.o11y.enabled }}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Set the name of admin secret in the deployment so the console can work when it is installed with a name other than "higress-console".

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
