### PR TITLE
feat: Support loading LLM service info from a K8s Secret

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/constant/SystemConfigKey.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/constant/SystemConfigKey.java
@@ -42,9 +42,9 @@ public class SystemConfigKey {
 
     public static final String CONFIG_MAP_NAME_KEY_DEFAULT = "higress-console";
 
-    public static final String ADMIN_SECRET_NAME_KEY = CONFIG_KEY_PREFIX + "admin.secret";
+    public static final String SECRET_NAME_KEY = CONFIG_KEY_PREFIX + "secret.name";
 
-    public static final String ADMIN_SECRET_NAME_DEFAULT = "higress-console";
+    public static final String SECRET_NAME_DEFAULT = "higress-console";
 
     public static final String ADMIN_COOKIE_NAME_KEY = CONFIG_KEY_PREFIX + "admin.cookie.name";
 

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/AiProxyController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/AiProxyController.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -118,8 +119,8 @@ public class AiProxyController {
             reloadServiceInfoFromK8s();
             ThreadFactory tf =
                 new ThreadFactoryBuilder().setDaemon(true).setNameFormat("AiProxyController-SecretLoader-%d").build();
-            Executors.newSingleThreadScheduledExecutor(tf).scheduleWithFixedDelay(this::reloadServiceInfoFromK8s,
-                SECRET_RELOAD_INTERVAL, SECRET_RELOAD_INTERVAL, TimeUnit.MILLISECONDS);
+            new ScheduledThreadPoolExecutor(1, tf).scheduleWithFixedDelay(this::reloadServiceInfoFromK8s,
+                    SECRET_RELOAD_INTERVAL, SECRET_RELOAD_INTERVAL, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/AiProxyController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/AiProxyController.java
@@ -19,7 +19,6 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/AiProxyController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/AiProxyController.java
@@ -17,12 +17,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Enumeration;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.collections4.MapUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.config.RequestConfig;
@@ -34,6 +40,7 @@ import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,18 +49,29 @@ import org.springframework.web.bind.annotation.RestController;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.higress.console.constant.SystemConfigKey;
 import com.alibaba.higress.console.controller.dto.Response;
+import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import joptsimple.internal.Strings;
+import io.kubernetes.client.openapi.models.V1Secret;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author CH3CHO
  */
+@Slf4j
 @RestController("AiProxyController")
 @RequestMapping(AiProxyController.BASE_PATH)
 public class AiProxyController {
 
     static final String BASE_PATH = "/aiproxy";
+
+    private static final String SERVICE_URL_KEY = "aiProxyServiceUrl";
+    private static final String SERVICE_TOKEN_KEY = "aiProxyServiceToken";
+    private static final long SECRET_RELOAD_INTERVAL = 60 * 1000;
 
     private static final Set<String> INVALID_REQUEST_HEADERS =
         ImmutableSet.of("connection", "content-length", "accept-encoding", "host", "cookie");
@@ -67,6 +85,9 @@ public class AiProxyController {
     @Value("${" + SystemConfigKey.AI_PROXY_SERVICE_TOKEN_KEY + ":}")
     private String serviceToken;
 
+    @Value("${" + SystemConfigKey.SECRET_NAME_KEY + ":" + SystemConfigKey.SECRET_NAME_DEFAULT + "}")
+    private String secretName = SystemConfigKey.SECRET_NAME_DEFAULT;
+
     @Value("${" + SystemConfigKey.AI_PROXY_CONNECTION_TIMEOUT_KEY + ":"
         + SystemConfigKey.AI_PROXY_CONNECTION_TIMEOUT_DEFAULT + "}")
     private int connectionTimeout = SystemConfigKey.AI_PROXY_CONNECTION_TIMEOUT_DEFAULT;
@@ -75,19 +96,64 @@ public class AiProxyController {
         + "}")
     private int socketTimeout = SystemConfigKey.AI_PROXY_SOCKET_TIMEOUT_DEFAULT;
 
+    private final AtomicReference<ServiceInfo> serviceInfoHolder = new AtomicReference<>();
+
     private CloseableHttpClient client;
+    private KubernetesClientService kubernetesClientService;
+
+    @Autowired
+    public void setKubernetesClientService(KubernetesClientService kubernetesClientService) {
+        this.kubernetesClientService = kubernetesClientService;
+    }
 
     @PostConstruct
     public void initialize() {
         RequestConfig requestConfig =
             RequestConfig.custom().setConnectTimeout(connectionTimeout).setSocketTimeout(socketTimeout).build();
         client = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+
+        if (!Strings.isNullOrEmpty(serviceUrl)) {
+            serviceInfoHolder.set(new ServiceInfo(serviceUrl, serviceToken));
+        } else {
+            reloadServiceInfoFromK8s();
+            ThreadFactory tf =
+                new ThreadFactoryBuilder().setDaemon(true).setNameFormat("AiProxyController-SecretLoader-%d").build();
+            Executors.newSingleThreadScheduledExecutor(tf).scheduleWithFixedDelay(this::reloadServiceInfoFromK8s,
+                SECRET_RELOAD_INTERVAL, SECRET_RELOAD_INTERVAL, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void reloadServiceInfoFromK8s() {
+        try {
+            V1Secret secret = kubernetesClientService.readSecret(secretName);
+            Map<String, byte[]> data = secret.getData();
+            if (MapUtils.isEmpty(data)) {
+                log.error("Secret {} is empty.", secretName);
+                return;
+            }
+            byte[] serviceUrlData = data.get(SERVICE_URL_KEY);
+            byte[] serviceTokenData = data.get(SERVICE_TOKEN_KEY);
+            if (serviceUrlData == null || serviceUrlData.length == 0 || serviceTokenData == null
+                || serviceTokenData.length == 0) {
+                log.error("Secret {} does not contain service URL or token for ai-proxy.", secretName);
+                return;
+            }
+            serviceInfoHolder.set(new ServiceInfo(new String(serviceUrlData), new String(serviceTokenData)));
+        } catch (Exception ex) {
+            log.error("Failed to reload AI service info from K8s.", ex);
+        }
     }
 
     @RequestMapping("/**")
     public Object proxy(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        ServiceInfo serviceInfo = serviceInfoHolder.get();
+        if (serviceInfo == null || serviceInfo.isInvalid()) {
+            throw new IllegalStateException("No valid service info is available for proxying.");
+        }
+
         try {
-            RequestBuilder requestBuilder = RequestBuilder.create(req.getMethod()).setUri(buildTargetUrl(req));
+            RequestBuilder requestBuilder =
+                RequestBuilder.create(req.getMethod()).setUri(buildTargetUrl(serviceInfo, req));
 
             final String method = req.getMethod().toUpperCase(Locale.ROOT);
             if ("POST".equals(method) || "PUT".equals(method)) {
@@ -104,6 +170,7 @@ public class AiProxyController {
                 }
             }
 
+            String serviceToken = serviceInfo.getServiceToken();
             if (!Strings.isNullOrEmpty(serviceToken)) {
                 requestBuilder.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + serviceToken);
             }
@@ -120,8 +187,8 @@ public class AiProxyController {
         return null;
     }
 
-    private String buildTargetUrl(HttpServletRequest req) {
-        final String baseUrl = this.serviceUrl;
+    private String buildTargetUrl(ServiceInfo serviceInfo, HttpServletRequest req) {
+        final String baseUrl = serviceInfo.getServiceUrl();
         if (Strings.isNullOrEmpty(baseUrl)) {
             throw new IllegalStateException("Missing serviceUrl.");
         }
@@ -164,6 +231,18 @@ public class AiProxyController {
                 output.write(buffer, 0, bytesRead);
                 output.flush();
             }
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class ServiceInfo {
+
+        private String serviceUrl;
+        private String serviceToken;
+
+        public boolean isInvalid() {
+            return Strings.isNullOrEmpty(serviceUrl);
         }
     }
 }

--- a/backend/console/src/main/java/com/alibaba/higress/console/service/SessionServiceImpl.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/service/SessionServiceImpl.java
@@ -67,8 +67,8 @@ public class SessionServiceImpl implements SessionService {
     @Value("${" + SystemConfigKey.ADMIN_COOKIE_MAX_AGE_KEY + ":" + SystemConfigKey.ADMIN_COOKIE_MAX_AGE_DEFAULT + "}")
     private int cookieMaxAge = SystemConfigKey.ADMIN_COOKIE_MAX_AGE_DEFAULT;
 
-    @Value("${" + SystemConfigKey.ADMIN_SECRET_NAME_KEY + ":" + SystemConfigKey.ADMIN_SECRET_NAME_DEFAULT + "}")
-    private String secretName = SystemConfigKey.ADMIN_SECRET_NAME_DEFAULT;
+    @Value("${" + SystemConfigKey.SECRET_NAME_KEY + ":" + SystemConfigKey.SECRET_NAME_DEFAULT + "}")
+    private String secretName = SystemConfigKey.SECRET_NAME_DEFAULT;
 
     @Value("${" + SystemConfigKey.ADMIN_CONFIG_TTL_KEY + ":" + SystemConfigKey.ADMIN_CONFIG_TTL_DEFAULT + "}")
     private long configTtl = SystemConfigKey.ADMIN_CONFIG_TTL_DEFAULT;

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               value: C.UTF-8
             - name: HIGRESS_CONSOLE_NS
               value: {{ .Release.Namespace }}
-            - name: HIGRESS_CONSOLE_ADMIN_SECRET
+            - name: HIGRESS_CONSOLE_SECRET_NAME
               value: {{ include "higress-console.name" . }}
             - name: HIGRESS_CONSOLE_CONFIG_MAP_NAME
               value: {{ include "higress-console.name" . }}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support loading LLM service info from a K8s Secret.

The default secret name is higress-console. Corresponding key names are:
- aiProxyServiceUrl
- aiProxyServiceToken

Configurations are reloaded every minute.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
