### PR TITLE
feat: Use console itself to forward requests to the built-in dashboard

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -60,6 +60,11 @@
 			<version>1.2.83</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+		</dependency>
+
 		<!-- https://github.com/kubernetes-client/java/wiki/2.-Versioning-and-Compatibility -->
 		<dependency>
 			<groupId>io.kubernetes</groupId>

--- a/backend/src/main/java/com/alibaba/higress/console/constant/CommonKey.java
+++ b/backend/src/main/java/com/alibaba/higress/console/constant/CommonKey.java
@@ -81,7 +81,8 @@ public class CommonKey {
 
     public final static String CONTROLLER_ACCESS_TOKEN_KEY = CONFIG_KEY_PREFIX + "controller.access-token";
 
-    public final static String DASHBOARD_OVERWRITE_WHEN_STARTUP_KEY = CONFIG_KEY_PREFIX + "dashboard.overwrite-when-startup";
+    public final static String DASHBOARD_OVERWRITE_WHEN_STARTUP_KEY =
+        CONFIG_KEY_PREFIX + "dashboard.overwrite-when-startup";
     public final static boolean DASHBOARD_OVERWRITE_WHEN_STARTUP_DEFAULT = true;
     public final static String DASHBOARD_BASE_URL_KEY = CONFIG_KEY_PREFIX + "dashboard.base-url";
 
@@ -98,6 +99,16 @@ public class CommonKey {
     public final static String DASHBOARD_DATASOURCE_NAME_DEFAULT = "Prometheus";
 
     public final static String DASHBOARD_DATASOURCE_URL_KEY = CONFIG_KEY_PREFIX + "dashboard.datasource.url";
+
+    public final static String DASHBOARD_PROXY_CONNECTION_TIMEOUT_KEY =
+        CONFIG_KEY_PREFIX + "dashboard.proxy.connection-timeout";
+
+    public final static int DASHBOARD_PROXY_CONNECTION_TIMEOUT_DEFAULT = 1200;
+
+    public final static String DASHBOARD_PROXY_SOCKET_TIMEOUT_KEY =
+        CONFIG_KEY_PREFIX + "dashboard.proxy.socket-timeout";
+
+    public final static int DASHBOARD_PROXY_SOCKET_TIMEOUT_DEFAULT = 2 * 60 * 1000;
 
     public final static String LOGIN_PAGE_PROMPT_KEY = CONFIG_KEY_PREFIX + "web.login.prompt";
 

--- a/backend/src/main/java/com/alibaba/higress/console/controller/GrafanaController.java
+++ b/backend/src/main/java/com/alibaba/higress/console/controller/GrafanaController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.console.controller;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.alibaba.higress.console.service.DashboardService;
+
+@Controller
+@RequestMapping(value = "/grafana/**")
+public class GrafanaController {
+
+    private DashboardService dashboardService;
+
+    @Autowired
+    public void setDashboardService(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    @RequestMapping
+    public void forward(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        dashboardService.forwardDashboardRequest(request, response);
+    }
+}

--- a/backend/src/main/java/com/alibaba/higress/console/service/DashboardService.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/DashboardService.java
@@ -12,6 +12,11 @@
  */
 package com.alibaba.higress.console.service;
 
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import com.alibaba.higress.console.controller.dto.DashboardInfo;
 
 /**
@@ -26,4 +31,6 @@ public interface DashboardService {
     void setDashboardUrl(String url);
 
     String buildConfigData(String dataSourceUid);
+
+    void forwardDashboardRequest(HttpServletRequest request, HttpServletResponse response) throws IOException;
 }

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -56,12 +56,20 @@ Create a default fully qualified app name for Grafana.
 {{- printf "%s-grafana" ($consoleName | trunc 55) }}
 {{- end }}
 
+{{- define "higress-console-grafana.path" -}}
+/grafana
+{{- end }}
+
 {{/*
 Create a default fully qualified app name for Prometheus.
 */}}
 {{- define "higress-console-prometheus.name" -}}
 {{- $consoleName := include "higress-console.name" . }}
 {{- printf "%s-prometheus" ($consoleName | trunc 52) }}
+{{- end }}
+
+{{- define "higress-console-prometheus.path" -}}
+/prometheus
 {{- end }}
 
 {{/*

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -47,9 +47,9 @@ spec:
               value: {{ include "higress-console.controller.jwtPolicy" . }}
             {{- if .Values.o11y.enabled }}
             - name: HIGRESS_CONSOLE_DASHBOARD_BASE_URL
-              value: http://{{ include "higress-console-grafana.name" . }}.{{ .Release.Namespace }}:{{ .Values.o11y.grafana.port }}{{ .Values.o11y.grafana.ingress.path }}
+              value: http://{{ include "higress-console-grafana.name" . }}.{{ .Release.Namespace }}:{{ .Values.o11y.grafana.port }}{{ include "higress-console-grafana.path" . }}
             - name: HIGRESS_CONSOLE_DASHBOARD_DATASOURCE_URL
-              value: http://{{ include "higress-console-prometheus.name" . }}.{{ .Release.Namespace }}:{{ .Values.o11y.prometheus.port }}{{ .Values.o11y.prometheus.ingress.path }}
+              value: http://{{ include "higress-console-prometheus.name" . }}.{{ .Release.Namespace }}:{{ .Values.o11y.prometheus.port }}{{ include "higress-console-prometheus.path" . }}
             {{- end }}
             - name: HIGRESS_CONSOLE_CONTROLLER_INGRESS_CLASS_NAME
               value: {{ .Values.global.ingressClass }}

--- a/helm/templates/grafana.yaml
+++ b/helm/templates/grafana.yaml
@@ -2,7 +2,6 @@
 {{- $appName := (include "higress-console-grafana.name" .) }}
 {{- $config := .Values.o11y.grafana }}
 {{- $port := $config.port -}}
-{{- $ingress := $config.ingress }}
 {{- $storageClassName := $config.pvc.storageClassName }}
 {{- $existedPvc := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $appName) }}
 {{- if $existedPvc }}
@@ -22,7 +21,7 @@ data:
     [server]
     protocol=http
     domain=localhost
-    root_url="%(protocol)s://%(domain)s{{ $ingress.path }}"
+    root_url="%(protocol)s://%(domain)s{{ include "higress-console-grafana.path" . }}"
     serve_from_sub_path=true
 
     [auth]
@@ -128,58 +127,4 @@ spec:
     app: {{ $appName }}
   sessionAffinity: None
   type: ClusterIP
----
-{{- if and .Values.global.ingressClass (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.global.ingressClass}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta2
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $appName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "higress-console.labels" . | nindent 4 }}
-  annotations:
-  {{- if .Values.tlsSecretName }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  {{- end }}
-  {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.global.ingressClass (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.global.ingressClass }}
-  {{- end }}
-  {{- if .Values.tlsSecretName }}
-  tls:
-    - hosts:
-        - {{ .Values.domain | quote }}
-      secretName: {{ .Values.tlsSecretName }}
-  {{- end }}
-  rules:
-    - http:
-        paths:
-          - path: {{ $ingress.path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: Prefix
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $appName }}
-                port:
-                  number: {{ $port }}
-              {{- else }}
-              serviceName: {{ $appName }}
-              servicePort: {{ $port }}
-              {{- end }}
-      host: {{ .Values.domain | quote }}
 {{- end }}

--- a/helm/templates/prometheus.yaml
+++ b/helm/templates/prometheus.yaml
@@ -2,7 +2,6 @@
 {{- $appName := (include "higress-console-prometheus.name" .) }}
 {{- $config := .Values.o11y.prometheus }}
 {{- $port := $config.port }}
-{{- $ingress := $config.ingress -}}
 {{- $storageClassName := $config.pvc.storageClassName }}
 {{- $existedPvc := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $appName) }}
 {{- if $existedPvc }}
@@ -24,7 +23,7 @@ data:
       evaluation_interval: 15s
     scrape_configs:
       - job_name: 'prometheus'
-        metrics_path: {{ $ingress.path }}/metrics
+        metrics_path: {{ include "higress-console-prometheus.path" . }}/metrics
         static_configs:
         - targets: ['localhost:{{ $port }}']
       - job_name: 'k8s_nodes'
@@ -117,7 +116,7 @@ spec:
         - "/bin/prometheus"
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
-        - "--web.external-url={{ $ingress.path }}"
+        - "--web.external-url={{ include "higress-console-prometheus.path" . }}"
         - "--storage.tsdb.path=/prometheus"
         - "--storage.tsdb.retention=6h"
         ports:
@@ -196,60 +195,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ $appName }}
   namespace: {{ .Release.Namespace }}
----
-{{- if .Values.o11y.prometheus.ingress.enabled }}
-{{- if and .Values.global.ingressClass (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{-   $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.global.ingressClass}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta2
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $appName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "higress-console.labels" . | nindent 4 }}
-  annotations:
-  {{- if .Values.tlsSecretName }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  {{- end }}
-  {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.global.ingressClass (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.global.ingressClass }}
-  {{- end }}
-  {{- if .Values.tlsSecretName }}
-  tls:
-    - hosts:
-        - {{ .Values.domain | quote }}
-      secretName: {{ .Values.tlsSecretName }}
-  {{- end }}
-  rules:
-    - http:
-        paths:
-          - path: {{ $ingress.path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: Prefix
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $appName }}
-                port:
-                  number: {{ $port }}
-              {{- else }}
-              serviceName: {{ $appName }}
-              servicePort: {{ $port }}
-              {{- end }}
-      host: {{ .Values.domain | quote }}
-{{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -74,8 +74,6 @@ o11y:
     image:
       repository: grafana/grafana
       tag: 9.3.6
-    ingress:
-      path: /grafana # Only pathType of Prefix is supported
     port: 3000
     storage: 1Gi
     pvc:
@@ -85,9 +83,6 @@ o11y:
     image:
       repository: prom/prometheus
       tag: v2.40.7
-    ingress:
-      enabled: false # Enabling Ingress for Prometheus may pose a potential security risk to the system. DO NOT enable it unless it is absolute necessary.
-      path: /prometheus # Only pathType of Prefix is supported
     port: 9090
     storage: 1Gi
     pvc:


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Use console itself to forward requests to the built-in dashboard.

Known issues:
- WebSocket connections used by Grafana Live aren't supported yet.

![image](https://github.com/higress-group/higress-console/assets/2909796/f0a6378c-2886-4c01-9a1c-dae60cdf5a46)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
