### PR TITLE
fix: Priority of global.pvc and pvc in helm chart

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $o11y := merge (dict) .Values.o11y .Values.global.o11y }}
+{{- $o11y := merge (dict) .Values.global.o11y .Values.o11y }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/grafana.yaml
+++ b/helm/templates/grafana.yaml
@@ -12,7 +12,7 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $pvc := merge (dict) .Values.pvc .Values.global.pvc}}
+{{- $pvc := merge (dict) .Values.global.pvc .Values.pvc }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/loki.yaml
+++ b/helm/templates/loki.yaml
@@ -12,7 +12,7 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $pvc := merge (dict) .Values.pvc .Values.global.pvc}}
+{{- $pvc := merge (dict) .Values.global.pvc .Values.pvc}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/prometheus.yaml
+++ b/helm/templates/prometheus.yaml
@@ -12,7 +12,7 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $pvc := merge (dict) .Values.pvc .Values.global.pvc}}
+{{- $pvc := merge (dict) .Values.global.pvc .Values.pvc}}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
- https://higress.io/zh-cn/docs/user/prometheus/
- https://higress.io/zh-cn/docs/ops/deploy-by-helm#%E5%B8%B8%E7%94%A8%E5%AE%89%E8%A3%85%E5%8F%82%E6%95%B0

- <img style="width: 50%;" alt="image" src="https://github.com/higress-group/higress-console/assets/73829796/6aba1047-9821-42be-a968-fc76c9a50419">

⚡⚡⚡ As noted in the documentation, the PersistentVolumeClaim access mode can be set to **ReadyWriteOnce** using `higress-console.pvc.rwxSupported=false`. Therefore, the priority of **pvc** in template should be higher than that of **global.pvc**.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
