### PR TITLE
fix: Fix startup error thrown when built-in o11y suite is not installed

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/service/DashboardServiceImpl.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/DashboardServiceImpl.java
@@ -130,12 +130,6 @@ public class DashboardServiceImpl implements DashboardService {
     @PostConstruct
     public void initialize() {
         try {
-            apiBaseUrlObject = new URL(apiBaseUrl);
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid dashboard base url: " + apiBaseUrl, e);
-        }
-
-        try {
             dashboardConfiguration = IOUtils.resourceToString(DASHBOARD_DATA_PATH, StandardCharsets.UTF_8);
             configuredDashboard = GrafanaClient.parseDashboardData(dashboardConfiguration);
         } catch (IOException e) {
@@ -143,6 +137,12 @@ public class DashboardServiceImpl implements DashboardService {
         }
 
         if (isBuiltIn()) {
+            try {
+                apiBaseUrlObject = new URL(apiBaseUrl);
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("Invalid dashboard base url: " + apiBaseUrl, e);
+            }
+
             RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(proxyConnectionTimeout)
                 .setSocketTimeout(proxySocketTimeout).build();
             realServerClient =


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix startup error thrown when built-in o11y suite is not installed. Only parse the Grafana API URL when built-in o11y suite is installed.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
