### PR TITLE
fix: Unify the name prefix of CRUD methods used in KubernetesClientService

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/service/ServiceSourceServiceImpl.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/ServiceSourceServiceImpl.java
@@ -68,7 +68,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
     public PaginatedResult<ServiceSource> list(CommonPageQuery query) {
         V1McpBridge mcpBridge;
         try {
-            mcpBridge = kubernetesClientService.getMcpBridge(V1McpBridge.DEFAULT_NAME);
+            mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
                 return PaginatedResult.createFromFullList(Collections.emptyList(), query);
@@ -96,7 +96,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
     public ServiceSource addOrUpdate(ServiceSource serviceSource) {
         V1McpBridge mcpBridge = null;
         try {
-            mcpBridge = kubernetesClientService.getMcpBridge(V1McpBridge.DEFAULT_NAME);
+            mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
             if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
                 throw new BusinessException("Error occurs when getting McpBridge.", e);
@@ -108,11 +108,11 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
                 kubernetesModelConverter.initV1McpBridge(mcpBridge);
                 V1RegistryConfig registry = kubernetesModelConverter.addV1McpBridgeRegistry(mcpBridge, serviceSource);
                 syncAuthSecret(serviceSource, registry);
-                kubernetesClientService.addMcpBridge(mcpBridge);
+                kubernetesClientService.createMcpBridge(mcpBridge);
             } else {
                 V1RegistryConfig registry = kubernetesModelConverter.addV1McpBridgeRegistry(mcpBridge, serviceSource);
                 syncAuthSecret(serviceSource, registry);
-                kubernetesClientService.updateMcpBridge(mcpBridge);
+                kubernetesClientService.replaceMcpBridge(mcpBridge);
             }
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.CONFLICT.value()) {
@@ -128,7 +128,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
     public void delete(String name) {
         V1McpBridge mcpBridge;
         try {
-            mcpBridge = kubernetesClientService.getMcpBridge(V1McpBridge.DEFAULT_NAME);
+            mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
                 return;
@@ -148,7 +148,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
             }
         }
         try {
-            kubernetesClientService.updateMcpBridge(mcpBridge);
+            kubernetesClientService.replaceMcpBridge(mcpBridge);
         } catch (ApiException e) {
             throw new BusinessException("Error occurs when deleting the ServiceSource with name: " + name, e);
         }
@@ -158,7 +158,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
     public ServiceSource query(String name) throws BusinessException {
         V1McpBridge mcpBridge;
         try {
-            mcpBridge = kubernetesClientService.getMcpBridge(V1McpBridge.DEFAULT_NAME);
+            mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
                 return null;
@@ -182,7 +182,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
     public ServiceSource add(ServiceSource serviceSource) {
         V1McpBridge mcpBridge = null;
         try {
-            mcpBridge = kubernetesClientService.getMcpBridge(V1McpBridge.DEFAULT_NAME);
+            mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
             if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
                 throw new BusinessException("Error occurs when getting McpBridge.", e);
@@ -194,7 +194,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
                 kubernetesModelConverter.initV1McpBridge(mcpBridge);
                 V1RegistryConfig registry = kubernetesModelConverter.addV1McpBridgeRegistry(mcpBridge, serviceSource);
                 syncAuthSecret(serviceSource, registry);
-                kubernetesClientService.addMcpBridge(mcpBridge);
+                kubernetesClientService.createMcpBridge(mcpBridge);
             } else {
                 V1McpBridgeSpec spec = mcpBridge.getSpec();
                 if (spec != null && spec.getRegistries() != null) {
@@ -206,7 +206,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
                 }
                 V1RegistryConfig registry = kubernetesModelConverter.addV1McpBridgeRegistry(mcpBridge, serviceSource);
                 syncAuthSecret(serviceSource, registry);
-                kubernetesClientService.updateMcpBridge(mcpBridge);
+                kubernetesClientService.replaceMcpBridge(mcpBridge);
             }
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.CONFLICT.value()) {

--- a/backend/src/main/java/com/alibaba/higress/console/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/WasmPluginInstanceServiceImpl.java
@@ -160,11 +160,11 @@ public class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService 
                 }
                 result = kubernetesModelConverter.wasmPluginToCr(plugin);
                 kubernetesModelConverter.setWasmPluginInstanceToCr(result, instance);
-                result = kubernetesClientService.addWasmPlugin(result);
+                result = kubernetesClientService.createWasmPlugin(result);
             } else {
                 result = existedCr;
                 kubernetesModelConverter.setWasmPluginInstanceToCr(result, instance);
-                result = kubernetesClientService.updateWasmPlugin(result);
+                result = kubernetesClientService.replaceWasmPlugin(result);
             }
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.CONFLICT.value()) {
@@ -210,7 +210,7 @@ public class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService 
             boolean needUpdate = kubernetesModelConverter.removeWasmPluginInstanceFromCr(cr, scope, target);
             if (needUpdate) {
                 try {
-                    kubernetesClientService.updateWasmPlugin(cr);
+                    kubernetesClientService.replaceWasmPlugin(cr);
                 } catch (ApiException e) {
                     throw new BusinessException(
                         "Error occurs when trying to updating WasmPlugin with name " + cr.getMetadata().getName(), e);

--- a/backend/src/main/java/com/alibaba/higress/console/service/WasmPluginServiceImpl.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/WasmPluginServiceImpl.java
@@ -392,7 +392,7 @@ public class WasmPluginServiceImpl implements WasmPluginService {
         cr.getSpec().setDefaultConfigDisable(true);
         V1alpha1WasmPlugin addedCr;
         try {
-            addedCr = kubernetesClientService.addWasmPlugin(cr);
+            addedCr = kubernetesClientService.createWasmPlugin(cr);
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.CONFLICT.value()) {
                 throw new ResourceConflictException();
@@ -446,7 +446,7 @@ public class WasmPluginServiceImpl implements WasmPluginService {
 
             V1alpha1WasmPlugin updatedCr;
             try {
-                updatedCr = kubernetesClientService.updateWasmPlugin(cr);
+                updatedCr = kubernetesClientService.replaceWasmPlugin(cr);
             } catch (ApiException e) {
                 if (e.getCode() == HttpStatus.CONFLICT.value()) {
                     throw new ResourceConflictException();
@@ -463,7 +463,7 @@ public class WasmPluginServiceImpl implements WasmPluginService {
 
         V1alpha1WasmPlugin updatedCr;
         try {
-            updatedCr = kubernetesClientService.addWasmPlugin(cr);
+            updatedCr = kubernetesClientService.createWasmPlugin(cr);
         } catch (ApiException e) {
             if (e.getCode() == HttpStatus.CONFLICT.value()) {
                 throw new ResourceConflictException();

--- a/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesClientService.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/kubernetes/KubernetesClientService.java
@@ -394,14 +394,14 @@ public class KubernetesClientService {
         }
     }
 
-    public V1McpBridge addMcpBridge(V1McpBridge mcpBridge) throws ApiException {
+    public V1McpBridge createMcpBridge(V1McpBridge mcpBridge) throws ApiException {
         CustomObjectsApi customObjectsApi = new CustomObjectsApi(client);
         Object response = customObjectsApi.createNamespacedCustomObject(V1McpBridge.API_GROUP, V1McpBridge.VERSION,
             controllerNamespace, V1McpBridge.PLURAL, mcpBridge, null, null, null);
         return client.getJSON().deserialize(client.getJSON().serialize(response), V1McpBridge.class);
     }
 
-    public V1McpBridge updateMcpBridge(V1McpBridge mcpBridge) throws ApiException {
+    public V1McpBridge replaceMcpBridge(V1McpBridge mcpBridge) throws ApiException {
         V1ObjectMeta metadata = mcpBridge.getMetadata();
         if (metadata == null) {
             throw new IllegalArgumentException("mcpBridge doesn't have a valid metadata.");
@@ -419,7 +419,7 @@ public class KubernetesClientService {
             V1McpBridge.PLURAL, name, null, null, null, null, null);
     }
 
-    public V1McpBridge getMcpBridge(String name) throws ApiException {
+    public V1McpBridge readMcpBridge(String name) throws ApiException {
         CustomObjectsApi customObjectsApi = new CustomObjectsApi(client);
         Object response = customObjectsApi.getNamespacedCustomObject(V1McpBridge.API_GROUP, V1McpBridge.VERSION,
             controllerNamespace, V1McpBridge.PLURAL, name);
@@ -461,7 +461,7 @@ public class KubernetesClientService {
         return sortKubernetesObjects(list.getItems());
     }
 
-    public V1alpha1WasmPlugin addWasmPlugin(V1alpha1WasmPlugin plugin) throws ApiException {
+    public V1alpha1WasmPlugin createWasmPlugin(V1alpha1WasmPlugin plugin) throws ApiException {
         CustomObjectsApi customObjectsApi = new CustomObjectsApi(client);
         renderDefaultLabels(plugin);
         Object response = customObjectsApi.createNamespacedCustomObject(V1alpha1WasmPlugin.API_GROUP,
@@ -469,7 +469,7 @@ public class KubernetesClientService {
         return client.getJSON().deserialize(client.getJSON().serialize(response), V1alpha1WasmPlugin.class);
     }
 
-    public V1alpha1WasmPlugin updateWasmPlugin(V1alpha1WasmPlugin plugin) throws ApiException {
+    public V1alpha1WasmPlugin replaceWasmPlugin(V1alpha1WasmPlugin plugin) throws ApiException {
         V1ObjectMeta metadata = plugin.getMetadata();
         if (metadata == null) {
             throw new IllegalArgumentException("WasmPlugin doesn't have a valid metadata.");
@@ -488,7 +488,7 @@ public class KubernetesClientService {
             controllerNamespace, V1alpha1WasmPlugin.PLURAL, name, null, null, null, null, null);
     }
 
-    public V1alpha1WasmPlugin getWasmPlugin(String name) throws ApiException {
+    public V1alpha1WasmPlugin readWasmPlugin(String name) throws ApiException {
         CustomObjectsApi customObjectsApi = new CustomObjectsApi(client);
         Object response = customObjectsApi.getNamespacedCustomObject(V1alpha1WasmPlugin.API_GROUP,
             V1alpha1WasmPlugin.VERSION, controllerNamespace, V1alpha1WasmPlugin.PLURAL, name);


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Unify the name prefix of CRUD methods used in KubernetesClientService:

- list
- read
- create
- replace
- delete

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
