### PR TITLE
fix: Compensate WasmPlugin.phase field if not set in the CR

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesModelConverter.java
@@ -40,6 +40,7 @@ import javax.security.auth.x500.X500Principal;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.x509.GeneralName;
 
@@ -67,6 +68,7 @@ import com.alibaba.higress.console.service.kubernetes.crd.mcp.V1McpBridge;
 import com.alibaba.higress.console.service.kubernetes.crd.mcp.V1McpBridgeSpec;
 import com.alibaba.higress.console.service.kubernetes.crd.mcp.V1RegistryConfig;
 import com.alibaba.higress.console.service.kubernetes.crd.wasm.MatchRule;
+import com.alibaba.higress.console.service.kubernetes.crd.wasm.PluginPhase;
 import com.alibaba.higress.console.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
 import com.alibaba.higress.console.service.kubernetes.crd.wasm.V1alpha1WasmPluginSpec;
 import com.alibaba.higress.console.util.TypeUtil;
@@ -383,7 +385,7 @@ public class KubernetesModelConverter {
 
         V1alpha1WasmPluginSpec spec = cr.getSpec();
         if (spec != null) {
-            plugin.setPhase(spec.getPhase());
+            plugin.setPhase(ObjectUtils.firstNonNull(spec.getPhase(), PluginPhase.UNSPECIFIED.getName()));
             plugin.setPriority(spec.getPriority());
             String url = spec.getUrl();
             if (StringUtils.isNotEmpty(url)) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Compensate WasmPlugin.phase field with the default value if it's not set in the CR

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
