### PR TITLE
feat: Suppress the exception log when git.properties doesn't exist

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/service/SystemServiceImpl.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/service/SystemServiceImpl.java
@@ -12,6 +12,8 @@
  */
 package com.alibaba.higress.console.service;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -41,12 +43,7 @@ public class SystemServiceImpl implements SystemService {
     static {
         String commitId = null;
         try {
-            Properties properties = new Properties();
-            properties.load(SystemServiceImpl.class.getResourceAsStream("/git.properties"));
-            commitId = properties.getProperty("git.commit.id");
-            if (commitId != null && commitId.length() > 7) {
-                commitId = commitId.substring(0, 7);
-            }
+            commitId = loadGitCommitId();
         } catch (Exception ex) {
             log.error("Failed to load git properties.", ex);
         }
@@ -89,5 +86,21 @@ public class SystemServiceImpl implements SystemService {
     @Override
     public SystemInfo getSystemInfo() {
         return new SystemInfo(fullVersion, capabilities);
+    }
+
+    private static String loadGitCommitId() throws IOException {
+        try (InputStream input = SystemServiceImpl.class.getResourceAsStream("/git.properties")) {
+            if (input == null) {
+                log.warn("git.properties not found.");
+                return null;
+            }
+            Properties properties = new Properties();
+            properties.load(input);
+            String commitId = properties.getProperty("git.commit.id");
+            if (commitId != null && commitId.length() > 7) {
+                commitId = commitId.substring(0, 7);
+            }
+            return commitId;
+        }
     }
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Suppress the exception log when git.properties doesn't exist.

![6acb08e8d09be936da43c9212cbf500d](https://github.com/higress-group/higress-console/assets/2909796/c94fb76c-5cbe-4a4c-867a-a507f5f02a94)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
