### PR TITLE
feat: Unify the UI style of strategy configuration drawers

### DIFF
--- a/frontend/src/pages/plugin/components/Cors/index.tsx
+++ b/frontend/src/pages/plugin/components/Cors/index.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Form, Row, Col, Switch, Radio, InputNumber, Input } from 'antd';
-
 import { useEffect, forwardRef, useImperativeHandle } from 'react';
 import { useTranslation } from 'react-i18next';
+import styles from './index.module.css';
 
 const { TextArea } = Input;
 
@@ -65,7 +65,7 @@ const Cors = forwardRef((props, ref) => {
 
   return (
     <div>
-      <Form name="basic" form={form} autoComplete="off" layout="vertical">
+      <Form name="basic" form={form} autoComplete="off" layout="horizontal">
         <Form.Item label={t('plugins.configForm.enableStatus')} name="enabled" valuePropName="checked">
           <Switch />
         </Form.Item>
@@ -73,6 +73,8 @@ const Cors = forwardRef((props, ref) => {
           label={t('plugins.builtIns.cors.allowOrigins')}
           name="allowOrigins"
           rules={[{ required: true, message: t('plugins.builtIns.cors.allowOriginsRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <TextArea />
         </Form.Item>
@@ -80,6 +82,8 @@ const Cors = forwardRef((props, ref) => {
           label={t('plugins.builtIns.cors.allowMethods')}
           name="allowMethods"
           rules={[{ required: true, message: t('plugins.builtIns.cors.allowMethodsRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <Checkbox.Group>
             <Row>
@@ -100,6 +104,8 @@ const Cors = forwardRef((props, ref) => {
           label={t('plugins.builtIns.cors.allowHeaders')}
           name="allowHeaders"
           rules={[{ required: true, message: t('plugins.builtIns.cors.allowHeadersRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <TextArea />
         </Form.Item>
@@ -107,6 +113,8 @@ const Cors = forwardRef((props, ref) => {
           label={t('plugins.builtIns.cors.exposeHeaders')}
           name="exposeHeaders"
           rules={[{ required: true, message: t('plugins.builtIns.cors.exposeHeadersRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <TextArea />
         </Form.Item>
@@ -114,6 +122,8 @@ const Cors = forwardRef((props, ref) => {
           label={t('plugins.builtIns.cors.allowCredentials')}
           name="allowCredentials"
           valuePropName="checked"
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <Radio.Group defaultValue="true">
             <Radio value="true">{t('plugins.builtIns.cors.allow')}</Radio>
@@ -124,6 +134,8 @@ const Cors = forwardRef((props, ref) => {
           label={t('plugins.builtIns.cors.maxAge')}
           name="maxAge"
           rules={[{ required: true, message: t('plugins.builtIns.cors.maxAgeRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <InputNumber addonAfter={t('misc.seconds')} />
         </Form.Item>

--- a/frontend/src/pages/plugin/components/Retries/index.tsx
+++ b/frontend/src/pages/plugin/components/Retries/index.tsx
@@ -44,7 +44,7 @@ const Retries = forwardRef((props, ref) => {
         initialValues={{ attempts: 3, retryOn: 'error' }}
         autoComplete="off"
         form={form}
-        layout="vertical"
+        layout="horizontal"
       >
         <Form.Item
           label={t('plugins.configForm.enableStatus')}
@@ -57,6 +57,8 @@ const Retries = forwardRef((props, ref) => {
           label={t('plugins.builtIns.retries.attempts')}
           name="attempts"
           rules={[{ required: true, message: t('plugins.builtIn.retries.attemptsRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <InputNumber style={{ width: '100%' }} max={3} />
         </Form.Item>
@@ -64,6 +66,8 @@ const Retries = forwardRef((props, ref) => {
           label={t('plugins.builtIns.retries.conditions')}
           name="conditions"
           rules={[{ required: true, message: t('plugins.builtIn.retries.conditionsRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <Select mode="multiple">
             <Option value="error">{t('plugins.builtIns.retries.condition.error')}</Option>
@@ -75,6 +79,8 @@ const Retries = forwardRef((props, ref) => {
           label={t('plugins.builtIns.retries.timeout')}
           name="timeout"
           rules={[{ required: true, message: t('plugins.builtIn.retries.timeoutRequired') || '' }]}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
         >
           <InputNumber style={{ width: '100%' }} min={1} max={600} addonAfter="秒" />
         </Form.Item>

--- a/frontend/src/pages/plugin/components/Rewrite/index.tsx
+++ b/frontend/src/pages/plugin/components/Rewrite/index.tsx
@@ -54,14 +54,21 @@ const Rewrite = forwardRef((props, ref) => {
 
   return (
     <div className={styles.rewrite}>
-      <Form name="basic" autoComplete="off" form={form} layout="vertical">
-        <Card title={t('plugins.configForm.enableStatus')}>
-          <Form.Item name="enabled" label="" valuePropName="checked">
-            <Switch />
-          </Form.Item>
-        </Card>
-        <Card title={t('plugins.builtIns.rewrite.path')}>
-          <Form.Item label={t('plugins.builtIns.rewrite.originalPath')}>
+      <Form name="basic" autoComplete="off" form={form} layout="horizontal">
+        <Form.Item name="enabled" label={t('plugins.configForm.enableStatus')} valuePropName="checked">
+          <Switch />
+        </Form.Item>
+
+        <Form.Item
+          label={t('plugins.builtIns.rewrite.path')}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
+        >
+          <Form.Item
+            label={t('plugins.builtIns.rewrite.originalPath')}
+            labelCol={{ span: 24 }}
+            wrapperCol={{ span: 24 }}
+          >
             <Input.Group compact>
               <Form.Item name={['origin', 'matchType']} noStyle>
                 <Select disabled style={{ width: '40%' }}>
@@ -75,7 +82,11 @@ const Rewrite = forwardRef((props, ref) => {
               </Form.Item>
             </Input.Group>
           </Form.Item>
-          <Form.Item label={t('plugins.builtIns.rewrite.rewritePath')}>
+          <Form.Item
+            label={t('plugins.builtIns.rewrite.rewritePath')}
+            labelCol={{ span: 24 }}
+            wrapperCol={{ span: 24 }}
+          >
             <Input.Group compact>
               <Form.Item name={['new', 'matchType']} noStyle>
                 <Select disabled style={{ width: '40%' }} placeholder={t('route.routeForm.matchType')}>
@@ -88,16 +99,30 @@ const Rewrite = forwardRef((props, ref) => {
               </Form.Item>
             </Input.Group>
           </Form.Item>
-        </Card>
+        </Form.Item>
 
-        <Card title={t('plugins.builtIns.rewrite.host')}>
-          <Form.Item label={t('plugins.builtIns.rewrite.originalHost')} name="origin_host">
+        <Form.Item
+          label={t('plugins.builtIns.rewrite.host')}
+          labelCol={{ span: 24 }}
+          wrapperCol={{ span: 24 }}
+        >
+          <Form.Item
+            label={t('plugins.builtIns.rewrite.originalHost')}
+            name="origin_host"
+            labelCol={{ span: 24 }}
+            wrapperCol={{ span: 24 }}
+          >
             <Input disabled />
           </Form.Item>
-          <Form.Item label={t('plugins.builtIns.rewrite.rewriteHost')} name="host">
+          <Form.Item
+            label={t('plugins.builtIns.rewrite.rewriteHost')}
+            name="host"
+            labelCol={{ span: 24 }}
+            wrapperCol={{ span: 24 }}
+          >
             <Input placeholder={t('plugins.builtIns.rewrite.rewriteHostPlaceholder')} maxLength={1024} />
           </Form.Item>
-        </Card>
+        </Form.Item>
       </Form>
     </div>
   );


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Unify the UI style of strategy configuration drawers.

Before:
![image](https://user-images.githubusercontent.com/2909796/236104516-69abba17-c15d-43a0-9d24-9f2db5f43c64.png)


After:
![image](https://user-images.githubusercontent.com/2909796/236104505-b0ed575e-8c0d-4d12-a05c-7c89684c134e.png)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
