### PR TITLE
feat: Avoid loading cached GET responses on the frontend

### DIFF
--- a/frontend/src/services/request.tsx
+++ b/frontend/src/services/request.tsx
@@ -19,6 +19,9 @@ request.interceptors.request.use((config) => {
       ...config.headers,
     };
   }
+  if (config.method && config.method.toUpperCase() == 'GET' && config.url) {
+    config.url = `${config.url}${config.url.indexOf('?') === -1 ? '?' : '&'}ts=${Date.now()}`;
+  }
   return config;
 });
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Add the current timestamp into the query string of GET requests so the browser won't load the cached responses.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
