### PR TITLE
fix: Only ask user to access Higress Console through Ingress

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,24 +1,10 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
+1. Use the following URL to access the console:
+{{- range $path := .Values.ingress.paths }}
+  http{{ if $.Values.tlsSecretName }}s{{ end }}://{{ $.Values.domain }}{{ .path }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "higress-console.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "higress-console.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "higress-console.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "higress-console.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- if or .Values.global.local .Values.global.kind }}
+  Since Higress Console is running in local mode, you may need to add the following line into your hosts file before accessing the console:
+  127.0.0.1 {{ $.Values.domain }}
 {{- end }}
 2. Use following commands to get the credential and login:
   export ADMIN_USERNAME=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "higress-console.fullname" . }} -o jsonpath="{.data.adminUsername}" | base64 -d)


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Only ask user to access Higress Console through Ingress, since accessing the pod of console directly won't return 404 when trying to access the build-in Grafana dashboard.

![image](https://github.com/higress-group/higress-console/assets/2909796/601973ee-dd0e-472c-a483-f022cb10b2b7)

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
