### PR TITLE
fix: Fix some bugs in Wasm plugin management module

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
@@ -426,7 +426,7 @@ public class KubernetesModelConverter {
             case GLOBAL:
                 if (target == null) {
                     enabled = !Boolean.TRUE.equals(spec.getDefaultConfigDisable());
-                    configurations = spec.getDefaultConfig();
+                    configurations = Optional.ofNullable(spec.getDefaultConfig()).orElse(Collections.emptyMap());
                 }
                 break;
             case DOMAIN:

--- a/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
@@ -454,7 +454,7 @@ public class KubernetesModelConverter {
         }
 
         if (enabled == null) {
-            // No enabled is set， which means not configured.
+            // No enabled is set, which means not configured.
             return null;
         }
         if (!enabled && MapUtils.isEmpty(configurations)) {

--- a/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
@@ -452,7 +452,13 @@ public class KubernetesModelConverter {
             default:
                 throw new IllegalArgumentException("Unsupported scope: " + scope);
         }
-        if (MapUtils.isEmpty(configurations)) {
+
+        if (enabled == null) {
+            // No enabled is set， which means not configured.
+            return null;
+        }
+        if (!enabled && MapUtils.isEmpty(configurations)) {
+            // Disabled and no configuration set. We just take it as not configured.
             return null;
         }
 

--- a/backend/src/main/resources/plugins/basic-auth/spec.yaml
+++ b/backend/src/main/resources/plugins/basic-auth/spec.yaml
@@ -21,6 +21,7 @@ spec:
       properties:
         global_auth:
           type: boolean
+          scope: GLOBAL
           title: 是否开启全局认证
           x-title-i18n:
             en-US: Enable Global Auth

--- a/backend/src/main/resources/plugins/bot-detect/spec.yaml
+++ b/backend/src/main/resources/plugins/bot-detect/spec.yaml
@@ -19,9 +19,5 @@ spec:
     openAPIV3Schema:
       type: object
       example:
-        allow:
-          - ".*Go-http-client.*"
-        deny:
-          - "*.Apache.*"
         blocked_code: 404
         blocked_message: "resource not found"

--- a/backend/src/main/resources/plugins/key-auth/spec.yaml
+++ b/backend/src/main/resources/plugins/key-auth/spec.yaml
@@ -21,6 +21,7 @@ spec:
       properties:
         global_auth:
           type: boolean
+          scope: GLOBAL
           title: 是否开启全局认证
           x-title-i18n:
             en-US: Enable Global Auth


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

1. Set the scope of global_auth property to GLOBAL
2. Fix the incorrect example configuration of bot-detect plugin
3. Keep the current plugin instances after a custom plugin being upgraded
4. Fix the incorrect rawConfigurations value of jwt-auth plugin
5. Return an empty object or string when querying config schema or readme file of a custom plugin
6. Make sure the new custom Wasm plugin is globally disabled by default

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
