### PR TITLE
fix: Fix the auth failure when the password contains any comma

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/service/SessionServiceImpl.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/SessionServiceImpl.java
@@ -59,6 +59,7 @@ public class SessionServiceImpl implements SessionService {
     private static final int ENCRYPT_KEY_LENGTH = 32;
     private static final String ENCRYPT_IV_KEY = "iv";
     private static final int ENCRYPT_IV_LENGTH = 16;
+    private static final String TOKEN_PART_SEPARATOR= "\1";
 
     @Value("${" + CommonKey.ADMIN_COOKIE_NAME_KEY + ":" + CommonKey.ADMIN_COOKIE_NAME_DEFAULT + "}")
     private String cookieName = CommonKey.ADMIN_COOKIE_NAME_DEFAULT;
@@ -182,7 +183,7 @@ public class SessionServiceImpl implements SessionService {
             return null;
         }
 
-        String[] segments = rawToken.split(CommonKey.COMMA);
+        String[] segments = rawToken.split(TOKEN_PART_SEPARATOR);
         if (segments.length < 3) {
             return null;
         }
@@ -237,7 +238,7 @@ public class SessionServiceImpl implements SessionService {
         if (!config.getUsername().equals(user.getName())) {
             return null;
         }
-        String rawToken = String.join(CommonKey.COMMA, config.getUsername(), config.getPassword(),
+        String rawToken = String.join(TOKEN_PART_SEPARATOR, config.getUsername(), config.getPassword(),
             String.valueOf(System.currentTimeMillis()));
         try {
             return AesUtil.encrypt(config.getEncryptKey(), config.getEncryptIv(), rawToken);


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Use a non-printable character instead of comma to as the separator when building auth tokens, so password containing comma won't break the parse logic.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
