### PR TITLE
fix: Use the current storageClass for existed PVCs when upgrading

### DIFF
--- a/helm/templates/grafana.yaml
+++ b/helm/templates/grafana.yaml
@@ -3,6 +3,11 @@
 {{- $config := .Values.o11y.grafana }}
 {{- $port := $config.port -}}
 {{- $ingress := $config.ingress }}
+{{- $storageClassName := $config.pvc.storageClassName }}
+{{- $existedPvc := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $appName) }}
+{{- if and $existedPvc $existedPvc.spec.storageClassName }}
+{{-   $storageClassName = $existedPvc.spec.storageClassName }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -39,7 +44,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  storageClassName: {{ $config.pvc.storageClassName }}
+  storageClassName: {{ $storageClassName }}
   resources:
     requests:
       storage: {{ $config.storage }}

--- a/helm/templates/prometheus.yaml
+++ b/helm/templates/prometheus.yaml
@@ -3,6 +3,11 @@
 {{- $config := .Values.o11y.prometheus }}
 {{- $port := $config.port }}
 {{- $ingress := $config.ingress -}}
+{{- $storageClassName := $config.pvc.storageClassName }}
+{{- $existedPvc := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $appName) }}
+{{- if and $existedPvc $existedPvc.spec.storageClassName }}
+{{-   $storageClassName = $existedPvc.spec.storageClassName }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -79,7 +84,7 @@ spec:
   {{- else }}
   - ReadWriteMany
   {{- end }}
-  storageClassName: {{ $config.pvc.storageClassName }}
+  storageClassName: {{ $storageClassName }}
   resources:
     requests:
       storage: {{ $config.storage }}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Use the current storageClass for existed PVCs when upgrading to fix the malfunction of upgrading Higress Console with `helm upgrade`.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
