### PR TITLE
feat: Support configuring custom annotations

### DIFF
--- a/backend/src/main/java/com/alibaba/higress/console/constant/KubernetesConstants.java
+++ b/backend/src/main/java/com/alibaba/higress/console/constant/KubernetesConstants.java
@@ -25,6 +25,7 @@ public class KubernetesConstants {
 
     public static class Annotation {
         public static final String KEY_PREFIX = "higress.io/";
+        public static final String NGINX_INGRESS_KEY_PREFIX = "nginx.ingress.kubernetes.io/";
         public final static String DISABLED_KEY_EXTRA_PREFIX = "disabled.";
         public static final String TRUE_VALUE = "true";
         public static final String USE_REGEX_KEY = "higress.io/use-regex";

--- a/backend/src/main/java/com/alibaba/higress/console/controller/dto/Route.java
+++ b/backend/src/main/java/com/alibaba/higress/console/controller/dto/Route.java
@@ -13,6 +13,7 @@
 package com.alibaba.higress.console.controller.dto;
 
 import java.util.List;
+import java.util.Map;
 
 import com.alibaba.higress.console.controller.dto.route.CorsConfig;
 import com.alibaba.higress.console.controller.dto.route.HeaderControlConfig;
@@ -70,8 +71,9 @@ public class Route implements VersionedDto {
 
     private ProxyNextUpstreamConfig proxyNextUpstream;
 
-    // TODO: Not supported yet.
     private CorsConfig cors;
 
     private HeaderControlConfig headerControl;
+
+    private Map<String, String> customConfigs;
 }

--- a/backend/src/main/java/com/alibaba/higress/console/service/RouteServiceImpl.java
+++ b/backend/src/main/java/com/alibaba/higress/console/service/RouteServiceImpl.java
@@ -98,11 +98,6 @@ public class RouteServiceImpl implements RouteService {
     public Route update(Route route) {
         V1Ingress ingress = kubernetesModelConverter.route2Ingress(route);
 
-        V1Ingress existedIngress = kubernetesClientService.readIngress(ingress.getMetadata().getName());
-        if (existedIngress != null) {
-            kubernetesModelConverter.migrateCustomAnnotations(existedIngress, ingress);
-        }
-
         V1Ingress updatedIngress;
         try {
             updatedIngress = kubernetesClientService.replaceIngress(ingress);

--- a/frontend/src/interfaces/route.ts
+++ b/frontend/src/interfaces/route.ts
@@ -112,6 +112,9 @@ export interface WasmPluginData {
   imageVersion?: string;
   phase?: string;
   priority?: number;
+  customConfigs?: {
+    [key: string]: string;
+  };
 
   resKey?: string;
   key?: string;

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -20,19 +20,6 @@
   "index": {
     "title": "Higress Console"
   },
-  "login": {
-    "title": "Login",
-    "buttonText": "Login",
-    "loginSuccess": "Login successful!",
-    "loginFailed": "Login failed. Please try again.",
-    "incorrectCredentials": "Incorrect username or password.",
-    "autoLogin": "Auto login",
-    "forgotPassword": "Forgot password",
-    "usernamePlaceholder": "Username",
-    "usernameRequired": "Please input username",
-    "passwordPlaceholder": "Password",
-    "passwordRequired": "Please input password"
-  },
   "init": {
     "title": "System Setup",
     "header": "Setup Admin Account",
@@ -45,6 +32,19 @@
     "confirmPasswordMismatched": "Password does not match. Enter the password again here.",
     "initSuccess": "Setup completed. Redirecting to the login page.",
     "initFailed": "Setup operation failed."
+  },
+  "login": {
+    "title": "Login",
+    "buttonText": "Login",
+    "loginSuccess": "Login successful!",
+    "loginFailed": "Login failed. Please try again.",
+    "incorrectCredentials": "Incorrect username or password.",
+    "autoLogin": "Auto login",
+    "forgotPassword": "Forgot password",
+    "usernamePlaceholder": "Username",
+    "usernameRequired": "Please input username",
+    "passwordPlaceholder": "Password",
+    "passwordRequired": "Please input password"
   },
   "domain": {
     "columns": {
@@ -307,6 +307,18 @@
       },
       "parameter": "Parameter"
     },
+    "keyValueGroup": {
+      "columns": {
+        "key": "Key",
+        "value": "ֵValue",
+        "operation": "Action"
+      },
+      "required": {
+        "key": "Please input annotation key.",
+        "value": "Please input annotation value."
+      },
+      "config": "Annotation"
+    },
     "routeForm": {
       "routeName": "Route Name",
       "routeNameTip": "Using a name related to the business scenario is recommended. e.g.: user-default, user-gray, etc.",
@@ -322,12 +334,14 @@
       "pathMatcherRequired": "Please input the path match target.",
       "pathMatcherPlacedholder": "Path match target. e.g.: /user",
       "caseInsensitive": "Case Insensitive",
-      "method": "Method",
-      "methodMatcherPlaceholder": "HTTP method to match. Multiple selections are allowed. If left blank, it will match all the HTTP methods.",
-      "header": "Request Header",
+      "method": "Methods",
+      "methodMatcherPlaceholder": "HTTP methods to match. Multiple selections are allowed. If left blank, it will match all the HTTP methods.",
+      "header": "Request Headers",
       "headerTooltip": "The relation among different arguments is \"and\".",
-      "query": "Query Parameter",
+      "query": "Query Parameters",
       "queryTooltip": "The relation among different arguments is \"and\".",
+      "customConfigs": "Custom Annotations",
+      "customConfigsTip": "Click this \"?\" to view the configuration guide.",
       "targetService": "Target Service",
       "targetServiceRequired": "Please choose the target service.",
       "targetServiceNamedPlaceholder": "Search target service by name"

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -307,6 +307,18 @@
       },
       "parameter": "参数"
     },
+    "keyValueGroup": {
+      "columns": {
+        "key": "Key",
+        "value": "值",
+        "operation": "操作"
+      },
+      "required": {
+        "key": "请输入Key",
+        "value": "请输入值"
+      },
+      "config": "注解"
+    },
     "routeForm": {
       "routeName": "路由名称",
       "routeNameTip": "推荐结合业务场景命名，例如user-default、user-gray等",
@@ -328,6 +340,8 @@
       "headerTooltip": "多个参数之间是“与”关系",
       "query": "请求参数（Query）",
       "queryTooltip": "多个参数之间是“与”关系",
+      "customConfigs": "附加注解（Annotation）",
+      "customConfigsTip": "点击问号查看注解配置说明",
       "targetService": "目标服务",
       "targetServiceRequired": "请选择目标服务",
       "targetServiceNamedPlaceholder": "搜索服务名称选择服务"

--- a/frontend/src/pages/route/components/FactorGroup/index.tsx
+++ b/frontend/src/pages/route/components/FactorGroup/index.tsx
@@ -111,11 +111,6 @@ interface DataType {
 
 type ColumnTypes = Exclude<EditableTableProps['columns'], undefined>;
 
-interface FactorGroupProps {
-  id: string;
-  onChange: (record) => void;
-}
-
 const FactorGroup: React.FC = ({ value, onChange }) => {
   const { t } = useTranslation();
 

--- a/frontend/src/pages/route/components/KeyValueGroup/index.module.css
+++ b/frontend/src/pages/route/components/KeyValueGroup/index.module.css
@@ -1,0 +1,5 @@
+.factor :global {
+  .ant-empty-normal {
+    margin: 0;
+  }
+}

--- a/frontend/src/pages/route/components/KeyValueGroup/index.tsx
+++ b/frontend/src/pages/route/components/KeyValueGroup/index.tsx
@@ -1,0 +1,206 @@
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button, Form, Input, Select, Table } from 'antd';
+import type { FormInstance } from 'antd/es/form';
+import { uniqueId } from 'lodash';
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './index.module.css';
+
+const EditableContext = React.createContext<FormInstance<any> | null>(null);
+
+interface Item {
+  key: string;
+}
+
+interface EditableRowProps {
+  index: number;
+}
+
+const EditableRow: React.FC<EditableRowProps> = ({ index, ...props }) => {
+  const [form] = Form.useForm();
+  return (
+    <Form form={form} component={false}>
+      <EditableContext.Provider value={form}>
+        <tr {...props} />
+      </EditableContext.Provider>
+    </Form>
+  );
+};
+
+interface EditableCellProps {
+  title: React.ReactNode;
+  editable: boolean;
+  children: React.ReactNode;
+  dataIndex: keyof Item;
+  record: Item;
+  nodeType: 'select' | 'input';
+  handleSave: (record: Item) => void;
+}
+
+const EditableCell: React.FC<EditableCellProps> = ({
+  title,
+  editable,
+  children,
+  dataIndex,
+  nodeType,
+  record,
+  handleSave,
+  ...restProps
+}) => {
+  const { t } = useTranslation();
+  const [editing] = useState(true);
+  const inputRef = useRef(null);
+  const form = useContext(EditableContext)!;
+
+  useEffect(() => {
+    form.setFieldsValue({ ...record });
+  }, [editing]);
+
+  const save = async () => {
+    try {
+      const values = await form.validateFields();
+      handleSave({ ...record, ...values });
+    } catch (errInfo) {
+      // eslint-disable-next-line no-console
+      console.log('Save failed:', errInfo);
+    }
+  };
+
+  let childNode = children;
+
+  if (editable) {
+    childNode = (
+      <Form.Item
+        style={{ margin: 0 }}
+        name={dataIndex}
+        rules={[
+          {
+            required: true,
+            message: t(`route.keyValueGroup.required.${dataIndex}`),
+          },
+        ]}
+      >
+        <Input ref={inputRef} onPressEnter={save} onBlur={save} />
+      </Form.Item>
+    );
+  }
+
+  return <td {...restProps}>{childNode}</td>;
+};
+
+type EditableTableProps = Parameters<typeof Table>[0];
+
+interface DataType {
+  uid: number;
+  key: string;
+  value: string;
+}
+
+type ColumnTypes = Exclude<EditableTableProps['columns'], undefined>;
+
+const KeyValueGroup: React.FC = ({ value, onChange }) => {
+  const { t } = useTranslation();
+
+  const initDataSource = value || [];
+  for (const item of initDataSource) {
+    if (!item.uid) {
+      item.uid = uniqueId();
+    }
+  }
+  const [dataSource, setDataSource] = useState<DataType[]>(value || []);
+
+  const defaultColumns: Array<ColumnTypes[number] & { editable?: boolean; dataIndex: string }> = [
+    {
+      title: t('route.keyValueGroup.columns.key'),
+      dataIndex: 'key',
+      editable: true,
+    },
+    {
+      title: t('route.keyValueGroup.columns.value'),
+      dataIndex: 'value',
+      editable: true,
+    },
+    {
+      title: t('route.keyValueGroup.columns.operation'),
+      dataIndex: 'operation',
+      width: 60,
+      render: (_, record: { uid: number }) =>
+        (dataSource.length >= 1 ? (
+          <div onClick={() => handleDelete(record.uid)}>
+            <DeleteOutlined />
+          </div>
+        ) : null),
+    },
+  ];
+
+  const handleAdd = () => {
+    const newData: DataType = {
+      uid: uniqueId(),
+      key: '',
+      value: '',
+    };
+    setDataSource([...dataSource, newData]);
+    onChange([...dataSource, newData]);
+  };
+
+  const handleDelete = (uid: number) => {
+    const newData = dataSource.filter((item) => item.uid !== uid);
+    setDataSource(newData);
+    onChange(newData);
+  };
+
+  const handleSave = (row: DataType) => {
+    const newData = [...dataSource];
+    const index = newData.findIndex((item) => row.uid === item.uid);
+    const item = newData[index];
+    newData.splice(index, 1, {
+      ...item,
+      ...row,
+    });
+    setDataSource(newData);
+    onChange(newData);
+  };
+
+  const components = {
+    body: {
+      row: EditableRow,
+      cell: EditableCell,
+    },
+  };
+
+  const columns = defaultColumns.map((col) => {
+    if (!col.editable) {
+      return col;
+    }
+    return {
+      ...col,
+      onCell: (record: DataType) => ({
+        record,
+        editable: col.editable,
+        dataIndex: col.dataIndex,
+        title: col.title,
+        nodeType: 'input',
+        handleSave,
+      }),
+    };
+  });
+
+  return (
+    <div>
+      <Table
+        components={components}
+        size="small"
+        className={styles.factor}
+        dataSource={dataSource}
+        columns={columns as ColumnTypes}
+        pagination={false}
+      />
+      <Button onClick={handleAdd} type="link">
+        <PlusOutlined />
+        {t('route.keyValueGroup.config')}
+      </Button>
+    </div>
+  );
+};
+
+export default KeyValueGroup;

--- a/frontend/src/pages/route/index.tsx
+++ b/frontend/src/pages/route/index.tsx
@@ -24,6 +24,9 @@ interface RouteFormProps {
   path: RoutePredicate;
   urlParams: KeyedRoutePredicate[];
   services: string;
+  customConfigs: {
+    [key: string]: string;
+  };
 }
 
 const RouteList: React.FC = () => {
@@ -126,7 +129,7 @@ const RouteList: React.FC = () => {
   const handleDrawerOK = async () => {
     try {
       const values: RouteFormProps = formRef.current && (await formRef.current.handleSubmit());
-      const { name, domains, headers, methods, urlParams, path, services: service } = values;
+      const { name, domains, headers, methods, urlParams, path, services: service, customConfigs } = values;
       path && normalizeRoutePredicate(path);
       headers && headers.forEach((h) => normalizeRoutePredicate(h));
       urlParams && urlParams.forEach((h) => normalizeRoutePredicate(h));
@@ -137,6 +140,7 @@ const RouteList: React.FC = () => {
         methods,
         path,
         urlParams,
+        customConfigs,
         services: [{ name: service }],
       };
       if (currentRoute) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support configuring custom annotations in the route editing form.

**Note:**

If user configures a console-supported feature (e.g. CORS) with Nginx Ingress annotations (with prefix `nginx.ingress.kubernetes.io/`), it won't be changed to Higress annotation (with prefix `higress.io/`) automatically.

User is still able to open the edit dialog of that route, but can't save it, because the API will return an error when trying to save an Nginx Ingress annotation with its corresponding Higress key supported by Console.

![image](https://github.com/higress-group/higress-console/assets/2909796/38775dec-ddb4-4d7f-a77d-e74a1867101f)

![image](https://github.com/higress-group/higress-console/assets/2909796/b7b2ba03-88c6-402f-abd2-493f4a01419c)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #271

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
