### PR TITLE
feat: Return null when trying to load a non-existent K8s resource

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/RouteServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/RouteServiceImpl.java
@@ -74,7 +74,12 @@ public class RouteServiceImpl implements RouteService {
 
     @Override
     public Route query(String routeName) {
-        V1Ingress ingress = kubernetesClientService.readIngress(routeName);
+        V1Ingress ingress;
+        try {
+            ingress = kubernetesClientService.readIngress(routeName);
+        } catch (ApiException e) {
+            throw new BusinessException("Error occurs when reading the Ingress with name: " + routeName, e);
+        }
         return ingress != null ? kubernetesModelConverter.ingress2Route(ingress) : null;
     }
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceSourceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceSourceServiceImpl.java
@@ -70,9 +70,6 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
         try {
             mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
-            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
-                return PaginatedResult.createFromFullList(Collections.emptyList(), query);
-            }
             throw new BusinessException("Error occurs when getting McpBridge.", e);
         }
         List<ServiceSource> serviceSources = Collections.emptyList();
@@ -94,13 +91,11 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
 
     @Override
     public ServiceSource addOrUpdate(ServiceSource serviceSource) {
-        V1McpBridge mcpBridge = null;
+        V1McpBridge mcpBridge;
         try {
             mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
-                throw new BusinessException("Error occurs when getting McpBridge.", e);
-            }
+            throw new BusinessException("Error occurs when getting McpBridge.", e);
         }
         try {
             if (null == mcpBridge) {
@@ -130,21 +125,19 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
         try {
             mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
-            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
-                return;
-            }
             throw new BusinessException("Error occurs when getting McpBridge.", e);
+        }
+        if (mcpBridge == null) {
+            return;
         }
         V1RegistryConfig registry = kubernetesModelConverter.removeV1McpBridgeRegistry(mcpBridge, name);
         if (StringUtils.isNotEmpty(registry.getAuthSecretName())) {
             try {
                 kubernetesClientService.deleteSecret(registry.getAuthSecretName());
             } catch (ApiException e) {
-                if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
-                    String message = "Error occurs when deleting the secret associated with ServiceSource named "
-                        + registry.getName();
-                    throw new BusinessException(message, e);
-                }
+                String message =
+                    "Error occurs when deleting the secret associated with ServiceSource named " + registry.getName();
+                throw new BusinessException(message, e);
             }
         }
         try {
@@ -160,9 +153,6 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
         try {
             mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
-            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
-                return null;
-            }
             throw new BusinessException("Error occurs when getting McpBridge.", e);
         }
         if (null == mcpBridge || CollectionUtils.isEmpty(mcpBridge.getSpec().getRegistries())) {
@@ -180,13 +170,11 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
 
     @Override
     public ServiceSource add(ServiceSource serviceSource) {
-        V1McpBridge mcpBridge = null;
+        V1McpBridge mcpBridge;
         try {
             mcpBridge = kubernetesClientService.readMcpBridge(V1McpBridge.DEFAULT_NAME);
         } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
-                throw new BusinessException("Error occurs when getting McpBridge.", e);
-            }
+            throw new BusinessException("Error occurs when getting McpBridge.", e);
         }
         try {
             if (null == mcpBridge) {
@@ -262,17 +250,16 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
             try {
                 secret = kubernetesClientService.readSecret(registry.getAuthSecretName());
             } catch (ApiException e) {
-                if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
-                    secret = new V1Secret();
-                    V1ObjectMeta metadata = new V1ObjectMeta();
-                    metadata.setName(registry.getAuthSecretName());
-                    secret.setMetadata(metadata);
-                    secretLost = true;
-                } else {
-                    String message = "Error occurs when getting the secret associated with ServiceSource named "
-                        + serviceSource.getName();
-                    throw new BusinessException(message, e);
-                }
+                String message = "Error occurs when getting the secret associated with ServiceSource named "
+                    + serviceSource.getName();
+                throw new BusinessException(message, e);
+            }
+            if (secret == null) {
+                secret = new V1Secret();
+                V1ObjectMeta metadata = new V1ObjectMeta();
+                metadata.setName(registry.getAuthSecretName());
+                secret.setMetadata(metadata);
+                secretLost = true;
             }
             secret.setData(secretData);
             try {
@@ -325,11 +312,7 @@ public class ServiceSourceServiceImpl implements ServiceSourceService {
             try {
                 secret = kubernetesClientService.readSecret(registry.getAuthSecretName());
             } catch (ApiException e) {
-                if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
-                    secret = null;
-                } else {
-                    throw new BusinessException("Error occurs when getting McpBridge.", e);
-                }
+                throw new BusinessException("Error occurs when getting McpBridge.", e);
             }
             if (secret != null && MapUtils.isNotEmpty(secret.getData())) {
                 authN.setEnabled(true);

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -129,9 +129,7 @@ public class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService 
                 existedCr = existedCrs.get(0);
             }
         } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
-                throw new BusinessException("Error occurs when getting WasmPlugin.", e);
-            }
+            throw new BusinessException("Error occurs when getting WasmPlugin.", e);
         }
 
         if (instance.getConfigurations() == null && StringUtils.isNotEmpty(instance.getRawConfigurations())) {
@@ -178,13 +176,11 @@ public class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService 
 
     @Override
     public void delete(WasmPluginInstanceScope scope, String target, String pluginName) {
-        List<V1alpha1WasmPlugin> existedCrs = null;
+        List<V1alpha1WasmPlugin> existedCrs;
         try {
             existedCrs = kubernetesClientService.listWasmPlugin(pluginName);
         } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
-                throw new BusinessException("Error occurs when getting WasmPlugin.", e);
-            }
+            throw new BusinessException("Error occurs when getting WasmPlugin.", e);
         }
         deletePluginInstances(existedCrs, scope, target);
     }
@@ -195,9 +191,7 @@ public class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService 
         try {
             existedCrs = kubernetesClientService.listWasmPlugin();
         } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.NOT_FOUND.value()) {
-                throw new BusinessException("Error occurs when getting WasmPlugin.", e);
-            }
+            throw new BusinessException("Error occurs when getting WasmPlugin.", e);
         }
         deletePluginInstances(existedCrs, scope, target);
     }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesClientService.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesClientService.java
@@ -239,14 +239,15 @@ public class KubernetesClientService {
         }
     }
 
-    public V1Ingress readIngress(String name) {
+    public V1Ingress readIngress(String name) throws ApiException {
         NetworkingV1Api apiInstance = new NetworkingV1Api(client);
         try {
             return apiInstance.readNamespacedIngress(name, controllerNamespace, null);
         } catch (ApiException e) {
-            log.error("getIngress Status code: " + e.getCode() + "Reason: " + e.getResponseBody() + "Response headers: "
-                + e.getResponseHeaders(), e);
-            return null;
+            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
+                return null;
+            }
+            throw e;
         }
     }
 
@@ -299,7 +300,14 @@ public class KubernetesClientService {
 
     public V1ConfigMap readConfigMap(String name) throws ApiException {
         CoreV1Api coreV1Api = new CoreV1Api(client);
-        return coreV1Api.readNamespacedConfigMap(name, controllerNamespace, null);
+        try {
+            return coreV1Api.readNamespacedConfigMap(name, controllerNamespace, null);
+        } catch (ApiException e) {
+            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
+                return null;
+            }
+            throw e;
+        }
     }
 
     public void deleteConfigMap(String name) throws ApiException {
@@ -341,7 +349,14 @@ public class KubernetesClientService {
 
     public V1Secret readSecret(String name) throws ApiException {
         CoreV1Api coreV1Api = new CoreV1Api(client);
-        return coreV1Api.readNamespacedSecret(name, controllerNamespace, null);
+        try {
+            return coreV1Api.readNamespacedSecret(name, controllerNamespace, null);
+        } catch (ApiException e) {
+            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
+                return null;
+            }
+            throw e;
+        }
     }
 
     public V1Secret createSecret(V1Secret secret) throws ApiException {
@@ -418,9 +433,16 @@ public class KubernetesClientService {
 
     public V1McpBridge readMcpBridge(String name) throws ApiException {
         CustomObjectsApi customObjectsApi = new CustomObjectsApi(client);
-        Object response = customObjectsApi.getNamespacedCustomObject(V1McpBridge.API_GROUP, V1McpBridge.VERSION,
-            controllerNamespace, V1McpBridge.PLURAL, name);
-        return client.getJSON().deserialize(client.getJSON().serialize(response), V1McpBridge.class);
+        try {
+            Object response = customObjectsApi.getNamespacedCustomObject(V1McpBridge.API_GROUP, V1McpBridge.VERSION,
+                controllerNamespace, V1McpBridge.PLURAL, name);
+            return client.getJSON().deserialize(client.getJSON().serialize(response), V1McpBridge.class);
+        } catch (ApiException e) {
+            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
+                return null;
+            }
+            throw e;
+        }
     }
 
     public List<V1alpha1WasmPlugin> listWasmPlugin() throws ApiException {
@@ -487,9 +509,16 @@ public class KubernetesClientService {
 
     public V1alpha1WasmPlugin readWasmPlugin(String name) throws ApiException {
         CustomObjectsApi customObjectsApi = new CustomObjectsApi(client);
-        Object response = customObjectsApi.getNamespacedCustomObject(V1alpha1WasmPlugin.API_GROUP,
-            V1alpha1WasmPlugin.VERSION, controllerNamespace, V1alpha1WasmPlugin.PLURAL, name);
-        return client.getJSON().deserialize(client.getJSON().serialize(response), V1alpha1WasmPlugin.class);
+        try {
+            Object response = customObjectsApi.getNamespacedCustomObject(V1alpha1WasmPlugin.API_GROUP,
+                V1alpha1WasmPlugin.VERSION, controllerNamespace, V1alpha1WasmPlugin.PLURAL, name);
+            return client.getJSON().deserialize(client.getJSON().serialize(response), V1alpha1WasmPlugin.class);
+        } catch (ApiException e) {
+            if (e.getCode() == HttpStatus.NOT_FOUND.value()) {
+                return null;
+            }
+            throw e;
+        }
     }
 
     private void checkResponseStatus(V1Status status) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -1252,6 +1252,10 @@ public class KubernetesModelConverter {
                     e);
             }
 
+            if (configMap == null) {
+                continue;
+            }
+
             Domain domain = configMap2Domain(configMap);
 
             if (Domain.EnableHttps.OFF.equals(domain.getEnableHttps())) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Return null when trying to load a non-existent K8s resource, so we don't need to check the response status of ApiException everywhere.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
