### PR TITLE
fix: Mark zkServicesPath property of ServiceSource as optional

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/controller/dto/ServiceSource.java
+++ b/backend/src/main/java/com/alibaba/higress/console/controller/dto/ServiceSource.java
@@ -64,10 +64,6 @@ public class ServiceSource {
             }
         }
 
-        if (V1McpBridge.REGISTRY_TYPE_ZK.equals(this.getType())
-            && null == this.getProperties().get(V1McpBridge.REGISTRY_TYPE_ZK_ZKSERVICESPATH)) {
-            return false;
-        }
         return true;
     }
 }

--- a/frontend/src/pages/service-source/components/SourceForm/index.tsx
+++ b/frontend/src/pages/service-source/components/SourceForm/index.tsx
@@ -127,12 +127,6 @@ const SourceForm: React.FC = forwardRef((props, ref) => {
               label={t('serviceSource.serviceSourceForm.zkServicesPath')}
               name={['properties', 'zkServicesPath']}
               tooltip={t('serviceSource.serviceSourceForm.zkServicesPathTooltip')}
-              rules={[
-                {
-                  required: true,
-                  message: t('serviceSource.serviceSourceForm.zkServicesPathRequired'),
-                },
-              ]}
             >
               <Select
                 allowClear


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Mark zkServicesPath property of ServiceSource as optional

![image](https://user-images.githubusercontent.com/2909796/227088131-c6d36ca5-9e66-4abe-85d5-464747b8a98c.png)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
