### PR TITLE
feat: Support overwriting the existed built-in dashboard configuration during startup

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/constant/CommonKey.java
+++ b/backend/src/main/java/com/alibaba/higress/console/constant/CommonKey.java
@@ -77,6 +77,8 @@ public class CommonKey {
 
     public final static String CONTROLLER_ACCESS_TOKEN_KEY = CONFIG_KEY_PREFIX + "controller.access-token";
 
+    public final static String DASHBOARD_OVERWRITE_WHEN_STARTUP_KEY = CONFIG_KEY_PREFIX + "dashboard.overwrite-when-startup";
+    public final static boolean DASHBOARD_OVERWRITE_WHEN_STARTUP_DEFAULT = true;
     public final static String DASHBOARD_BASE_URL_KEY = CONFIG_KEY_PREFIX + "dashboard.base-url";
 
     public final static String DASHBOARD_USERNAME_KEY = CONFIG_KEY_PREFIX + "dashboard.username";


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support overwriting the existed built-in dashboard configuration during startup. Overwriting is enabled by default. And user can disable it by setting the environment variable  `HIGRESS_CONSOLE_DASHBOARD_OVERWRITE_WHEN_STARTUP` to `false`.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
