### PR TITLE
fix: Fix the incorrect filter result in service source page

### DIFF
--- a/frontend/src/pages/service/index.tsx
+++ b/frontend/src/pages/service/index.tsx
@@ -54,7 +54,7 @@ const ServiceList: React.FC = () => {
       const _namespaces: OptionItem[] = [];
       result && result.forEach(service => {
         const { name, namespace } = service;
-        service.key = name;
+        service.key = serviceToString(service);
         if (!_os.has(namespace)) {
           _namespaces.push({
             label: namespace,


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix the incorrect filter result in service source page.

Before:
![4d579e5085a85e975643bf0538dd6879](https://user-images.githubusercontent.com/2909796/227473481-e88c5ec5-2e33-488a-9888-3853b92a0638.png)

After:
![image](https://user-images.githubusercontent.com/2909796/227473514-d812aba7-7e28-4bb8-8920-27a163dd1630.png)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
