### PR TITLE
feat:add unit test for KubernetesModelConverter

### DIFF
--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
@@ -64,44 +64,44 @@ import java.util.Map;
 import static org.mockito.Mockito.mock;
 
 public class KubernetesModelConverterTest {
-    
+
     private KubernetesModelConverter converter;
-    
+
     @BeforeEach
     public void setUp() {
         KubernetesClientService service = mock(KubernetesClientService.class);
         converter = new KubernetesModelConverter(service);
     }
-    
+
     @AfterEach
     public void tearDown() {
         converter = null;
     }
-    
+
     @Test
     public void isIngressSupportedTestMissingMetadata() {
         V1Ingress ingress = buildBasicSupportedIngress();
         ingress.setMetadata(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMissingSpec() {
         V1Ingress ingress = buildBasicSupportedIngress();
         ingress.setSpec(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMissingRules() {
         V1Ingress ingress = buildBasicSupportedIngress();
         ingress.getSpec().setRules(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
-        
+
         ingress.getSpec().setRules(Collections.emptyList());
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMultipleRules() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -109,7 +109,7 @@ public class KubernetesModelConverterTest {
         rules.add(rules.get(0));
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMissingHttpRule() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -117,18 +117,18 @@ public class KubernetesModelConverterTest {
         rule.setHttp(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMissingPath() {
         V1Ingress ingress = buildBasicSupportedIngress();
         V1HTTPIngressRuleValue httpRule = ingress.getSpec().getRules().get(0).getHttp();
         httpRule.setPaths(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
-        
+
         httpRule.setPaths(Collections.emptyList());
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMultiplePaths() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -137,7 +137,7 @@ public class KubernetesModelConverterTest {
         paths.add(paths.get(0));
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestUnsupportedPathType() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -145,7 +145,7 @@ public class KubernetesModelConverterTest {
         path.setPathType(KubernetesConstants.IngressPathType.IMPLEMENTATION_SPECIFIC);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestMissingBackend() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -153,7 +153,7 @@ public class KubernetesModelConverterTest {
         path.setBackend(null);
         Assertions.assertTrue(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestServiceBackend() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -161,7 +161,7 @@ public class KubernetesModelConverterTest {
         backend.setService(new V1IngressServiceBackend());
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestNonMcpBackend() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -170,28 +170,28 @@ public class KubernetesModelConverterTest {
         reference.setName("DummyKind");
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void isIngressSupportedTestAllGood() {
         V1Ingress ingress = buildBasicSupportedIngress();
         Assertions.assertTrue(converter.isIngressSupported(ingress));
     }
-    
+
     @Test
     public void ingress2RouteTestPrefixPathSingleService() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local");
-        
+            "hello.default.svc.cluster.local");
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -202,22 +202,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     public void ingress2RouteTestPrefixPathSingleServiceWithWeight() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "10% hello.default.svc.cluster.local");
-        
+            "10% hello.default.svc.cluster.local");
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -228,22 +228,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     public void ingress2RouteTestPrefixPathSingleServiceWithPort() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local:8080");
-        
+            "hello.default.svc.cluster.local:8080");
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -254,22 +254,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     public void ingress2RouteTestPrefixPathSingleServiceWithPortAndVersion() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local:8080 v1");
-        
+            "hello.default.svc.cluster.local:8080 v1");
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -280,23 +280,23 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     public void ingress2RouteTestPrefixPathMultipleServices() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "20% hello1.default.svc.cluster.local:8080\n"
-                        + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
-        
+            "20% hello1.default.svc.cluster.local:8080\n"
+                + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -309,22 +309,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Arrays.asList(service1, service2, service3));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     public void ingress2RouteTestExactPathSingleService() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local");
-        
+            "hello.default.svc.cluster.local");
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.EXACT);
         path.setPath("/foo");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -335,24 +335,24 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     public void ingress2RouteTestRegularPathSingleService() {
         V1Ingress ingress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local");
+            "hello.default.svc.cluster.local");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.USE_REGEX_KEY,
-                KubernetesConstants.Annotation.TRUE_VALUE);
-        
+            KubernetesConstants.Annotation.TRUE_VALUE);
+
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/route_\\d+");
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -363,142 +363,139 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-    
+
     @Test
     void route2IngressTestMultipleDomainsThrowsException() {
         Route route = new Route();
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setPath(RoutePredicate.builder().matchType("exact").matchValue("/test").build());
         route.setServices(Collections.singletonList(new UpstreamService()));
-        
+
         Assertions.assertThrows(IllegalArgumentException.class, () -> converter.route2Ingress(route));
     }
-    
+
     @Test
     void route2IngressTestInvalidPathMatchTypeThrowsException() {
         Route route = new Route();
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setPath(RoutePredicate.builder().matchType("invalid").matchValue("/test").build());
         route.setServices(Collections.singletonList(new UpstreamService()));
-        
+
         Assertions.assertThrows(IllegalArgumentException.class, () -> converter.route2Ingress(route));
     }
-    
-    
+
     @Test
     void route2IngressTestCustomAnnotationsValidInputSuccess() {
         Route route = new Route();
         route.setName("test-route");
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setCustomConfigs(Collections.singletonMap("custom.higress.cn", "value"));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         Assertions.assertNotNull(ingress);
         Assertions.assertEquals("test-route", ingress.getMetadata().getName());
         Assertions.assertEquals("value", ingress.getMetadata().getAnnotations().get("custom.higress.cn"));
     }
-    
+
     @Test
     void route2IngressTestCustomAnnotationsThrowsValidationException() {
         Route route = new Route();
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setCustomConfigs(Collections.singletonMap("higress.io/enable-proxy-next-upstream", "value"));
-        
+
         Assertions.assertThrows(ValidationException.class, () -> converter.route2Ingress(route));
     }
-    
+
     @Test
     void route2IngressTestCorsConfigSuccess() {
         Route route = new Route();
         route.setName("test-route");
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setCors(new CorsConfig(true,                          // enabled (Boolean)
-                Collections.singletonList("https://higress.cn"),            // allowOrigins (List<String>)
-                Collections.singletonList("GET"),                           // allowMethods (List<String>)
-                Collections.singletonList("Content-Type"),                  // allowHeaders (List<String>)
-                Collections.singletonList("Content-Length"),                // exposeHeaders (List<String>)
-                3600,                                                       // maxAge (Integer)
-                true                                                        // allowCredentials (Boolean)
+            Collections.singletonList("https://higress.cn"),            // allowOrigins (List<String>)
+            Collections.singletonList("GET"),                           // allowMethods (List<String>)
+            Collections.singletonList("Content-Type"),                  // allowHeaders (List<String>)
+            Collections.singletonList("Content-Length"),                // exposeHeaders (List<String>)
+            3600,                                                       // maxAge (Integer)
+            true                                                        // allowCredentials (Boolean)
         ));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         Assertions.assertNotNull(ingress);
         Assertions.assertEquals("test-route", ingress.getMetadata().getName());
         Assertions.assertTrue(Boolean.parseBoolean(
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ENABLED_KEY)));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ENABLED_KEY)));
         Assertions.assertEquals("3600",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_MAX_AGE_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_MAX_AGE_KEY));
         Assertions.assertTrue(Boolean.parseBoolean(
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_CREDENTIALS_KEY)));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_CREDENTIALS_KEY)));
         Assertions.assertEquals("https://higress.cn",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_ORIGIN_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_ORIGIN_KEY));
         Assertions.assertEquals("Content-Type",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_HEADERS_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_HEADERS_KEY));
         Assertions.assertEquals("GET",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_METHODS_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_METHODS_KEY));
         Assertions.assertEquals("Content-Length",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_EXPOSE_HEADERS_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_EXPOSE_HEADERS_KEY));
     }
-    
-    
+
     @Test
     void route2IngressTestMethodsSuccess() {
         Route route = new Route();
         route.setName("test-route");
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setMethods(Collections.singletonList("GET"));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         Assertions.assertNotNull(ingress);
         Assertions.assertEquals("test-route", ingress.getMetadata().getName());
         Assertions.assertEquals("GET",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.METHOD_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.METHOD_KEY));
     }
-    
+
     @Test
     void route2IngressTestRewriteConfig() {
         Route route = new Route();
         route.setName("test-route");
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setRewrite(new RewriteConfig(true, "/new-path", "new-host"));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         Assertions.assertNotNull(ingress);
         Assertions.assertEquals("test-route", ingress.getMetadata().getName());
         Assertions.assertTrue(Boolean.parseBoolean(
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.REWRITE_ENABLED_KEY)));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.REWRITE_ENABLED_KEY)));
         Assertions.assertEquals("/new-path",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.REWRITE_PATH_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.REWRITE_PATH_KEY));
         Assertions.assertEquals("new-host",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.UPSTREAM_VHOST_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.UPSTREAM_VHOST_KEY));
     }
-    
+
     @Test
     void route2IngressTestProxyNextUpstreamConfig() {
         Route route = new Route();
         route.setName("test-route");
         route.setDomains(Collections.singletonList("higress.cn"));
         route.setProxyNextUpstream(new ProxyNextUpstreamConfig(true, 2, 10, new String[] {"$http_4xx"}));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         Assertions.assertNotNull(ingress);
         Assertions.assertEquals("test-route", ingress.getMetadata().getName());
         Assertions.assertTrue(Boolean.parseBoolean(ingress.getMetadata().getAnnotations()
-                .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_ENABLED_KEY)));
-        Assertions.assertEquals("2", ingress.getMetadata().getAnnotations()
-                .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_TRIES_KEY));
-        Assertions.assertEquals("10", ingress.getMetadata().getAnnotations()
-                .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_TIMEOUT_KEY));
+            .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_ENABLED_KEY)));
+        Assertions.assertEquals("2",
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_TRIES_KEY));
+        Assertions.assertEquals("10",
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_TIMEOUT_KEY));
         Assertions.assertEquals("$http_4xx",
-                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_KEY));
+            ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_KEY));
     }
-    
-    
+
     @Test
     public void route2IngressTestPrefixPathSingleService() {
         Route route = buildBasicRoute();
@@ -509,23 +506,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", null, null, null);
         route.setServices(Collections.singletonList(service));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local");
-        
+            "hello.default.svc.cluster.local");
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     public void route2IngressTestPrefixPathSingleServiceWithWeight() {
         Route route = buildBasicRoute();
@@ -536,23 +533,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", null, null, 15);
         route.setServices(Collections.singletonList(service));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local");
-        
+            "hello.default.svc.cluster.local");
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     public void route2IngressTestPrefixPathSingleServiceWithPort() {
         Route route = buildBasicRoute();
@@ -563,23 +560,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, null, null);
         route.setServices(Collections.singletonList(service));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local:8080");
-        
+            "hello.default.svc.cluster.local:8080");
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     public void route2IngressTestPrefixPathSingleServiceWithPortAndVersion() {
         Route route = buildBasicRoute();
@@ -590,23 +587,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, "v1", 100);
         route.setServices(Collections.singletonList(service));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local:8080");
-        
+            "hello.default.svc.cluster.local:8080");
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     public void route2IngressTestPrefixPathMultipleServices() {
         Route route = buildBasicRoute();
@@ -619,24 +616,24 @@ public class KubernetesModelConverterTest {
         UpstreamService service2 = new UpstreamService("hello2.default.svc.cluster.local", 18080, "v1", 30);
         UpstreamService service3 = new UpstreamService("hello3.default.svc.cluster.local", null, "v2", 50);
         route.setServices(Arrays.asList(service1, service2, service3));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "20% hello1.default.svc.cluster.local:8080\n"
-                        + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
-        
+            "20% hello1.default.svc.cluster.local:8080\n"
+                + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     public void route2IngressTestExactPathSingleService() {
         Route route = buildBasicRoute();
@@ -647,23 +644,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, "v1", 100);
         route.setServices(Collections.singletonList(service));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local:8080");
-        
+            "hello.default.svc.cluster.local:8080");
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.EXACT);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     public void route2IngressTestRegularPathSingleService() {
         Route route = buildBasicRoute();
@@ -674,25 +671,25 @@ public class KubernetesModelConverterTest {
         pathPredicate.setCaseSensitive(null);
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, "v1", 100);
         route.setServices(Collections.singletonList(service));
-        
+
         V1Ingress ingress = converter.route2Ingress(route);
-        
+
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-        
+
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-                "hello.default.svc.cluster.local:8080");
+            "hello.default.svc.cluster.local:8080");
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.USE_REGEX_KEY,
-                KubernetesConstants.Annotation.TRUE_VALUE);
-        
+            KubernetesConstants.Annotation.TRUE_VALUE);
+
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-        
+
         Assertions.assertEquals(expectedIngress, ingress);
     }
-    
+
     @Test
     void domain2ConfigMapTestNormalizeDomainName() {
         V1ConfigMap domainConfigMap = new V1ConfigMap();
@@ -713,99 +710,99 @@ public class KubernetesModelConverterTest {
         V1ConfigMap target = converter.domain2ConfigMap(domain);
         Assertions.assertEquals(domainConfigMap, target);
     }
-    
+
     @Test
     void configMap2DomainTestValidConfigMapShouldReturnDomain() {
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setResourceVersion("1");
-        
+
         Map<String, String> data = new HashMap<>();
         data.put(CommonKey.DOMAIN, "higress.cn");
         data.put(KubernetesConstants.K8S_CERT, "cert-identifier");
         data.put(KubernetesConstants.K8S_ENABLE_HTTPS, "true");
-        
+
         V1ConfigMap configMap = new V1ConfigMap();
         configMap.setMetadata(metadata);
         configMap.setData(data);
-        
+
         Domain domain = converter.configMap2Domain(configMap);
-        
+
         Assertions.assertNotNull(domain);
         Assertions.assertEquals("higress.cn", domain.getName());
         Assertions.assertEquals("1", domain.getVersion());
         Assertions.assertEquals("cert-identifier", domain.getCertIdentifier());
         Assertions.assertEquals("true", domain.getEnableHttps());
     }
-    
-    
+
     @Test
     void configMap2DomainTestNullMetadataShouldReturnDomainWithNullVersion() {
         Map<String, String> data = new HashMap<>();
         data.put(CommonKey.DOMAIN, "higress.cn");
-        
+
         V1ConfigMap configMap = new V1ConfigMap();
         configMap.setData(data);
-        
+
         Domain domain = converter.configMap2Domain(configMap);
-        
+
         Assertions.assertNotNull(domain);
         Assertions.assertEquals("higress.cn", domain.getName());
         Assertions.assertNull(domain.getVersion());
         Assertions.assertNull(domain.getCertIdentifier());
         Assertions.assertNull(domain.getEnableHttps());
     }
-    
+
     @Test
     void configMap2DomainTestNullDataShouldThrowIllegalArgumentException() {
         V1ConfigMap configMap = new V1ConfigMap();
         configMap.setData(null);
-        
+
         IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
             converter.configMap2Domain(configMap);
         });
         Assertions.assertEquals("The ConfigMap data is illegal", exception.getMessage());
     }
-    
+
     @Test
     void configMap2DomainTestMissingFieldsShouldReturnDomainWithNullFields() {
         Map<String, String> data = new HashMap<>();
         data.put(CommonKey.DOMAIN, "higress.cn");
-        
+
         V1ConfigMap configMap = new V1ConfigMap();
         configMap.setData(data);
-        
+
         Domain domain = converter.configMap2Domain(configMap);
-        
+
         Assertions.assertNotNull(domain);
         Assertions.assertEquals("higress.cn", domain.getName());
         Assertions.assertNull(domain.getCertIdentifier());
         Assertions.assertNull(domain.getEnableHttps());
     }
-    
+
     @Test
     void tlsCertificate2SecretTestValidCertificateWithoutDomainsShouldNotSetLabels() {
-        TlsCertificate certificate = TlsCertificate.builder().cert("dummyCert").key("dummyKey").name("test-certificate")
-                .version("1").domains(Collections.emptyList()).build();
-        
+        TlsCertificate certificate =
+            TlsCertificate.builder().cert("dummyCert").key("dummyKey").name("test-certificate").version("1")
+                .domains(Collections.emptyList()).build();
+
         V1Secret secret = converter.tlsCertificate2Secret(certificate);
-        
+
         Assertions.assertNotNull(secret);
         Assertions.assertEquals(KubernetesConstants.SECRET_TYPE_TLS, secret.getType());
         Assertions.assertEquals("test-certificate", secret.getMetadata().getName());
         Assertions.assertEquals("1", secret.getMetadata().getResourceVersion());
-        
+
         Map<String, byte[]> data = secret.getData();
         Assertions.assertNotNull(data);
         Assertions.assertEquals(2, data.size());
         Assertions.assertArrayEquals(TypeUtil.string2Bytes("dummyCert"),
-                data.get(KubernetesConstants.SECRET_TLS_CRT_FIELD));
+            data.get(KubernetesConstants.SECRET_TLS_CRT_FIELD));
         Assertions.assertArrayEquals(TypeUtil.string2Bytes("dummyKey"),
-                data.get(KubernetesConstants.SECRET_TLS_KEY_FIELD));
-        
+            data.get(KubernetesConstants.SECRET_TLS_KEY_FIELD));
+
         Map<String, String> labels = secret.getMetadata().getLabels();
         Assertions.assertNull(labels);
     }
-    
+
     @Test
     void secret2TlsCertificateTestValidSecretWithoutCertAndKeyShouldReturnTlsCertificateWithoutCertAndKey() {
         V1Secret secret = new V1Secret();
@@ -813,9 +810,9 @@ public class KubernetesModelConverterTest {
             setName("test-secret");
             setResourceVersion("123");
         }});
-        
+
         TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
-        
+
         Assertions.assertNotNull(tlsCertificate);
         Assertions.assertEquals("test-secret", tlsCertificate.getName());
         Assertions.assertEquals("123", tlsCertificate.getVersion());
@@ -825,7 +822,7 @@ public class KubernetesModelConverterTest {
         Assertions.assertNull(tlsCertificate.getValidityEnd());
         Assertions.assertNull(tlsCertificate.getDomains());
     }
-    
+
     @Test
     void secret2TlsCertificateTestNullMetadataShouldReturnTlsCertificateWithoutNameAndVersion() {
         V1Secret secret = new V1Secret();
@@ -833,16 +830,16 @@ public class KubernetesModelConverterTest {
             put(KubernetesConstants.SECRET_TLS_CRT_FIELD, "certData".getBytes());
             put(KubernetesConstants.SECRET_TLS_KEY_FIELD, "keyData".getBytes());
         }});
-        
+
         TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
-        
+
         Assertions.assertNotNull(tlsCertificate);
         Assertions.assertNull(tlsCertificate.getName());
         Assertions.assertNull(tlsCertificate.getVersion());
         Assertions.assertEquals("certData", tlsCertificate.getCert());
         Assertions.assertEquals("keyData", tlsCertificate.getKey());
     }
-    
+
     @Test
     void secret2TlsCertificateTestEmptyDataShouldReturnTlsCertificateWithoutCertAndKey() {
         V1Secret secret = new V1Secret();
@@ -851,9 +848,9 @@ public class KubernetesModelConverterTest {
             setResourceVersion("123");
         }});
         secret.setData(Collections.emptyMap());
-        
+
         TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
-        
+
         Assertions.assertNotNull(tlsCertificate);
         Assertions.assertEquals("test-secret", tlsCertificate.getName());
         Assertions.assertEquals("123", tlsCertificate.getVersion());
@@ -863,16 +860,15 @@ public class KubernetesModelConverterTest {
         Assertions.assertNull(tlsCertificate.getValidityEnd());
         Assertions.assertNull(tlsCertificate.getDomains());
     }
-    
-    
+
     @Test
     void wasmPluginFromCrTestWithValidInputShouldReturnWasmPlugin() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
         cr.setMetadata(createMetadata());
         cr.setSpec(createSpec());
-        
+
         WasmPlugin plugin = converter.wasmPluginFromCr(cr);
-        
+
         Assertions.assertNotNull(plugin);
         Assertions.assertEquals("test-plugin", plugin.getName());
         Assertions.assertEquals("v1", plugin.getPluginVersion());
@@ -886,19 +882,19 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(PluginPhase.UNSPECIFIED.getName(), plugin.getPhase());
         Assertions.assertEquals(10, plugin.getPriority());
     }
-    
+
     @Test
     void wasmPluginFromCrTestWithMissingFieldsShouldHandleGracefully() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
         cr.setMetadata(createMetadata());
         cr.setSpec(createSpec());
-        
+
         cr.getMetadata().getLabels().remove(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY);
         cr.getMetadata().getLabels().remove(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY);
         cr.getSpec().setUrl("image");
-        
+
         WasmPlugin plugin = converter.wasmPluginFromCr(cr);
-        
+
         Assertions.assertNotNull(plugin);
         Assertions.assertEquals(null, plugin.getName());
         Assertions.assertEquals(null, plugin.getPluginVersion());
@@ -912,97 +908,99 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(PluginPhase.UNSPECIFIED.getName(), plugin.getPhase());
         Assertions.assertEquals(10, plugin.getPriority());
     }
-    
+
     @Test
     void wasmPluginToCrTestValidInput_ShouldConvertCorrectly() {
-        WasmPlugin plugin = WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1")
-                .category("test-category").title("Test Plugin").description("A test plugin").icon("test-icon")
-                .builtIn(true).imageRepository("test-repository").imageVersion("test-version").phase("test-phase")
-                .priority(10).build();
-        
+        WasmPlugin plugin =
+            WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1").category("test-category")
+                .title("Test Plugin").description("A test plugin").icon("test-icon").builtIn(true)
+                .imageRepository("test-repository").imageVersion("test-version").phase("test-phase").priority(10)
+                .build();
+
         V1alpha1WasmPlugin cr = converter.wasmPluginToCr(plugin);
-        
+
         Assertions.assertNotNull(cr);
         Assertions.assertNotNull(cr.getMetadata());
         Assertions.assertEquals("test-plugin-1.0.0", cr.getMetadata().getName());
         Assertions.assertEquals("1", cr.getMetadata().getResourceVersion());
-        
+
         Assertions.assertEquals("test-plugin",
-                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY));
+            cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY));
         Assertions.assertEquals("1.0.0",
-                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY));
+            cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY));
         Assertions.assertEquals("test-category",
-                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_CATEGORY_KEY));
+            cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_CATEGORY_KEY));
         Assertions.assertEquals("true",
-                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_BUILT_IN_KEY));
-        
+            cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_BUILT_IN_KEY));
+
         Assertions.assertEquals("Test Plugin",
-                cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_TITLE_KEY));
+            cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_TITLE_KEY));
         Assertions.assertEquals("A test plugin",
-                cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_DESCRIPTION_KEY));
+            cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_DESCRIPTION_KEY));
         Assertions.assertEquals("test-icon",
-                cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_ICON_KEY));
-        
+            cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_ICON_KEY));
+
         Assertions.assertNotNull(cr.getSpec());
         Assertions.assertEquals("test-phase", cr.getSpec().getPhase());
         Assertions.assertEquals(10, cr.getSpec().getPriority().intValue());
         Assertions.assertEquals("oci://test-repository:test-version", cr.getSpec().getUrl());
     }
-    
+
     @Test
     void wasmPluginToCrTestNullImageRepositoryShouldHandleCorrectly() {
-        WasmPlugin plugin = WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1")
-                .imageRepository(null).imageVersion("test-version").build();
-        
+        WasmPlugin plugin =
+            WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1").imageRepository(null)
+                .imageVersion("test-version").build();
+
         V1alpha1WasmPlugin cr = converter.wasmPluginToCr(plugin);
-        
+
         Assertions.assertNotNull(cr);
         Assertions.assertNotNull(cr.getSpec());
         Assertions.assertEquals(null, cr.getSpec().getUrl());
     }
-    
+
     @Test
     void wasmPluginToCrTestEmptyImageVersionShouldHandleCorrectly() {
         WasmPlugin plugin = WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1")
-                .imageRepository("test-repository").imageVersion("").build();
-        
+            .imageRepository("test-repository").imageVersion("").build();
+
         V1alpha1WasmPlugin cr = converter.wasmPluginToCr(plugin);
-        
+
         Assertions.assertNotNull(cr);
         Assertions.assertNotNull(cr.getSpec());
         Assertions.assertEquals("oci://test-repository", cr.getSpec().getUrl());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestSourceSpecNullDestinationSpecUnchanged() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
         srcPlugin.setSpec(null);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
         dstSpec.setDefaultConfig(new HashMap<>());
         dstPlugin.setSpec(dstSpec);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestDestinationSpecNullSetNewSpec() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
         srcSpec.setDefaultConfig(new HashMap<>());
         srcPlugin.setSpec(srcSpec);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         dstPlugin.setSpec(null);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestMatchRulesMergedAndSorted() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
@@ -1011,74 +1009,74 @@ public class KubernetesModelConverterTest {
         srcSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
         srcSpec.getMatchRules().add(MatchRule.forDomain("test.higress.cn"));
         srcPlugin.setSpec(srcSpec);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
         dstSpec.setMatchRules(new ArrayList<>());
         dstSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
         dstSpec.getMatchRules().add(MatchRule.forDomain("test.higress.cn"));
         dstPlugin.setSpec(dstSpec);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         List<MatchRule> expected = new ArrayList<>();
         expected.add(MatchRule.forDomain("higress.cn"));
         expected.add(MatchRule.forDomain("test.higress.cn"));
-        
+
         Assertions.assertEquals(expected, dstPlugin.getSpec().getMatchRules());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestEmptyMatchRulesNoChange() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
         srcSpec.setMatchRules(new ArrayList<>());
         srcPlugin.setSpec(srcSpec);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
         dstSpec.setMatchRules(new ArrayList<>());
         dstSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
         dstPlugin.setSpec(dstSpec);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         List<MatchRule> expected = new ArrayList<>();
         expected.add(MatchRule.forDomain("higress.cn"));
-        
+
         Assertions.assertEquals(expected, dstPlugin.getSpec().getMatchRules());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestSrcSpecNullNoChangeToDstPlugin() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
         srcPlugin.setSpec(null);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
         dstSpec.setDefaultConfig(new HashMap<>());
         dstPlugin.setSpec(dstSpec);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestDstSpecNullSetNewSpec() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
         srcSpec.setDefaultConfig(new HashMap<>());
         srcPlugin.setSpec(srcSpec);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         dstPlugin.setSpec(null);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
     }
-    
+
     @Test
     void mergeWasmPluginSpecTestMatchRulesMergedAndSortedWithExistingRules() {
         V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
@@ -1087,30 +1085,30 @@ public class KubernetesModelConverterTest {
         srcSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
         srcSpec.getMatchRules().add(MatchRule.forDomain("test.higress.cn"));
         srcPlugin.setSpec(srcSpec);
-        
+
         V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
         dstSpec.setMatchRules(new ArrayList<>());
         dstSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
         dstPlugin.setSpec(dstSpec);
-        
+
         converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
-        
+
         List<MatchRule> expected = new ArrayList<>();
         expected.add(MatchRule.forDomain("higress.cn"));
         expected.add(MatchRule.forDomain("test.higress.cn"));
-        
+
         Assertions.assertEquals(expected, dstPlugin.getSpec().getMatchRules());
     }
-    
+
     @Test
     void setWasmPluginInstanceToCrTestGlobalScopeConfigured() {
         V1alpha1WasmPlugin plugin = new V1alpha1WasmPlugin();
         plugin.setMetadata(createMetadata("global", "test-plugin", "v1"));
         plugin.setSpec(createSpecWithGlobalConfig());
-        
-        WasmPluginInstance instance = converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.GLOBAL,
-                null);
+
+        WasmPluginInstance instance =
+            converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.GLOBAL, null);
         Assertions.assertNotNull(instance);
         Assertions.assertEquals("v1", instance.getPluginVersion());
         Assertions.assertEquals(WasmPluginInstanceScope.GLOBAL, instance.getScope());
@@ -1118,36 +1116,35 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(1, instance.getConfigurations().size());
         Assertions.assertEquals("value", instance.getConfigurations().get("key"));
     }
-    
+
     @Test
     void setWasmPluginInstanceToCrTestDomainScopeNotConfigured() {
         V1alpha1WasmPlugin plugin = new V1alpha1WasmPlugin();
         plugin.setMetadata(createMetadata("domain", "test-plugin", "v1"));
         plugin.setSpec(createSpecWithDomainConfig("higress.cn"));
-        
-        WasmPluginInstance instance = converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.DOMAIN,
-                "higress.cn");
+
+        WasmPluginInstance instance =
+            converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.DOMAIN, "higress.cn");
         Assertions.assertNotNull(instance);
         Assertions.assertEquals("v1", instance.getPluginVersion());
         Assertions.assertEquals(WasmPluginInstanceScope.DOMAIN, instance.getScope());
         Assertions.assertTrue(instance.getEnabled());
         Assertions.assertEquals(1, instance.getConfigurations().size());
         Assertions.assertEquals("value", instance.getConfigurations().get("key"));
-        
-        WasmPluginInstance instanceNotConfigured = converter.getWasmPluginInstanceFromCr(plugin,
-                WasmPluginInstanceScope.DOMAIN, "nonexistent.com");
+
+        WasmPluginInstance instanceNotConfigured =
+            converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.DOMAIN, "nonexistent.com");
         Assertions.assertNull(instanceNotConfigured);
     }
-    
-    
+
     @Test
     void setWasmPluginInstanceToCrTestRouteScopeConfigured() {
         V1alpha1WasmPlugin plugin = new V1alpha1WasmPlugin();
         plugin.setMetadata(createMetadata("route", "test-plugin", "v1"));
         plugin.setSpec(createSpecWithRouteConfig("test-route"));
-        
-        WasmPluginInstance instance = converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.ROUTE,
-                "test-route");
+
+        WasmPluginInstance instance =
+            converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.ROUTE, "test-route");
         Assertions.assertNotNull(instance);
         Assertions.assertEquals("v1", instance.getPluginVersion());
         Assertions.assertEquals(WasmPluginInstanceScope.ROUTE, instance.getScope());
@@ -1155,29 +1152,31 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(1, instance.getConfigurations().size());
         Assertions.assertEquals("value", instance.getConfigurations().get("key"));
     }
-    
+
     @Test
     void setWasmPluginInstanceToCrTestGlobalScopeShouldSetDefaultConfig() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
-        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.GLOBAL).target(null)
-                .enabled(true).configurations(Map.of("key", "value")).build();
-        
+        WasmPluginInstance instance =
+            WasmPluginInstance.builder().scope(WasmPluginInstanceScope.GLOBAL).target(null).enabled(true)
+                .configurations(Map.of("key", "value")).build();
+
         converter.setWasmPluginInstanceToCr(cr, instance);
-        
+
         V1alpha1WasmPluginSpec spec = cr.getSpec();
         Assertions.assertNotNull(spec);
         Assertions.assertEquals(Map.of("key", "value"), spec.getDefaultConfig());
         Assertions.assertFalse(spec.getDefaultConfigDisable());
     }
-    
+
     @Test
     void setWasmPluginInstanceToCrTestDomainScopeShouldAddOrUpdateDomainRule() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
-        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.DOMAIN)
-                .target("higress.cn").enabled(true).configurations(Map.of("key", "value")).build();
-        
+        WasmPluginInstance instance =
+            WasmPluginInstance.builder().scope(WasmPluginInstanceScope.DOMAIN).target("higress.cn").enabled(true)
+                .configurations(Map.of("key", "value")).build();
+
         converter.setWasmPluginInstanceToCr(cr, instance);
-        
+
         V1alpha1WasmPluginSpec spec = cr.getSpec();
         Assertions.assertNotNull(spec);
         List<MatchRule> matchRules = spec.getMatchRules();
@@ -1188,19 +1187,20 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(Map.of("key", "value"), domainRule.getConfig());
         Assertions.assertFalse(domainRule.getConfigDisable());
     }
-    
+
     @Test
     void setWasmPluginInstanceToCrTestDomainScopeExistingRuleShouldUpdateExistingDomainRule() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
         V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
         spec.setMatchRules(List.of(new MatchRule(false, Map.of("key", "original"), List.of("higress.cn"), List.of())));
         cr.setSpec(spec);
-        
-        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.DOMAIN)
-                .target("higress.cn").enabled(true).configurations(Map.of("key", "updated")).build();
-        
+
+        WasmPluginInstance instance =
+            WasmPluginInstance.builder().scope(WasmPluginInstanceScope.DOMAIN).target("higress.cn").enabled(true)
+                .configurations(Map.of("key", "updated")).build();
+
         converter.setWasmPluginInstanceToCr(cr, instance);
-        
+
         List<MatchRule> matchRules = cr.getSpec().getMatchRules();
         Assertions.assertNotNull(matchRules);
         Assertions.assertEquals(1, matchRules.size());
@@ -1209,16 +1209,16 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(Map.of("key", "updated"), domainRule.getConfig());
         Assertions.assertFalse(domainRule.getConfigDisable());
     }
-    
-    
+
     @Test
     void setWasmPluginInstanceToCrTestRouteScopeShouldAddOrUpdateRouteRule() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
-        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.ROUTE)
-                .target("route-1").enabled(true).configurations(Map.of("key", "value")).build();
-        
+        WasmPluginInstance instance =
+            WasmPluginInstance.builder().scope(WasmPluginInstanceScope.ROUTE).target("route-1").enabled(true)
+                .configurations(Map.of("key", "value")).build();
+
         converter.setWasmPluginInstanceToCr(cr, instance);
-        
+
         V1alpha1WasmPluginSpec spec = cr.getSpec();
         Assertions.assertNotNull(spec);
         List<MatchRule> matchRules = spec.getMatchRules();
@@ -1229,7 +1229,7 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(Map.of("key", "value"), routeRule.getConfig());
         Assertions.assertFalse(routeRule.getConfigDisable());
     }
-    
+
     @Test
     void removeWasmPluginInstanceFromCrTestGlobalScopeTargetNullShouldRemoveDefaultConfig() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
@@ -1239,11 +1239,11 @@ public class KubernetesModelConverterTest {
         spec.setDefaultConfig(config);
         cr.setSpec(spec);
         boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.GLOBAL, null);
-        
+
         Assertions.assertTrue(result);
         Assertions.assertNull(cr.getSpec().getDefaultConfig());
     }
-    
+
     @Test
     void removeWasmPluginInstanceFromCrTestDomainScopeValidTargetShouldRemoveDomain() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
@@ -1256,13 +1256,13 @@ public class KubernetesModelConverterTest {
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
-        
+
         boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.DOMAIN, "higress.cn");
-        
+
         Assertions.assertTrue(result);
         Assertions.assertTrue(cr.getSpec().getMatchRules().isEmpty());
     }
-    
+
     @Test
     void removeWasmPluginInstanceFromCrTestDomainScopeEmptyTargetShouldNotChange() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
@@ -1275,14 +1275,13 @@ public class KubernetesModelConverterTest {
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
-        
+
         boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.DOMAIN, "");
-        
+
         Assertions.assertFalse(result);
         Assertions.assertEquals(1, cr.getSpec().getMatchRules().size());
     }
-    
-    
+
     @Test
     void removeWasmPluginInstanceFromCrTestRouteScopeValidTargetShouldRemoveIngress() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
@@ -1295,13 +1294,13 @@ public class KubernetesModelConverterTest {
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
-        
+
         boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.ROUTE, "test-route");
-        
+
         Assertions.assertTrue(result);
         Assertions.assertTrue(cr.getSpec().getMatchRules().isEmpty());
     }
-    
+
     @Test
     void removeWasmPluginInstanceFromCrTestRouteScopeEmptyTargetShouldNotChange() {
         V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
@@ -1314,14 +1313,13 @@ public class KubernetesModelConverterTest {
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
-        
+
         boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.ROUTE, "");
-        
+
         Assertions.assertFalse(result);
         Assertions.assertEquals(1, cr.getSpec().getMatchRules().size());
     }
-    
-    
+
     @Test
     public void v1RegistryConfig2ServiceSourceTestNacosType() {
         V1RegistryConfig v1RegistryConfig = new V1RegistryConfig();
@@ -1331,9 +1329,9 @@ public class KubernetesModelConverterTest {
         v1RegistryConfig.setName("testName");
         v1RegistryConfig.setNacosNamespaceId("testNamespaceId");
         v1RegistryConfig.setNacosGroups(List.of("testGroup1", "testGroup2"));
-        
+
         ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(v1RegistryConfig);
-        
+
         Assertions.assertNotNull(serviceSource);
         Assertions.assertEquals(V1McpBridge.REGISTRY_TYPE_NACOS, serviceSource.getType());
         Assertions.assertEquals("testDomain", serviceSource.getDomain());
@@ -1343,9 +1341,9 @@ public class KubernetesModelConverterTest {
         Assertions.assertNotNull(properties);
         Assertions.assertEquals("testNamespaceId", properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_NAMESPACE_ID));
         Assertions.assertEquals(List.of("testGroup1", "testGroup2"),
-                properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_GROUPS));
+            properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_GROUPS));
     }
-    
+
     @Test
     public void v1RegistryConfig2ServiceSourceTestZkType() {
         V1RegistryConfig v1RegistryConfig = new V1RegistryConfig();
@@ -1354,9 +1352,9 @@ public class KubernetesModelConverterTest {
         v1RegistryConfig.setPort(80);
         v1RegistryConfig.setName("testName");
         v1RegistryConfig.setZkServicesPath(List.of("testPath1", "testPath2"));
-        
+
         ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(v1RegistryConfig);
-        
+
         Assertions.assertNotNull(serviceSource);
         Assertions.assertEquals(V1McpBridge.REGISTRY_TYPE_ZK, serviceSource.getType());
         Assertions.assertEquals("testDomain", serviceSource.getDomain());
@@ -1365,9 +1363,9 @@ public class KubernetesModelConverterTest {
         Map<String, Object> properties = serviceSource.getProperties();
         Assertions.assertNotNull(properties);
         Assertions.assertEquals(List.of("testPath1", "testPath2"),
-                properties.get(V1McpBridge.REGISTRY_TYPE_ZK_SERVICES_PATH));
+            properties.get(V1McpBridge.REGISTRY_TYPE_ZK_SERVICES_PATH));
     }
-    
+
     @Test
     public void v1RegistryConfig2ServiceSourceTestConsulType() {
         V1RegistryConfig v1RegistryConfig = new V1RegistryConfig();
@@ -1378,9 +1376,9 @@ public class KubernetesModelConverterTest {
         v1RegistryConfig.setConsulDataCenter("testDataCenter");
         v1RegistryConfig.setConsulServiceTag("testServiceTag");
         v1RegistryConfig.setConsulRefreshInterval(30);
-        
+
         ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(v1RegistryConfig);
-        
+
         Assertions.assertNotNull(serviceSource);
         Assertions.assertEquals(V1McpBridge.REGISTRY_TYPE_CONSUL, serviceSource.getType());
         Assertions.assertEquals("testDomain", serviceSource.getDomain());
@@ -1392,77 +1390,77 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals("testServiceTag", properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_SERVICE_TAG));
         Assertions.assertEquals(30, properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_REFRESH_INTERVAL));
     }
-    
+
     @Test
     public void v1RegistryConfig2ServiceSourceTestNullInput() {
         ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(null);
-        
+
         Assertions.assertNotNull(serviceSource);
         Assertions.assertEquals(new ServiceSource(), serviceSource);
     }
-    
+
     @Test
     public void generateAuthSecretNameTestValidServiceSourceName() {
         String serviceSourceName = "test-service-source";
         String expectedPattern = serviceSourceName + "-auth-\\w{5}";
-        
+
         String authSecretName = converter.generateAuthSecretName(serviceSourceName);
-        
+
         Assertions.assertTrue(authSecretName.matches(expectedPattern),
-                "Auth secret name should match the expected pattern");
+            "Auth secret name should match the expected pattern");
     }
-    
+
     @Test
     public void generateAuthSecretNameTestEmptyServiceSourceName() {
         String serviceSourceName = "";
         String expectedPattern = serviceSourceName + "-auth-\\w{5}";
-        
+
         String authSecretName = converter.generateAuthSecretName(serviceSourceName);
-        
+
         Assertions.assertTrue(authSecretName.matches(expectedPattern),
-                "Auth secret name should match the expected pattern");
+            "Auth secret name should match the expected pattern");
     }
-    
+
     @Test
     public void generateAuthSecretNameTestNullServiceSourceName() {
         String serviceSourceName = null;
         String expectedPattern = "null-auth-\\w{5}";
-        
+
         String authSecretName = converter.generateAuthSecretName(serviceSourceName);
-        
+
         Assertions.assertTrue(authSecretName.matches(expectedPattern),
-                "Auth secret name should match the expected pattern");
+            "Auth secret name should match the expected pattern");
     }
-    
+
     @Test
     void initV1McpBridgeTestShouldSetDefaultValues() {
         V1McpBridge v1McpBridge = new V1McpBridge();
-        
+
         converter.initV1McpBridge(v1McpBridge);
-        
+
         Assertions.assertNotNull(v1McpBridge.getMetadata(), "Metadata should not be null");
         Assertions.assertEquals(V1McpBridge.DEFAULT_NAME, v1McpBridge.getMetadata().getName(),
-                "Metadata name should be set to default");
+            "Metadata name should be set to default");
         Assertions.assertNotNull(v1McpBridge.getSpec(), "Spec should not be null");
         Assertions.assertNotNull(v1McpBridge.getSpec().getRegistries(), "Spec registries should not be null");
         Assertions.assertEquals(0, v1McpBridge.getSpec().getRegistries().size(),
-                "Spec registries should be initialized as empty list");
+            "Spec registries should be initialized as empty list");
     }
-    
+
     @Test
     public void addV1McpBridgeRegistryTestRegistryDoesNotExistShouldAddAndReturnRegistryConfig() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
+
         List<V1RegistryConfig> registries = new ArrayList<>();
         spec.setRegistries(registries);
-        
-        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
-                new HashMap<>(), null);
-        
+
+        ServiceSource serviceSource =
+            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, new HashMap<>(), null);
+
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
-        
+
         Assertions.assertNotNull(result);
         Assertions.assertEquals(serviceSource.getName(), result.getName());
         Assertions.assertEquals(serviceSource.getDomain(), result.getDomain());
@@ -1470,24 +1468,24 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(serviceSource.getPort(), result.getPort());
         Assertions.assertTrue(registries.contains(result));
     }
-    
+
     @Test
     public void addV1McpBridgeRegistryTestRegistryExistsShouldUpdateAndReturnRegistryConfig() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
+
         List<V1RegistryConfig> registries = new ArrayList<>();
         V1RegistryConfig existingRegistry = new V1RegistryConfig();
         existingRegistry.setName("testService");
         registries.add(existingRegistry);
         spec.setRegistries(registries);
-        
-        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
-                new HashMap<>(), null);
-        
+
+        ServiceSource serviceSource =
+            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, new HashMap<>(), null);
+
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
-        
+
         Assertions.assertNotNull(result);
         Assertions.assertEquals(serviceSource.getName(), result.getName());
         Assertions.assertEquals(serviceSource.getDomain(), result.getDomain());
@@ -1495,302 +1493,297 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(serviceSource.getPort(), result.getPort());
         Assertions.assertTrue(registries.contains(result));
     }
-    
+
     @Test
     public void addV1McpBridgeRegistryTestNullServiceSourceShouldReturnNull() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
+
         List<V1RegistryConfig> registries = new ArrayList<>();
         spec.setRegistries(registries);
-        
+
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, null);
-        
+
         Assertions.assertNull(result);
     }
-    
+
     @Test
     public void addV1McpBridgeRegistryTestNullSpecShouldCreateSpecAndAddRegistry() {
         V1McpBridge v1McpBridge = new V1McpBridge();
-        
-        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
-                new HashMap<>(), null);
-        
+
+        ServiceSource serviceSource =
+            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, new HashMap<>(), null);
+
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
-        
+
         Assertions.assertNotNull(result);
         Assertions.assertNotNull(v1McpBridge.getSpec());
         Assertions.assertNotNull(v1McpBridge.getSpec().getRegistries());
         Assertions.assertTrue(v1McpBridge.getSpec().getRegistries().contains(result));
     }
-    
+
     @Test
     public void addV1McpBridgeRegistryTestNullRegistriesShouldCreateRegistriesAndAddRegistry() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
-        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
-                new HashMap<>(), null);
-        
+
+        ServiceSource serviceSource =
+            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, new HashMap<>(), null);
+
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
-        
+
         Assertions.assertNotNull(result);
         Assertions.assertNotNull(v1McpBridge.getSpec().getRegistries());
         Assertions.assertTrue(v1McpBridge.getSpec().getRegistries().contains(result));
     }
-    
-    
+
     @Test
     public void removeV1McpBridgeRegistryTestRegistryExistsShouldRemoveAndReturnRegistryConfig() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
+
         List<V1RegistryConfig> registries = new ArrayList<>();
         V1RegistryConfig registryConfig = new V1RegistryConfig();
         registryConfig.setName("testRegistry");
         registries.add(registryConfig);
         spec.setRegistries(registries);
-        
+
         V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "testRegistry");
-        
+
         Assertions.assertNotNull(result);
         Assertions.assertEquals("testRegistry", result.getName());
         Assertions.assertTrue(spec.getRegistries().isEmpty());
     }
-    
+
     @Test
     public void removeV1McpBridgeRegistryTestRegistryDoesNotExistShouldReturnNull() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
+
         List<V1RegistryConfig> registries = new ArrayList<>();
         V1RegistryConfig registryConfig = new V1RegistryConfig();
         registryConfig.setName("existingRegistry");
         registries.add(registryConfig);
         spec.setRegistries(registries);
-        
+
         V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "nonExistingRegistry");
-        
+
         Assertions.assertNull(result);
         Assertions.assertEquals(1, spec.getRegistries().size());
     }
-    
+
     @Test
     public void removeV1McpBridgeRegistryTestNoRegistriesShouldReturnNull() {
         V1McpBridge v1McpBridge = new V1McpBridge();
         V1McpBridgeSpec spec = new V1McpBridgeSpec();
         v1McpBridge.setSpec(spec);
-        
+
         spec.setRegistries(new ArrayList<>());
-        
+
         V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "testRegistry");
-        
+
         Assertions.assertNull(result);
     }
-    
-    
+
     @Test
     public void removeV1McpBridgeRegistryTestNullSpecShouldReturnNull() {
         V1McpBridge v1McpBridge = new V1McpBridge();
-        
+
         v1McpBridge.setSpec(null);
-        
+
         V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "testRegistry");
-        
+
         Assertions.assertNull(result);
     }
-    
-    
+
     @Test
     void ingress2RouteTestValidIngressWithSingleRule() {
         V1IngressBackend backend = new V1IngressBackend();
         V1IngressSpec spec = new V1IngressSpec();
         spec.setDefaultBackend(backend);
-        
+
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setName("test-ingress");
         metadata.setResourceVersion("1");
-        
+
         V1Ingress ingress = new V1Ingress();
         ingress.setMetadata(metadata);
         ingress.setSpec(spec);
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Assertions.assertNotNull(route);
         Assertions.assertEquals("test-ingress", route.getName());
         Assertions.assertEquals("1", route.getVersion());
     }
-    
+
     @Test
     void ingress2RouteTestValidIngressWithMultipleRules() {
         V1IngressBackend backend = new V1IngressBackend();
         V1IngressSpec spec = new V1IngressSpec();
         spec.setDefaultBackend(backend);
-        
+
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setName("test-ingress");
         metadata.setResourceVersion("1");
-        
+
         V1IngressRule rule1 = new V1IngressRule();
         rule1.setHost("example.com");
-        
+
         V1IngressRule rule2 = new V1IngressRule();
         rule2.setHost("test.example.com");
-        
+
         spec.setRules(Arrays.asList(rule1, rule2));
-        
+
         V1Ingress ingress = new V1Ingress();
         ingress.setMetadata(metadata);
         ingress.setSpec(spec);
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Assertions.assertNotNull(route);
         Assertions.assertEquals("test-ingress", route.getName());
         Assertions.assertEquals("1", route.getVersion());
         Assertions.assertEquals(null, route.getDomains());
     }
-    
+
     @Test
     void ingress2RouteTestValidIngressWithTLS() {
         V1IngressBackend backend = new V1IngressBackend();
         V1IngressSpec spec = new V1IngressSpec();
         spec.setDefaultBackend(backend);
-        
+
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setName("test-ingress");
         metadata.setResourceVersion("1");
-        
+
         V1IngressTLS tls = new V1IngressTLS();
         tls.setHosts(Arrays.asList("higress.cn", "test.higress.cn"));
-        
+
         spec.setTls(Arrays.asList(tls));
-        
+
         V1Ingress ingress = new V1Ingress();
         ingress.setMetadata(metadata);
         ingress.setSpec(spec);
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Assertions.assertNotNull(route);
         Assertions.assertEquals("test-ingress", route.getName());
         Assertions.assertEquals("1", route.getVersion());
         Assertions.assertEquals(null, route.getDomains());
     }
-    
+
     @Test
     void ingress2RouteTestValidIngressWithAnnotationsReturnsValidRoute() {
         V1IngressBackend backend = new V1IngressBackend();
         V1IngressSpec spec = new V1IngressSpec();
         spec.setDefaultBackend(backend);
-        
+
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setName("test-ingress");
         metadata.setResourceVersion("1");
         metadata.setAnnotations(new HashMap<String, String>() {{
             put("higress.cn", "annotation-value");
         }});
-        
+
         V1Ingress ingress = new V1Ingress();
         ingress.setMetadata(metadata);
         ingress.setSpec(spec);
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Assertions.assertNotNull(route);
         Assertions.assertEquals("test-ingress", route.getName());
         Assertions.assertEquals("1", route.getVersion());
         Assertions.assertNotNull(route.getCustomConfigs());
         Assertions.assertEquals("annotation-value", route.getCustomConfigs().get("higress.cn"));
     }
-    
+
     @Test
     void ingress2RouteTestNullMetadataReturnsRouteWithDefaults() {
         V1IngressBackend backend = new V1IngressBackend();
         V1IngressSpec spec = new V1IngressSpec();
         spec.setDefaultBackend(backend);
-        
+
         V1Ingress ingress = new V1Ingress();
         ingress.setSpec(spec);
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Assertions.assertNotNull(route);
         Assertions.assertEquals(null, route.getName());
         Assertions.assertEquals(null, route.getVersion());
     }
-    
+
     @Test
     void ingress2RouteTestNullSpecReturnsRouteWithDefaults() {
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setName("test-ingress");
         metadata.setResourceVersion("1");
-        
+
         V1Ingress ingress = new V1Ingress();
         ingress.setMetadata(metadata);
-        
+
         Route route = converter.ingress2Route(ingress);
-        
+
         Assertions.assertNotNull(route);
         Assertions.assertEquals("test-ingress", route.getName());
         Assertions.assertEquals("1", route.getVersion());
         Assertions.assertNull(route.getDomains());
     }
-    
-    
+
     @Test
     public void domainName2ConfigMapNameTestNormalDomainNameConfigMapNameCreated() {
         String domainName = "www.higress.cn";
         String expectedConfigMapName = "domain-www.higress.cn";
         String actualConfigMapName = converter.domainName2ConfigMapName(domainName);
-        
+
         Assertions.assertEquals(expectedConfigMapName, actualConfigMapName,
-                "ConfigMap name should be 'domain-www.higress.cn'");
+            "ConfigMap name should be 'domain-www.higress.cn'");
     }
-    
+
     @Test
     public void domainName2ConfigMapNameTestWildcardDomainNameConfigMapNameCreated() {
         String domainName = "*.higress.cn";
         String expectedConfigMapName = "domain-wildcard.higress.cn";
         String actualConfigMapName = converter.domainName2ConfigMapName(domainName);
-        
+
         Assertions.assertEquals(expectedConfigMapName, actualConfigMapName,
-                "ConfigMap name should be 'domain-wildcard.higress.cn'");
+            "ConfigMap name should be 'domain-wildcard.higress.cn'");
     }
-    
-    
+
     private V1Ingress buildBasicSupportedIngress() {
         V1Ingress ingress = new V1Ingress();
-        
+
         V1ObjectMeta metadata = new V1ObjectMeta();
         ingress.setMetadata(metadata);
-        
+
         V1IngressSpec spec = new V1IngressSpec();
         ingress.setSpec(spec);
-        
+
         V1IngressRule rule = new V1IngressRule();
-        
+
         List<V1IngressRule> rules = new ArrayList<>();
         rules.add(rule);
         spec.setRules(rules);
-        
+
         V1HTTPIngressRuleValue httpRule = new V1HTTPIngressRuleValue();
         rule.setHttp(httpRule);
-        
+
         V1HTTPIngressPath path = new V1HTTPIngressPath();
-        
+
         List<V1HTTPIngressPath> paths = new ArrayList<>();
         paths.add(path);
         httpRule.setPaths(paths);
-        
+
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-        
+
         V1IngressBackend backend = new V1IngressBackend();
         V1TypedLocalObjectReference reference = new V1TypedLocalObjectReference();
         reference.setApiGroup(V1McpBridge.API_GROUP);
@@ -1798,10 +1791,10 @@ public class KubernetesModelConverterTest {
         reference.setName(V1McpBridge.DEFAULT_NAME);
         backend.setResource(reference);
         path.setBackend(backend);
-        
+
         return ingress;
     }
-    
+
     private static Route buildBasicRoute() {
         Route route = new Route();
         route.setDomains(new ArrayList<>());
@@ -1810,14 +1803,14 @@ public class KubernetesModelConverterTest {
         route.setCustomConfigs(new HashMap<>());
         return route;
     }
-    
+
     private V1alpha1WasmPluginSpec createSpecWithGlobalConfig() {
         V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
         spec.setDefaultConfig(Collections.singletonMap("key", "value"));
         spec.setDefaultConfigDisable(false);
         return spec;
     }
-    
+
     private V1alpha1WasmPluginSpec createSpecWithDomainConfig(String domain) {
         V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
         MatchRule matchRule = new MatchRule();
@@ -1827,7 +1820,7 @@ public class KubernetesModelConverterTest {
         spec.setMatchRules(Collections.singletonList(matchRule));
         return spec;
     }
-    
+
     private V1alpha1WasmPluginSpec createSpecWithRouteConfig(String route) {
         V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
         MatchRule matchRule = new MatchRule();
@@ -1837,7 +1830,7 @@ public class KubernetesModelConverterTest {
         spec.setMatchRules(Collections.singletonList(matchRule));
         return spec;
     }
-    
+
     private V1ObjectMeta createMetadata(String name, String pluginName, String pluginVersion) {
         Map<String, String> labels = new HashMap<>();
         labels.put(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY, pluginName);
@@ -1847,26 +1840,25 @@ public class KubernetesModelConverterTest {
         metadata.setLabels(labels);
         return metadata;
     }
-    
-    
+
     private V1ObjectMeta createMetadata() {
         Map<String, String> labels = new HashMap<>();
         labels.put(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY, "test-plugin");
         labels.put(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY, "v1");
         labels.put(KubernetesConstants.Label.WASM_PLUGIN_CATEGORY_KEY, "test-category");
         labels.put(KubernetesConstants.Label.WASM_PLUGIN_BUILT_IN_KEY, "true");
-        
+
         Map<String, String> annotations = new HashMap<>();
         annotations.put(KubernetesConstants.Annotation.WASM_PLUGIN_TITLE_KEY, "Test Plugin");
         annotations.put(KubernetesConstants.Annotation.WASM_PLUGIN_DESCRIPTION_KEY, "A test plugin");
         annotations.put(KubernetesConstants.Annotation.WASM_PLUGIN_ICON_KEY, "icon.png");
-        
+
         V1ObjectMeta metadata = new V1ObjectMeta();
         metadata.setLabels(labels);
         metadata.setAnnotations(annotations);
         return metadata;
     }
-    
+
     private V1alpha1WasmPluginSpec createSpec() {
         V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
         spec.setUrl("test/image:v1");

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
@@ -10,27 +10,34 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.alibaba.higress.sdk.service.kubernetes;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
+import com.alibaba.higress.sdk.constant.CommonKey;
 import com.alibaba.higress.sdk.constant.KubernetesConstants;
+import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.Domain;
 import com.alibaba.higress.sdk.model.Route;
+import com.alibaba.higress.sdk.model.ServiceSource;
+import com.alibaba.higress.sdk.model.TlsCertificate;
+import com.alibaba.higress.sdk.model.WasmPlugin;
+import com.alibaba.higress.sdk.model.WasmPluginInstance;
+import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
 import com.alibaba.higress.sdk.model.route.CorsConfig;
+import com.alibaba.higress.sdk.model.route.ProxyNextUpstreamConfig;
+import com.alibaba.higress.sdk.model.route.RewriteConfig;
 import com.alibaba.higress.sdk.model.route.RoutePredicate;
 import com.alibaba.higress.sdk.model.route.RoutePredicateTypeEnum;
 import com.alibaba.higress.sdk.model.route.UpstreamService;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
-
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridgeSpec;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1RegistryConfig;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.MatchRule;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.PluginPhase;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPluginSpec;
+import com.alibaba.higress.sdk.util.TypeUtil;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1HTTPIngressPath;
 import io.kubernetes.client.openapi.models.V1HTTPIngressRuleValue;
 import io.kubernetes.client.openapi.models.V1Ingress;
@@ -38,50 +45,63 @@ import io.kubernetes.client.openapi.models.V1IngressBackend;
 import io.kubernetes.client.openapi.models.V1IngressRule;
 import io.kubernetes.client.openapi.models.V1IngressServiceBackend;
 import io.kubernetes.client.openapi.models.V1IngressSpec;
+import io.kubernetes.client.openapi.models.V1IngressTLS;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1TypedLocalObjectReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
 public class KubernetesModelConverterTest {
-
+    
     private KubernetesModelConverter converter;
-
+    
     @BeforeEach
     public void setUp() {
         KubernetesClientService service = mock(KubernetesClientService.class);
         converter = new KubernetesModelConverter(service);
     }
-
+    
     @AfterEach
     public void tearDown() {
         converter = null;
     }
-
+    
     @Test
     public void isIngressSupportedTestMissingMetadata() {
         V1Ingress ingress = buildBasicSupportedIngress();
         ingress.setMetadata(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMissingSpec() {
         V1Ingress ingress = buildBasicSupportedIngress();
         ingress.setSpec(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMissingRules() {
         V1Ingress ingress = buildBasicSupportedIngress();
         ingress.getSpec().setRules(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
-
+        
         ingress.getSpec().setRules(Collections.emptyList());
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMultipleRules() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -89,7 +109,7 @@ public class KubernetesModelConverterTest {
         rules.add(rules.get(0));
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMissingHttpRule() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -97,18 +117,18 @@ public class KubernetesModelConverterTest {
         rule.setHttp(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMissingPath() {
         V1Ingress ingress = buildBasicSupportedIngress();
         V1HTTPIngressRuleValue httpRule = ingress.getSpec().getRules().get(0).getHttp();
         httpRule.setPaths(null);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
-
+        
         httpRule.setPaths(Collections.emptyList());
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMultiplePaths() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -117,7 +137,7 @@ public class KubernetesModelConverterTest {
         paths.add(paths.get(0));
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestUnsupportedPathType() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -125,7 +145,7 @@ public class KubernetesModelConverterTest {
         path.setPathType(KubernetesConstants.IngressPathType.IMPLEMENTATION_SPECIFIC);
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestMissingBackend() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -133,7 +153,7 @@ public class KubernetesModelConverterTest {
         path.setBackend(null);
         Assertions.assertTrue(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestServiceBackend() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -141,7 +161,7 @@ public class KubernetesModelConverterTest {
         backend.setService(new V1IngressServiceBackend());
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestNonMcpBackend() {
         V1Ingress ingress = buildBasicSupportedIngress();
@@ -150,28 +170,28 @@ public class KubernetesModelConverterTest {
         reference.setName("DummyKind");
         Assertions.assertFalse(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void isIngressSupportedTestAllGood() {
         V1Ingress ingress = buildBasicSupportedIngress();
         Assertions.assertTrue(converter.isIngressSupported(ingress));
     }
-
+    
     @Test
     public void ingress2RouteTestPrefixPathSingleService() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local");
-
+                "hello.default.svc.cluster.local");
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -182,22 +202,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
     @Test
     public void ingress2RouteTestPrefixPathSingleServiceWithWeight() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "10% hello.default.svc.cluster.local");
-
+                "10% hello.default.svc.cluster.local");
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -208,22 +228,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
     @Test
     public void ingress2RouteTestPrefixPathSingleServiceWithPort() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local:8080");
-
+                "hello.default.svc.cluster.local:8080");
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -234,22 +254,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
     @Test
     public void ingress2RouteTestPrefixPathSingleServiceWithPortAndVersion() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local:8080 v1");
-
+                "hello.default.svc.cluster.local:8080 v1");
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -260,23 +280,23 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
     @Test
     public void ingress2RouteTestPrefixPathMultipleServices() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "20% hello1.default.svc.cluster.local:8080\n"
-                + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
-
+                "20% hello1.default.svc.cluster.local:8080\n"
+                        + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -289,22 +309,22 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Arrays.asList(service1, service2, service3));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
     @Test
     public void ingress2RouteTestExactPathSingleService() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local");
-
+                "hello.default.svc.cluster.local");
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.EXACT);
         path.setPath("/foo");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -315,24 +335,24 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
     @Test
     public void ingress2RouteTestRegularPathSingleService() {
         V1Ingress ingress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta metadata = ingress.getMetadata();
         metadata.setName("test");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local");
+                "hello.default.svc.cluster.local");
         KubernetesUtil.setAnnotation(metadata, KubernetesConstants.Annotation.USE_REGEX_KEY,
-            KubernetesConstants.Annotation.TRUE_VALUE);
-
+                KubernetesConstants.Annotation.TRUE_VALUE);
+        
         V1HTTPIngressPath path = ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/route_\\d+");
-
+        
         Route route = converter.ingress2Route(ingress);
-
+        
         Route expectedRoute = buildBasicRoute();
         expectedRoute.setName(metadata.getName());
         RoutePredicate pathPredicate = expectedRoute.getPath();
@@ -343,7 +363,142 @@ public class KubernetesModelConverterTest {
         expectedRoute.setServices(Collections.singletonList(service));
         Assertions.assertEquals(expectedRoute, route);
     }
-
+    
+    @Test
+    void route2IngressTestMultipleDomainsThrowsException() {
+        Route route = new Route();
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setPath(RoutePredicate.builder().matchType("exact").matchValue("/test").build());
+        route.setServices(Collections.singletonList(new UpstreamService()));
+        
+        Assertions.assertThrows(IllegalArgumentException.class, () -> converter.route2Ingress(route));
+    }
+    
+    @Test
+    void route2IngressTestInvalidPathMatchTypeThrowsException() {
+        Route route = new Route();
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setPath(RoutePredicate.builder().matchType("invalid").matchValue("/test").build());
+        route.setServices(Collections.singletonList(new UpstreamService()));
+        
+        Assertions.assertThrows(IllegalArgumentException.class, () -> converter.route2Ingress(route));
+    }
+    
+    
+    @Test
+    void route2IngressTestCustomAnnotationsValidInputSuccess() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setCustomConfigs(Collections.singletonMap("custom.higress.cn", "value"));
+        
+        V1Ingress ingress = converter.route2Ingress(route);
+        
+        Assertions.assertNotNull(ingress);
+        Assertions.assertEquals("test-route", ingress.getMetadata().getName());
+        Assertions.assertEquals("value", ingress.getMetadata().getAnnotations().get("custom.higress.cn"));
+    }
+    
+    @Test
+    void route2IngressTestCustomAnnotationsThrowsValidationException() {
+        Route route = new Route();
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setCustomConfigs(Collections.singletonMap("higress.io/enable-proxy-next-upstream", "value"));
+        
+        Assertions.assertThrows(ValidationException.class, () -> converter.route2Ingress(route));
+    }
+    
+    @Test
+    void route2IngressTestCorsConfigSuccess() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setCors(new CorsConfig(true,                          // enabled (Boolean)
+                Collections.singletonList("https://higress.cn"),            // allowOrigins (List<String>)
+                Collections.singletonList("GET"),                           // allowMethods (List<String>)
+                Collections.singletonList("Content-Type"),                  // allowHeaders (List<String>)
+                Collections.singletonList("Content-Length"),                // exposeHeaders (List<String>)
+                3600,                                                       // maxAge (Integer)
+                true                                                        // allowCredentials (Boolean)
+        ));
+        
+        V1Ingress ingress = converter.route2Ingress(route);
+        
+        Assertions.assertNotNull(ingress);
+        Assertions.assertEquals("test-route", ingress.getMetadata().getName());
+        Assertions.assertTrue(Boolean.parseBoolean(
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ENABLED_KEY)));
+        Assertions.assertEquals("3600",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_MAX_AGE_KEY));
+        Assertions.assertTrue(Boolean.parseBoolean(
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_CREDENTIALS_KEY)));
+        Assertions.assertEquals("https://higress.cn",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_ORIGIN_KEY));
+        Assertions.assertEquals("Content-Type",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_HEADERS_KEY));
+        Assertions.assertEquals("GET",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_ALLOW_METHODS_KEY));
+        Assertions.assertEquals("Content-Length",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.CORS_EXPOSE_HEADERS_KEY));
+    }
+    
+    
+    @Test
+    void route2IngressTestMethodsSuccess() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setMethods(Collections.singletonList("GET"));
+        
+        V1Ingress ingress = converter.route2Ingress(route);
+        
+        Assertions.assertNotNull(ingress);
+        Assertions.assertEquals("test-route", ingress.getMetadata().getName());
+        Assertions.assertEquals("GET",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.METHOD_KEY));
+    }
+    
+    @Test
+    void route2IngressTestRewriteConfig() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setRewrite(new RewriteConfig(true, "/new-path", "new-host"));
+        
+        V1Ingress ingress = converter.route2Ingress(route);
+        
+        Assertions.assertNotNull(ingress);
+        Assertions.assertEquals("test-route", ingress.getMetadata().getName());
+        Assertions.assertTrue(Boolean.parseBoolean(
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.REWRITE_ENABLED_KEY)));
+        Assertions.assertEquals("/new-path",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.REWRITE_PATH_KEY));
+        Assertions.assertEquals("new-host",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.UPSTREAM_VHOST_KEY));
+    }
+    
+    @Test
+    void route2IngressTestProxyNextUpstreamConfig() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setDomains(Collections.singletonList("higress.cn"));
+        route.setProxyNextUpstream(new ProxyNextUpstreamConfig(true, 2, 10, new String[] {"$http_4xx"}));
+        
+        V1Ingress ingress = converter.route2Ingress(route);
+        
+        Assertions.assertNotNull(ingress);
+        Assertions.assertEquals("test-route", ingress.getMetadata().getName());
+        Assertions.assertTrue(Boolean.parseBoolean(ingress.getMetadata().getAnnotations()
+                .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_ENABLED_KEY)));
+        Assertions.assertEquals("2", ingress.getMetadata().getAnnotations()
+                .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_TRIES_KEY));
+        Assertions.assertEquals("10", ingress.getMetadata().getAnnotations()
+                .get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_TIMEOUT_KEY));
+        Assertions.assertEquals("$http_4xx",
+                ingress.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.PROXY_NEXT_UPSTREAM_KEY));
+    }
+    
+    
     @Test
     public void route2IngressTestPrefixPathSingleService() {
         Route route = buildBasicRoute();
@@ -354,23 +509,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", null, null, null);
         route.setServices(Collections.singletonList(service));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local");
-
+                "hello.default.svc.cluster.local");
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
     @Test
     public void route2IngressTestPrefixPathSingleServiceWithWeight() {
         Route route = buildBasicRoute();
@@ -381,23 +536,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", null, null, 15);
         route.setServices(Collections.singletonList(service));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local");
-
+                "hello.default.svc.cluster.local");
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
     @Test
     public void route2IngressTestPrefixPathSingleServiceWithPort() {
         Route route = buildBasicRoute();
@@ -408,23 +563,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, null, null);
         route.setServices(Collections.singletonList(service));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local:8080");
-
+                "hello.default.svc.cluster.local:8080");
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
     @Test
     public void route2IngressTestPrefixPathSingleServiceWithPortAndVersion() {
         Route route = buildBasicRoute();
@@ -435,23 +590,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, "v1", 100);
         route.setServices(Collections.singletonList(service));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local:8080");
-
+                "hello.default.svc.cluster.local:8080");
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
     @Test
     public void route2IngressTestPrefixPathMultipleServices() {
         Route route = buildBasicRoute();
@@ -464,24 +619,24 @@ public class KubernetesModelConverterTest {
         UpstreamService service2 = new UpstreamService("hello2.default.svc.cluster.local", 18080, "v1", 30);
         UpstreamService service3 = new UpstreamService("hello3.default.svc.cluster.local", null, "v2", 50);
         route.setServices(Arrays.asList(service1, service2, service3));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "20% hello1.default.svc.cluster.local:8080\n"
-                + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
-
+                "20% hello1.default.svc.cluster.local:8080\n"
+                        + "30% hello2.default.svc.cluster.local:18080 v1\n50% hello3.default.svc.cluster.local v2");
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
     @Test
     public void route2IngressTestExactPathSingleService() {
         Route route = buildBasicRoute();
@@ -492,23 +647,23 @@ public class KubernetesModelConverterTest {
         pathPredicate.setMatchValue("/");
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, "v1", 100);
         route.setServices(Collections.singletonList(service));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local:8080");
-
+                "hello.default.svc.cluster.local:8080");
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.EXACT);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
     @Test
     public void route2IngressTestRegularPathSingleService() {
         Route route = buildBasicRoute();
@@ -519,52 +674,1123 @@ public class KubernetesModelConverterTest {
         pathPredicate.setCaseSensitive(null);
         UpstreamService service = new UpstreamService("hello.default.svc.cluster.local", 8080, "v1", 100);
         route.setServices(Collections.singletonList(service));
-
+        
         V1Ingress ingress = converter.route2Ingress(route);
-
+        
         V1Ingress expectedIngress = buildBasicSupportedIngress();
-
+        
         V1ObjectMeta expectedMetadata = expectedIngress.getMetadata();
         expectedMetadata.setName(route.getName());
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.DESTINATION_KEY,
-            "hello.default.svc.cluster.local:8080");
+                "hello.default.svc.cluster.local:8080");
         KubernetesUtil.setAnnotation(expectedMetadata, KubernetesConstants.Annotation.USE_REGEX_KEY,
-            KubernetesConstants.Annotation.TRUE_VALUE);
-
+                KubernetesConstants.Annotation.TRUE_VALUE);
+        
         V1HTTPIngressPath expectedPath = expectedIngress.getSpec().getRules().get(0).getHttp().getPaths().get(0);
         expectedPath.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         expectedPath.setPath(pathPredicate.getMatchValue());
-
+        
         Assertions.assertEquals(expectedIngress, ingress);
     }
-
+    
+    @Test
+    void domain2ConfigMapTestNormalizeDomainName() {
+        V1ConfigMap domainConfigMap = new V1ConfigMap();
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName(converter.domainName2ConfigMapName("domain-name"));
+        metadata.setResourceVersion("0.0.1");
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(CommonKey.DOMAIN, "domain-name");
+        configMap.put(KubernetesConstants.K8S_CERT, "domain-cert");
+        configMap.put(KubernetesConstants.K8S_ENABLE_HTTPS, "domain-https");
+        domainConfigMap.metadata(metadata);
+        domainConfigMap.data(configMap);
+        Domain domain = new Domain();
+        domain.setName("domain-name");
+        domain.setVersion("0.0.1");
+        domain.setCertIdentifier("domain-cert");
+        domain.setEnableHttps("domain-https");
+        V1ConfigMap target = converter.domain2ConfigMap(domain);
+        Assertions.assertEquals(domainConfigMap, target);
+    }
+    
+    @Test
+    void configMap2DomainTestValidConfigMapShouldReturnDomain() {
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setResourceVersion("1");
+        
+        Map<String, String> data = new HashMap<>();
+        data.put(CommonKey.DOMAIN, "higress.cn");
+        data.put(KubernetesConstants.K8S_CERT, "cert-identifier");
+        data.put(KubernetesConstants.K8S_ENABLE_HTTPS, "true");
+        
+        V1ConfigMap configMap = new V1ConfigMap();
+        configMap.setMetadata(metadata);
+        configMap.setData(data);
+        
+        Domain domain = converter.configMap2Domain(configMap);
+        
+        Assertions.assertNotNull(domain);
+        Assertions.assertEquals("higress.cn", domain.getName());
+        Assertions.assertEquals("1", domain.getVersion());
+        Assertions.assertEquals("cert-identifier", domain.getCertIdentifier());
+        Assertions.assertEquals("true", domain.getEnableHttps());
+    }
+    
+    
+    @Test
+    void configMap2DomainTestNullMetadataShouldReturnDomainWithNullVersion() {
+        Map<String, String> data = new HashMap<>();
+        data.put(CommonKey.DOMAIN, "higress.cn");
+        
+        V1ConfigMap configMap = new V1ConfigMap();
+        configMap.setData(data);
+        
+        Domain domain = converter.configMap2Domain(configMap);
+        
+        Assertions.assertNotNull(domain);
+        Assertions.assertEquals("higress.cn", domain.getName());
+        Assertions.assertNull(domain.getVersion());
+        Assertions.assertNull(domain.getCertIdentifier());
+        Assertions.assertNull(domain.getEnableHttps());
+    }
+    
+    @Test
+    void configMap2DomainTestNullDataShouldThrowIllegalArgumentException() {
+        V1ConfigMap configMap = new V1ConfigMap();
+        configMap.setData(null);
+        
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            converter.configMap2Domain(configMap);
+        });
+        Assertions.assertEquals("The ConfigMap data is illegal", exception.getMessage());
+    }
+    
+    @Test
+    void configMap2DomainTestMissingFieldsShouldReturnDomainWithNullFields() {
+        Map<String, String> data = new HashMap<>();
+        data.put(CommonKey.DOMAIN, "higress.cn");
+        
+        V1ConfigMap configMap = new V1ConfigMap();
+        configMap.setData(data);
+        
+        Domain domain = converter.configMap2Domain(configMap);
+        
+        Assertions.assertNotNull(domain);
+        Assertions.assertEquals("higress.cn", domain.getName());
+        Assertions.assertNull(domain.getCertIdentifier());
+        Assertions.assertNull(domain.getEnableHttps());
+    }
+    
+    @Test
+    void tlsCertificate2SecretTestValidCertificateWithoutDomainsShouldNotSetLabels() {
+        TlsCertificate certificate = TlsCertificate.builder().cert("dummyCert").key("dummyKey").name("test-certificate")
+                .version("1").domains(Collections.emptyList()).build();
+        
+        V1Secret secret = converter.tlsCertificate2Secret(certificate);
+        
+        Assertions.assertNotNull(secret);
+        Assertions.assertEquals(KubernetesConstants.SECRET_TYPE_TLS, secret.getType());
+        Assertions.assertEquals("test-certificate", secret.getMetadata().getName());
+        Assertions.assertEquals("1", secret.getMetadata().getResourceVersion());
+        
+        Map<String, byte[]> data = secret.getData();
+        Assertions.assertNotNull(data);
+        Assertions.assertEquals(2, data.size());
+        Assertions.assertArrayEquals(TypeUtil.string2Bytes("dummyCert"),
+                data.get(KubernetesConstants.SECRET_TLS_CRT_FIELD));
+        Assertions.assertArrayEquals(TypeUtil.string2Bytes("dummyKey"),
+                data.get(KubernetesConstants.SECRET_TLS_KEY_FIELD));
+        
+        Map<String, String> labels = secret.getMetadata().getLabels();
+        Assertions.assertNull(labels);
+    }
+    
+    @Test
+    void secret2TlsCertificateTestValidSecretWithoutCertAndKeyShouldReturnTlsCertificateWithoutCertAndKey() {
+        V1Secret secret = new V1Secret();
+        secret.setMetadata(new V1ObjectMeta() {{
+            setName("test-secret");
+            setResourceVersion("123");
+        }});
+        
+        TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
+        
+        Assertions.assertNotNull(tlsCertificate);
+        Assertions.assertEquals("test-secret", tlsCertificate.getName());
+        Assertions.assertEquals("123", tlsCertificate.getVersion());
+        Assertions.assertNull(tlsCertificate.getCert());
+        Assertions.assertNull(tlsCertificate.getKey());
+        Assertions.assertNull(tlsCertificate.getValidityStart());
+        Assertions.assertNull(tlsCertificate.getValidityEnd());
+        Assertions.assertNull(tlsCertificate.getDomains());
+    }
+    
+    @Test
+    void secret2TlsCertificateTestNullMetadataShouldReturnTlsCertificateWithoutNameAndVersion() {
+        V1Secret secret = new V1Secret();
+        secret.setData(new HashMap<String, byte[]>() {{
+            put(KubernetesConstants.SECRET_TLS_CRT_FIELD, "certData".getBytes());
+            put(KubernetesConstants.SECRET_TLS_KEY_FIELD, "keyData".getBytes());
+        }});
+        
+        TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
+        
+        Assertions.assertNotNull(tlsCertificate);
+        Assertions.assertNull(tlsCertificate.getName());
+        Assertions.assertNull(tlsCertificate.getVersion());
+        Assertions.assertEquals("certData", tlsCertificate.getCert());
+        Assertions.assertEquals("keyData", tlsCertificate.getKey());
+    }
+    
+    @Test
+    void secret2TlsCertificateTestEmptyDataShouldReturnTlsCertificateWithoutCertAndKey() {
+        V1Secret secret = new V1Secret();
+        secret.setMetadata(new V1ObjectMeta() {{
+            setName("test-secret");
+            setResourceVersion("123");
+        }});
+        secret.setData(Collections.emptyMap());
+        
+        TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
+        
+        Assertions.assertNotNull(tlsCertificate);
+        Assertions.assertEquals("test-secret", tlsCertificate.getName());
+        Assertions.assertEquals("123", tlsCertificate.getVersion());
+        Assertions.assertNull(tlsCertificate.getCert());
+        Assertions.assertNull(tlsCertificate.getKey());
+        Assertions.assertNull(tlsCertificate.getValidityStart());
+        Assertions.assertNull(tlsCertificate.getValidityEnd());
+        Assertions.assertNull(tlsCertificate.getDomains());
+    }
+    
+    
+    @Test
+    void wasmPluginFromCrTestWithValidInputShouldReturnWasmPlugin() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        cr.setMetadata(createMetadata());
+        cr.setSpec(createSpec());
+        
+        WasmPlugin plugin = converter.wasmPluginFromCr(cr);
+        
+        Assertions.assertNotNull(plugin);
+        Assertions.assertEquals("test-plugin", plugin.getName());
+        Assertions.assertEquals("v1", plugin.getPluginVersion());
+        Assertions.assertEquals("test-category", plugin.getCategory());
+        Assertions.assertEquals(Boolean.TRUE, plugin.getBuiltIn());
+        Assertions.assertEquals("Test Plugin", plugin.getTitle());
+        Assertions.assertEquals("A test plugin", plugin.getDescription());
+        Assertions.assertEquals("icon.png", plugin.getIcon());
+        Assertions.assertEquals("test/image", plugin.getImageRepository());
+        Assertions.assertEquals("v1", plugin.getImageVersion());
+        Assertions.assertEquals(PluginPhase.UNSPECIFIED.getName(), plugin.getPhase());
+        Assertions.assertEquals(10, plugin.getPriority());
+    }
+    
+    @Test
+    void wasmPluginFromCrTestWithMissingFieldsShouldHandleGracefully() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        cr.setMetadata(createMetadata());
+        cr.setSpec(createSpec());
+        
+        cr.getMetadata().getLabels().remove(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY);
+        cr.getMetadata().getLabels().remove(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY);
+        cr.getSpec().setUrl("image");
+        
+        WasmPlugin plugin = converter.wasmPluginFromCr(cr);
+        
+        Assertions.assertNotNull(plugin);
+        Assertions.assertEquals(null, plugin.getName());
+        Assertions.assertEquals(null, plugin.getPluginVersion());
+        Assertions.assertEquals("test-category", plugin.getCategory());
+        Assertions.assertEquals(Boolean.TRUE, plugin.getBuiltIn());
+        Assertions.assertEquals("Test Plugin", plugin.getTitle());
+        Assertions.assertEquals("A test plugin", plugin.getDescription());
+        Assertions.assertEquals("icon.png", plugin.getIcon());
+        Assertions.assertEquals("image", plugin.getImageRepository());
+        Assertions.assertEquals(null, plugin.getImageVersion());
+        Assertions.assertEquals(PluginPhase.UNSPECIFIED.getName(), plugin.getPhase());
+        Assertions.assertEquals(10, plugin.getPriority());
+    }
+    
+    @Test
+    void wasmPluginToCrTestValidInput_ShouldConvertCorrectly() {
+        WasmPlugin plugin = WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1")
+                .category("test-category").title("Test Plugin").description("A test plugin").icon("test-icon")
+                .builtIn(true).imageRepository("test-repository").imageVersion("test-version").phase("test-phase")
+                .priority(10).build();
+        
+        V1alpha1WasmPlugin cr = converter.wasmPluginToCr(plugin);
+        
+        Assertions.assertNotNull(cr);
+        Assertions.assertNotNull(cr.getMetadata());
+        Assertions.assertEquals("test-plugin-1.0.0", cr.getMetadata().getName());
+        Assertions.assertEquals("1", cr.getMetadata().getResourceVersion());
+        
+        Assertions.assertEquals("test-plugin",
+                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY));
+        Assertions.assertEquals("1.0.0",
+                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY));
+        Assertions.assertEquals("test-category",
+                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_CATEGORY_KEY));
+        Assertions.assertEquals("true",
+                cr.getMetadata().getLabels().get(KubernetesConstants.Label.WASM_PLUGIN_BUILT_IN_KEY));
+        
+        Assertions.assertEquals("Test Plugin",
+                cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_TITLE_KEY));
+        Assertions.assertEquals("A test plugin",
+                cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_DESCRIPTION_KEY));
+        Assertions.assertEquals("test-icon",
+                cr.getMetadata().getAnnotations().get(KubernetesConstants.Annotation.WASM_PLUGIN_ICON_KEY));
+        
+        Assertions.assertNotNull(cr.getSpec());
+        Assertions.assertEquals("test-phase", cr.getSpec().getPhase());
+        Assertions.assertEquals(10, cr.getSpec().getPriority().intValue());
+        Assertions.assertEquals("oci://test-repository:test-version", cr.getSpec().getUrl());
+    }
+    
+    @Test
+    void wasmPluginToCrTestNullImageRepositoryShouldHandleCorrectly() {
+        WasmPlugin plugin = WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1")
+                .imageRepository(null).imageVersion("test-version").build();
+        
+        V1alpha1WasmPlugin cr = converter.wasmPluginToCr(plugin);
+        
+        Assertions.assertNotNull(cr);
+        Assertions.assertNotNull(cr.getSpec());
+        Assertions.assertEquals(null, cr.getSpec().getUrl());
+    }
+    
+    @Test
+    void wasmPluginToCrTestEmptyImageVersionShouldHandleCorrectly() {
+        WasmPlugin plugin = WasmPlugin.builder().name("test-plugin").pluginVersion("1.0.0").version("1")
+                .imageRepository("test-repository").imageVersion("").build();
+        
+        V1alpha1WasmPlugin cr = converter.wasmPluginToCr(plugin);
+        
+        Assertions.assertNotNull(cr);
+        Assertions.assertNotNull(cr.getSpec());
+        Assertions.assertEquals("oci://test-repository", cr.getSpec().getUrl());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestSourceSpecNullDestinationSpecUnchanged() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        srcPlugin.setSpec(null);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
+        dstSpec.setDefaultConfig(new HashMap<>());
+        dstPlugin.setSpec(dstSpec);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestDestinationSpecNullSetNewSpec() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
+        srcSpec.setDefaultConfig(new HashMap<>());
+        srcPlugin.setSpec(srcSpec);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        dstPlugin.setSpec(null);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestMatchRulesMergedAndSorted() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
+        srcSpec.setMatchRules(new ArrayList<>());
+        srcSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
+        srcSpec.getMatchRules().add(MatchRule.forDomain("test.higress.cn"));
+        srcPlugin.setSpec(srcSpec);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
+        dstSpec.setMatchRules(new ArrayList<>());
+        dstSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
+        dstSpec.getMatchRules().add(MatchRule.forDomain("test.higress.cn"));
+        dstPlugin.setSpec(dstSpec);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        List<MatchRule> expected = new ArrayList<>();
+        expected.add(MatchRule.forDomain("higress.cn"));
+        expected.add(MatchRule.forDomain("test.higress.cn"));
+        
+        Assertions.assertEquals(expected, dstPlugin.getSpec().getMatchRules());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestEmptyMatchRulesNoChange() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
+        srcSpec.setMatchRules(new ArrayList<>());
+        srcPlugin.setSpec(srcSpec);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
+        dstSpec.setMatchRules(new ArrayList<>());
+        dstSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
+        dstPlugin.setSpec(dstSpec);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        List<MatchRule> expected = new ArrayList<>();
+        expected.add(MatchRule.forDomain("higress.cn"));
+        
+        Assertions.assertEquals(expected, dstPlugin.getSpec().getMatchRules());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestSrcSpecNullNoChangeToDstPlugin() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        srcPlugin.setSpec(null);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
+        dstSpec.setDefaultConfig(new HashMap<>());
+        dstPlugin.setSpec(dstSpec);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestDstSpecNullSetNewSpec() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
+        srcSpec.setDefaultConfig(new HashMap<>());
+        srcPlugin.setSpec(srcSpec);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        dstPlugin.setSpec(null);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        Assertions.assertEquals(new HashMap<>(), dstPlugin.getSpec().getDefaultConfig());
+    }
+    
+    @Test
+    void mergeWasmPluginSpecTestMatchRulesMergedAndSortedWithExistingRules() {
+        V1alpha1WasmPlugin srcPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec srcSpec = new V1alpha1WasmPluginSpec();
+        srcSpec.setMatchRules(new ArrayList<>());
+        srcSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
+        srcSpec.getMatchRules().add(MatchRule.forDomain("test.higress.cn"));
+        srcPlugin.setSpec(srcSpec);
+        
+        V1alpha1WasmPlugin dstPlugin = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec dstSpec = new V1alpha1WasmPluginSpec();
+        dstSpec.setMatchRules(new ArrayList<>());
+        dstSpec.getMatchRules().add(MatchRule.forDomain("higress.cn"));
+        dstPlugin.setSpec(dstSpec);
+        
+        converter.mergeWasmPluginSpec(srcPlugin, dstPlugin);
+        
+        List<MatchRule> expected = new ArrayList<>();
+        expected.add(MatchRule.forDomain("higress.cn"));
+        expected.add(MatchRule.forDomain("test.higress.cn"));
+        
+        Assertions.assertEquals(expected, dstPlugin.getSpec().getMatchRules());
+    }
+    
+    @Test
+    void setWasmPluginInstanceToCrTestGlobalScopeConfigured() {
+        V1alpha1WasmPlugin plugin = new V1alpha1WasmPlugin();
+        plugin.setMetadata(createMetadata("global", "test-plugin", "v1"));
+        plugin.setSpec(createSpecWithGlobalConfig());
+        
+        WasmPluginInstance instance = converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.GLOBAL,
+                null);
+        Assertions.assertNotNull(instance);
+        Assertions.assertEquals("v1", instance.getPluginVersion());
+        Assertions.assertEquals(WasmPluginInstanceScope.GLOBAL, instance.getScope());
+        Assertions.assertTrue(instance.getEnabled());
+        Assertions.assertEquals(1, instance.getConfigurations().size());
+        Assertions.assertEquals("value", instance.getConfigurations().get("key"));
+    }
+    
+    @Test
+    void setWasmPluginInstanceToCrTestDomainScopeNotConfigured() {
+        V1alpha1WasmPlugin plugin = new V1alpha1WasmPlugin();
+        plugin.setMetadata(createMetadata("domain", "test-plugin", "v1"));
+        plugin.setSpec(createSpecWithDomainConfig("higress.cn"));
+        
+        WasmPluginInstance instance = converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.DOMAIN,
+                "higress.cn");
+        Assertions.assertNotNull(instance);
+        Assertions.assertEquals("v1", instance.getPluginVersion());
+        Assertions.assertEquals(WasmPluginInstanceScope.DOMAIN, instance.getScope());
+        Assertions.assertTrue(instance.getEnabled());
+        Assertions.assertEquals(1, instance.getConfigurations().size());
+        Assertions.assertEquals("value", instance.getConfigurations().get("key"));
+        
+        WasmPluginInstance instanceNotConfigured = converter.getWasmPluginInstanceFromCr(plugin,
+                WasmPluginInstanceScope.DOMAIN, "nonexistent.com");
+        Assertions.assertNull(instanceNotConfigured);
+    }
+    
+    
+    @Test
+    void setWasmPluginInstanceToCrTestRouteScopeConfigured() {
+        V1alpha1WasmPlugin plugin = new V1alpha1WasmPlugin();
+        plugin.setMetadata(createMetadata("route", "test-plugin", "v1"));
+        plugin.setSpec(createSpecWithRouteConfig("test-route"));
+        
+        WasmPluginInstance instance = converter.getWasmPluginInstanceFromCr(plugin, WasmPluginInstanceScope.ROUTE,
+                "test-route");
+        Assertions.assertNotNull(instance);
+        Assertions.assertEquals("v1", instance.getPluginVersion());
+        Assertions.assertEquals(WasmPluginInstanceScope.ROUTE, instance.getScope());
+        Assertions.assertTrue(instance.getEnabled());
+        Assertions.assertEquals(1, instance.getConfigurations().size());
+        Assertions.assertEquals("value", instance.getConfigurations().get("key"));
+    }
+    
+    @Test
+    void setWasmPluginInstanceToCrTestGlobalScopeShouldSetDefaultConfig() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.GLOBAL).target(null)
+                .enabled(true).configurations(Map.of("key", "value")).build();
+        
+        converter.setWasmPluginInstanceToCr(cr, instance);
+        
+        V1alpha1WasmPluginSpec spec = cr.getSpec();
+        Assertions.assertNotNull(spec);
+        Assertions.assertEquals(Map.of("key", "value"), spec.getDefaultConfig());
+        Assertions.assertFalse(spec.getDefaultConfigDisable());
+    }
+    
+    @Test
+    void setWasmPluginInstanceToCrTestDomainScopeShouldAddOrUpdateDomainRule() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.DOMAIN)
+                .target("higress.cn").enabled(true).configurations(Map.of("key", "value")).build();
+        
+        converter.setWasmPluginInstanceToCr(cr, instance);
+        
+        V1alpha1WasmPluginSpec spec = cr.getSpec();
+        Assertions.assertNotNull(spec);
+        List<MatchRule> matchRules = spec.getMatchRules();
+        Assertions.assertNotNull(matchRules);
+        Assertions.assertEquals(1, matchRules.size());
+        MatchRule domainRule = matchRules.get(0);
+        Assertions.assertTrue(domainRule.getDomain().contains("higress.cn"));
+        Assertions.assertEquals(Map.of("key", "value"), domainRule.getConfig());
+        Assertions.assertFalse(domainRule.getConfigDisable());
+    }
+    
+    @Test
+    void setWasmPluginInstanceToCrTestDomainScopeExistingRuleShouldUpdateExistingDomainRule() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        spec.setMatchRules(List.of(new MatchRule(false, Map.of("key", "original"), List.of("higress.cn"), List.of())));
+        cr.setSpec(spec);
+        
+        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.DOMAIN)
+                .target("higress.cn").enabled(true).configurations(Map.of("key", "updated")).build();
+        
+        converter.setWasmPluginInstanceToCr(cr, instance);
+        
+        List<MatchRule> matchRules = cr.getSpec().getMatchRules();
+        Assertions.assertNotNull(matchRules);
+        Assertions.assertEquals(1, matchRules.size());
+        MatchRule domainRule = matchRules.get(0);
+        Assertions.assertTrue(domainRule.getDomain().contains("higress.cn"));
+        Assertions.assertEquals(Map.of("key", "updated"), domainRule.getConfig());
+        Assertions.assertFalse(domainRule.getConfigDisable());
+    }
+    
+    
+    @Test
+    void setWasmPluginInstanceToCrTestRouteScopeShouldAddOrUpdateRouteRule() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        WasmPluginInstance instance = WasmPluginInstance.builder().scope(WasmPluginInstanceScope.ROUTE)
+                .target("route-1").enabled(true).configurations(Map.of("key", "value")).build();
+        
+        converter.setWasmPluginInstanceToCr(cr, instance);
+        
+        V1alpha1WasmPluginSpec spec = cr.getSpec();
+        Assertions.assertNotNull(spec);
+        List<MatchRule> matchRules = spec.getMatchRules();
+        Assertions.assertNotNull(matchRules);
+        Assertions.assertEquals(1, matchRules.size());
+        MatchRule routeRule = matchRules.get(0);
+        Assertions.assertTrue(routeRule.getIngress().contains("route-1"));
+        Assertions.assertEquals(Map.of("key", "value"), routeRule.getConfig());
+        Assertions.assertFalse(routeRule.getConfigDisable());
+    }
+    
+    @Test
+    void removeWasmPluginInstanceFromCrTestGlobalScopeTargetNullShouldRemoveDefaultConfig() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        Map<String, Object> config = new HashMap<>();
+        config.put("key", "value");
+        spec.setDefaultConfig(config);
+        cr.setSpec(spec);
+        boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.GLOBAL, null);
+        
+        Assertions.assertTrue(result);
+        Assertions.assertNull(cr.getSpec().getDefaultConfig());
+    }
+    
+    @Test
+    void removeWasmPluginInstanceFromCrTestDomainScopeValidTargetShouldRemoveDomain() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        List<MatchRule> matchRules = new ArrayList<>();
+        MatchRule rule = new MatchRule();
+        rule.setDomain(new ArrayList<String>() {{
+            add("higress.cn");
+        }});
+        matchRules.add(rule);
+        spec.setMatchRules(matchRules);
+        cr.setSpec(spec);
+        
+        boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.DOMAIN, "higress.cn");
+        
+        Assertions.assertTrue(result);
+        Assertions.assertTrue(cr.getSpec().getMatchRules().isEmpty());
+    }
+    
+    @Test
+    void removeWasmPluginInstanceFromCrTestDomainScopeEmptyTargetShouldNotChange() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        List<MatchRule> matchRules = new ArrayList<>();
+        MatchRule rule = new MatchRule();
+        rule.setDomain(new ArrayList<String>() {{
+            add("higress.cn");
+        }});
+        matchRules.add(rule);
+        spec.setMatchRules(matchRules);
+        cr.setSpec(spec);
+        
+        boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.DOMAIN, "");
+        
+        Assertions.assertFalse(result);
+        Assertions.assertEquals(1, cr.getSpec().getMatchRules().size());
+    }
+    
+    
+    @Test
+    void removeWasmPluginInstanceFromCrTestRouteScopeValidTargetShouldRemoveIngress() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        List<MatchRule> matchRules = new ArrayList<>();
+        MatchRule rule = new MatchRule();
+        rule.setIngress(new ArrayList<String>() {{
+            add("test-route");
+        }});
+        matchRules.add(rule);
+        spec.setMatchRules(matchRules);
+        cr.setSpec(spec);
+        
+        boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.ROUTE, "test-route");
+        
+        Assertions.assertTrue(result);
+        Assertions.assertTrue(cr.getSpec().getMatchRules().isEmpty());
+    }
+    
+    @Test
+    void removeWasmPluginInstanceFromCrTestRouteScopeEmptyTargetShouldNotChange() {
+        V1alpha1WasmPlugin cr = new V1alpha1WasmPlugin();
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        List<MatchRule> matchRules = new ArrayList<>();
+        MatchRule rule = new MatchRule();
+        rule.setIngress(new ArrayList<String>() {{
+            add("test-route");
+        }});
+        matchRules.add(rule);
+        spec.setMatchRules(matchRules);
+        cr.setSpec(spec);
+        
+        boolean result = converter.removeWasmPluginInstanceFromCr(cr, WasmPluginInstanceScope.ROUTE, "");
+        
+        Assertions.assertFalse(result);
+        Assertions.assertEquals(1, cr.getSpec().getMatchRules().size());
+    }
+    
+    
+    @Test
+    public void v1RegistryConfig2ServiceSourceTestNacosType() {
+        V1RegistryConfig v1RegistryConfig = new V1RegistryConfig();
+        v1RegistryConfig.setType(V1McpBridge.REGISTRY_TYPE_NACOS);
+        v1RegistryConfig.setDomain("testDomain");
+        v1RegistryConfig.setPort(80);
+        v1RegistryConfig.setName("testName");
+        v1RegistryConfig.setNacosNamespaceId("testNamespaceId");
+        v1RegistryConfig.setNacosGroups(List.of("testGroup1", "testGroup2"));
+        
+        ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(v1RegistryConfig);
+        
+        Assertions.assertNotNull(serviceSource);
+        Assertions.assertEquals(V1McpBridge.REGISTRY_TYPE_NACOS, serviceSource.getType());
+        Assertions.assertEquals("testDomain", serviceSource.getDomain());
+        Assertions.assertEquals(80, serviceSource.getPort());
+        Assertions.assertEquals("testName", serviceSource.getName());
+        Map<String, Object> properties = serviceSource.getProperties();
+        Assertions.assertNotNull(properties);
+        Assertions.assertEquals("testNamespaceId", properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_NAMESPACE_ID));
+        Assertions.assertEquals(List.of("testGroup1", "testGroup2"),
+                properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_GROUPS));
+    }
+    
+    @Test
+    public void v1RegistryConfig2ServiceSourceTestZkType() {
+        V1RegistryConfig v1RegistryConfig = new V1RegistryConfig();
+        v1RegistryConfig.setType(V1McpBridge.REGISTRY_TYPE_ZK);
+        v1RegistryConfig.setDomain("testDomain");
+        v1RegistryConfig.setPort(80);
+        v1RegistryConfig.setName("testName");
+        v1RegistryConfig.setZkServicesPath(List.of("testPath1", "testPath2"));
+        
+        ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(v1RegistryConfig);
+        
+        Assertions.assertNotNull(serviceSource);
+        Assertions.assertEquals(V1McpBridge.REGISTRY_TYPE_ZK, serviceSource.getType());
+        Assertions.assertEquals("testDomain", serviceSource.getDomain());
+        Assertions.assertEquals(80, serviceSource.getPort());
+        Assertions.assertEquals("testName", serviceSource.getName());
+        Map<String, Object> properties = serviceSource.getProperties();
+        Assertions.assertNotNull(properties);
+        Assertions.assertEquals(List.of("testPath1", "testPath2"),
+                properties.get(V1McpBridge.REGISTRY_TYPE_ZK_SERVICES_PATH));
+    }
+    
+    @Test
+    public void v1RegistryConfig2ServiceSourceTestConsulType() {
+        V1RegistryConfig v1RegistryConfig = new V1RegistryConfig();
+        v1RegistryConfig.setType(V1McpBridge.REGISTRY_TYPE_CONSUL);
+        v1RegistryConfig.setDomain("testDomain");
+        v1RegistryConfig.setPort(80);
+        v1RegistryConfig.setName("testName");
+        v1RegistryConfig.setConsulDataCenter("testDataCenter");
+        v1RegistryConfig.setConsulServiceTag("testServiceTag");
+        v1RegistryConfig.setConsulRefreshInterval(30);
+        
+        ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(v1RegistryConfig);
+        
+        Assertions.assertNotNull(serviceSource);
+        Assertions.assertEquals(V1McpBridge.REGISTRY_TYPE_CONSUL, serviceSource.getType());
+        Assertions.assertEquals("testDomain", serviceSource.getDomain());
+        Assertions.assertEquals(80, serviceSource.getPort());
+        Assertions.assertEquals("testName", serviceSource.getName());
+        Map<String, Object> properties = serviceSource.getProperties();
+        Assertions.assertNotNull(properties);
+        Assertions.assertEquals("testDataCenter", properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_DATA_CENTER));
+        Assertions.assertEquals("testServiceTag", properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_SERVICE_TAG));
+        Assertions.assertEquals(30, properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_REFRESH_INTERVAL));
+    }
+    
+    @Test
+    public void v1RegistryConfig2ServiceSourceTestNullInput() {
+        ServiceSource serviceSource = converter.v1RegistryConfig2ServiceSource(null);
+        
+        Assertions.assertNotNull(serviceSource);
+        Assertions.assertEquals(new ServiceSource(), serviceSource);
+    }
+    
+    @Test
+    public void generateAuthSecretNameTestValidServiceSourceName() {
+        String serviceSourceName = "test-service-source";
+        String expectedPattern = serviceSourceName + "-auth-\\w{5}";
+        
+        String authSecretName = converter.generateAuthSecretName(serviceSourceName);
+        
+        Assertions.assertTrue(authSecretName.matches(expectedPattern),
+                "Auth secret name should match the expected pattern");
+    }
+    
+    @Test
+    public void generateAuthSecretNameTestEmptyServiceSourceName() {
+        String serviceSourceName = "";
+        String expectedPattern = serviceSourceName + "-auth-\\w{5}";
+        
+        String authSecretName = converter.generateAuthSecretName(serviceSourceName);
+        
+        Assertions.assertTrue(authSecretName.matches(expectedPattern),
+                "Auth secret name should match the expected pattern");
+    }
+    
+    @Test
+    public void generateAuthSecretNameTestNullServiceSourceName() {
+        String serviceSourceName = null;
+        String expectedPattern = "null-auth-\\w{5}";
+        
+        String authSecretName = converter.generateAuthSecretName(serviceSourceName);
+        
+        Assertions.assertTrue(authSecretName.matches(expectedPattern),
+                "Auth secret name should match the expected pattern");
+    }
+    
+    @Test
+    void initV1McpBridgeTestShouldSetDefaultValues() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        
+        converter.initV1McpBridge(v1McpBridge);
+        
+        Assertions.assertNotNull(v1McpBridge.getMetadata(), "Metadata should not be null");
+        Assertions.assertEquals(V1McpBridge.DEFAULT_NAME, v1McpBridge.getMetadata().getName(),
+                "Metadata name should be set to default");
+        Assertions.assertNotNull(v1McpBridge.getSpec(), "Spec should not be null");
+        Assertions.assertNotNull(v1McpBridge.getSpec().getRegistries(), "Spec registries should not be null");
+        Assertions.assertEquals(0, v1McpBridge.getSpec().getRegistries().size(),
+                "Spec registries should be initialized as empty list");
+    }
+    
+    @Test
+    public void addV1McpBridgeRegistryTestRegistryDoesNotExistShouldAddAndReturnRegistryConfig() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        List<V1RegistryConfig> registries = new ArrayList<>();
+        spec.setRegistries(registries);
+        
+        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
+                new HashMap<>(), null);
+        
+        V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(serviceSource.getName(), result.getName());
+        Assertions.assertEquals(serviceSource.getDomain(), result.getDomain());
+        Assertions.assertEquals(serviceSource.getType(), result.getType());
+        Assertions.assertEquals(serviceSource.getPort(), result.getPort());
+        Assertions.assertTrue(registries.contains(result));
+    }
+    
+    @Test
+    public void addV1McpBridgeRegistryTestRegistryExistsShouldUpdateAndReturnRegistryConfig() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        List<V1RegistryConfig> registries = new ArrayList<>();
+        V1RegistryConfig existingRegistry = new V1RegistryConfig();
+        existingRegistry.setName("testService");
+        registries.add(existingRegistry);
+        spec.setRegistries(registries);
+        
+        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
+                new HashMap<>(), null);
+        
+        V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(serviceSource.getName(), result.getName());
+        Assertions.assertEquals(serviceSource.getDomain(), result.getDomain());
+        Assertions.assertEquals(serviceSource.getType(), result.getType());
+        Assertions.assertEquals(serviceSource.getPort(), result.getPort());
+        Assertions.assertTrue(registries.contains(result));
+    }
+    
+    @Test
+    public void addV1McpBridgeRegistryTestNullServiceSourceShouldReturnNull() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        List<V1RegistryConfig> registries = new ArrayList<>();
+        spec.setRegistries(registries);
+        
+        V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, null);
+        
+        Assertions.assertNull(result);
+    }
+    
+    @Test
+    public void addV1McpBridgeRegistryTestNullSpecShouldCreateSpecAndAddRegistry() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        
+        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
+                new HashMap<>(), null);
+        
+        V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertNotNull(v1McpBridge.getSpec());
+        Assertions.assertNotNull(v1McpBridge.getSpec().getRegistries());
+        Assertions.assertTrue(v1McpBridge.getSpec().getRegistries().contains(result));
+    }
+    
+    @Test
+    public void addV1McpBridgeRegistryTestNullRegistriesShouldCreateRegistriesAndAddRegistry() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        ServiceSource serviceSource = new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080,
+                new HashMap<>(), null);
+        
+        V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertNotNull(v1McpBridge.getSpec().getRegistries());
+        Assertions.assertTrue(v1McpBridge.getSpec().getRegistries().contains(result));
+    }
+    
+    
+    @Test
+    public void removeV1McpBridgeRegistryTestRegistryExistsShouldRemoveAndReturnRegistryConfig() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        List<V1RegistryConfig> registries = new ArrayList<>();
+        V1RegistryConfig registryConfig = new V1RegistryConfig();
+        registryConfig.setName("testRegistry");
+        registries.add(registryConfig);
+        spec.setRegistries(registries);
+        
+        V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "testRegistry");
+        
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("testRegistry", result.getName());
+        Assertions.assertTrue(spec.getRegistries().isEmpty());
+    }
+    
+    @Test
+    public void removeV1McpBridgeRegistryTestRegistryDoesNotExistShouldReturnNull() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        List<V1RegistryConfig> registries = new ArrayList<>();
+        V1RegistryConfig registryConfig = new V1RegistryConfig();
+        registryConfig.setName("existingRegistry");
+        registries.add(registryConfig);
+        spec.setRegistries(registries);
+        
+        V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "nonExistingRegistry");
+        
+        Assertions.assertNull(result);
+        Assertions.assertEquals(1, spec.getRegistries().size());
+    }
+    
+    @Test
+    public void removeV1McpBridgeRegistryTestNoRegistriesShouldReturnNull() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        V1McpBridgeSpec spec = new V1McpBridgeSpec();
+        v1McpBridge.setSpec(spec);
+        
+        spec.setRegistries(new ArrayList<>());
+        
+        V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "testRegistry");
+        
+        Assertions.assertNull(result);
+    }
+    
+    
+    @Test
+    public void removeV1McpBridgeRegistryTestNullSpecShouldReturnNull() {
+        V1McpBridge v1McpBridge = new V1McpBridge();
+        
+        v1McpBridge.setSpec(null);
+        
+        V1RegistryConfig result = converter.removeV1McpBridgeRegistry(v1McpBridge, "testRegistry");
+        
+        Assertions.assertNull(result);
+    }
+    
+    
+    @Test
+    void ingress2RouteTestValidIngressWithSingleRule() {
+        V1IngressBackend backend = new V1IngressBackend();
+        V1IngressSpec spec = new V1IngressSpec();
+        spec.setDefaultBackend(backend);
+        
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName("test-ingress");
+        metadata.setResourceVersion("1");
+        
+        V1Ingress ingress = new V1Ingress();
+        ingress.setMetadata(metadata);
+        ingress.setSpec(spec);
+        
+        Route route = converter.ingress2Route(ingress);
+        
+        Assertions.assertNotNull(route);
+        Assertions.assertEquals("test-ingress", route.getName());
+        Assertions.assertEquals("1", route.getVersion());
+    }
+    
+    @Test
+    void ingress2RouteTestValidIngressWithMultipleRules() {
+        V1IngressBackend backend = new V1IngressBackend();
+        V1IngressSpec spec = new V1IngressSpec();
+        spec.setDefaultBackend(backend);
+        
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName("test-ingress");
+        metadata.setResourceVersion("1");
+        
+        V1IngressRule rule1 = new V1IngressRule();
+        rule1.setHost("example.com");
+        
+        V1IngressRule rule2 = new V1IngressRule();
+        rule2.setHost("test.example.com");
+        
+        spec.setRules(Arrays.asList(rule1, rule2));
+        
+        V1Ingress ingress = new V1Ingress();
+        ingress.setMetadata(metadata);
+        ingress.setSpec(spec);
+        
+        Route route = converter.ingress2Route(ingress);
+        
+        Assertions.assertNotNull(route);
+        Assertions.assertEquals("test-ingress", route.getName());
+        Assertions.assertEquals("1", route.getVersion());
+        Assertions.assertEquals(null, route.getDomains());
+    }
+    
+    @Test
+    void ingress2RouteTestValidIngressWithTLS() {
+        V1IngressBackend backend = new V1IngressBackend();
+        V1IngressSpec spec = new V1IngressSpec();
+        spec.setDefaultBackend(backend);
+        
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName("test-ingress");
+        metadata.setResourceVersion("1");
+        
+        V1IngressTLS tls = new V1IngressTLS();
+        tls.setHosts(Arrays.asList("higress.cn", "test.higress.cn"));
+        
+        spec.setTls(Arrays.asList(tls));
+        
+        V1Ingress ingress = new V1Ingress();
+        ingress.setMetadata(metadata);
+        ingress.setSpec(spec);
+        
+        Route route = converter.ingress2Route(ingress);
+        
+        Assertions.assertNotNull(route);
+        Assertions.assertEquals("test-ingress", route.getName());
+        Assertions.assertEquals("1", route.getVersion());
+        Assertions.assertEquals(null, route.getDomains());
+    }
+    
+    @Test
+    void ingress2RouteTestValidIngressWithAnnotationsReturnsValidRoute() {
+        V1IngressBackend backend = new V1IngressBackend();
+        V1IngressSpec spec = new V1IngressSpec();
+        spec.setDefaultBackend(backend);
+        
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName("test-ingress");
+        metadata.setResourceVersion("1");
+        metadata.setAnnotations(new HashMap<String, String>() {{
+            put("higress.cn", "annotation-value");
+        }});
+        
+        V1Ingress ingress = new V1Ingress();
+        ingress.setMetadata(metadata);
+        ingress.setSpec(spec);
+        
+        Route route = converter.ingress2Route(ingress);
+        
+        Assertions.assertNotNull(route);
+        Assertions.assertEquals("test-ingress", route.getName());
+        Assertions.assertEquals("1", route.getVersion());
+        Assertions.assertNotNull(route.getCustomConfigs());
+        Assertions.assertEquals("annotation-value", route.getCustomConfigs().get("higress.cn"));
+    }
+    
+    @Test
+    void ingress2RouteTestNullMetadataReturnsRouteWithDefaults() {
+        V1IngressBackend backend = new V1IngressBackend();
+        V1IngressSpec spec = new V1IngressSpec();
+        spec.setDefaultBackend(backend);
+        
+        V1Ingress ingress = new V1Ingress();
+        ingress.setSpec(spec);
+        
+        Route route = converter.ingress2Route(ingress);
+        
+        Assertions.assertNotNull(route);
+        Assertions.assertEquals(null, route.getName());
+        Assertions.assertEquals(null, route.getVersion());
+    }
+    
+    @Test
+    void ingress2RouteTestNullSpecReturnsRouteWithDefaults() {
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName("test-ingress");
+        metadata.setResourceVersion("1");
+        
+        V1Ingress ingress = new V1Ingress();
+        ingress.setMetadata(metadata);
+        
+        Route route = converter.ingress2Route(ingress);
+        
+        Assertions.assertNotNull(route);
+        Assertions.assertEquals("test-ingress", route.getName());
+        Assertions.assertEquals("1", route.getVersion());
+        Assertions.assertNull(route.getDomains());
+    }
+    
+    
+    @Test
+    public void domainName2ConfigMapNameTestNormalDomainNameConfigMapNameCreated() {
+        String domainName = "www.higress.cn";
+        String expectedConfigMapName = "domain-www.higress.cn";
+        String actualConfigMapName = converter.domainName2ConfigMapName(domainName);
+        
+        Assertions.assertEquals(expectedConfigMapName, actualConfigMapName,
+                "ConfigMap name should be 'domain-www.higress.cn'");
+    }
+    
+    @Test
+    public void domainName2ConfigMapNameTestWildcardDomainNameConfigMapNameCreated() {
+        String domainName = "*.higress.cn";
+        String expectedConfigMapName = "domain-wildcard.higress.cn";
+        String actualConfigMapName = converter.domainName2ConfigMapName(domainName);
+        
+        Assertions.assertEquals(expectedConfigMapName, actualConfigMapName,
+                "ConfigMap name should be 'domain-wildcard.higress.cn'");
+    }
+    
+    
     private V1Ingress buildBasicSupportedIngress() {
         V1Ingress ingress = new V1Ingress();
-
+        
         V1ObjectMeta metadata = new V1ObjectMeta();
         ingress.setMetadata(metadata);
-
+        
         V1IngressSpec spec = new V1IngressSpec();
         ingress.setSpec(spec);
-
+        
         V1IngressRule rule = new V1IngressRule();
-
+        
         List<V1IngressRule> rules = new ArrayList<>();
         rules.add(rule);
         spec.setRules(rules);
-
+        
         V1HTTPIngressRuleValue httpRule = new V1HTTPIngressRuleValue();
         rule.setHttp(httpRule);
-
+        
         V1HTTPIngressPath path = new V1HTTPIngressPath();
-
+        
         List<V1HTTPIngressPath> paths = new ArrayList<>();
         paths.add(path);
         httpRule.setPaths(paths);
-
+        
         path.setPathType(KubernetesConstants.IngressPathType.PREFIX);
         path.setPath("/");
-
+        
         V1IngressBackend backend = new V1IngressBackend();
         V1TypedLocalObjectReference reference = new V1TypedLocalObjectReference();
         reference.setApiGroup(V1McpBridge.API_GROUP);
@@ -572,10 +1798,10 @@ public class KubernetesModelConverterTest {
         reference.setName(V1McpBridge.DEFAULT_NAME);
         backend.setResource(reference);
         path.setBackend(backend);
-
+        
         return ingress;
     }
-
+    
     private static Route buildBasicRoute() {
         Route route = new Route();
         route.setDomains(new ArrayList<>());
@@ -583,5 +1809,69 @@ public class KubernetesModelConverterTest {
         route.setCors(new CorsConfig());
         route.setCustomConfigs(new HashMap<>());
         return route;
+    }
+    
+    private V1alpha1WasmPluginSpec createSpecWithGlobalConfig() {
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        spec.setDefaultConfig(Collections.singletonMap("key", "value"));
+        spec.setDefaultConfigDisable(false);
+        return spec;
+    }
+    
+    private V1alpha1WasmPluginSpec createSpecWithDomainConfig(String domain) {
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        MatchRule matchRule = new MatchRule();
+        matchRule.setDomain(Collections.singletonList(domain));
+        matchRule.setConfig(Collections.singletonMap("key", "value"));
+        matchRule.setConfigDisable(false);
+        spec.setMatchRules(Collections.singletonList(matchRule));
+        return spec;
+    }
+    
+    private V1alpha1WasmPluginSpec createSpecWithRouteConfig(String route) {
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        MatchRule matchRule = new MatchRule();
+        matchRule.setIngress(Collections.singletonList(route));
+        matchRule.setConfig(Collections.singletonMap("key", "value"));
+        matchRule.setConfigDisable(false);
+        spec.setMatchRules(Collections.singletonList(matchRule));
+        return spec;
+    }
+    
+    private V1ObjectMeta createMetadata(String name, String pluginName, String pluginVersion) {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY, pluginName);
+        labels.put(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY, pluginVersion);
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setName(name);
+        metadata.setLabels(labels);
+        return metadata;
+    }
+    
+    
+    private V1ObjectMeta createMetadata() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(KubernetesConstants.Label.WASM_PLUGIN_NAME_KEY, "test-plugin");
+        labels.put(KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY, "v1");
+        labels.put(KubernetesConstants.Label.WASM_PLUGIN_CATEGORY_KEY, "test-category");
+        labels.put(KubernetesConstants.Label.WASM_PLUGIN_BUILT_IN_KEY, "true");
+        
+        Map<String, String> annotations = new HashMap<>();
+        annotations.put(KubernetesConstants.Annotation.WASM_PLUGIN_TITLE_KEY, "Test Plugin");
+        annotations.put(KubernetesConstants.Annotation.WASM_PLUGIN_DESCRIPTION_KEY, "A test plugin");
+        annotations.put(KubernetesConstants.Annotation.WASM_PLUGIN_ICON_KEY, "icon.png");
+        
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        metadata.setLabels(labels);
+        metadata.setAnnotations(annotations);
+        return metadata;
+    }
+    
+    private V1alpha1WasmPluginSpec createSpec() {
+        V1alpha1WasmPluginSpec spec = new V1alpha1WasmPluginSpec();
+        spec.setUrl("test/image:v1");
+        spec.setPhase(PluginPhase.UNSPECIFIED.getName());
+        spec.setPriority(10);
+        return spec;
     }
 }

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
@@ -807,9 +807,9 @@ public class KubernetesModelConverterTest {
     void secret2TlsCertificateTestValidSecretWithoutCertAndKeyShouldReturnTlsCertificateWithoutCertAndKey() {
         V1Secret secret = new V1Secret();
         secret.setMetadata(new V1ObjectMeta() {{
-            setName("test-secret");
-            setResourceVersion("123");
-        }});
+                setName("test-secret");
+                setResourceVersion("123");
+            }});
 
         TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
 
@@ -827,9 +827,9 @@ public class KubernetesModelConverterTest {
     void secret2TlsCertificateTestNullMetadataShouldReturnTlsCertificateWithoutNameAndVersion() {
         V1Secret secret = new V1Secret();
         secret.setData(new HashMap<String, byte[]>() {{
-            put(KubernetesConstants.SECRET_TLS_CRT_FIELD, "certData".getBytes());
-            put(KubernetesConstants.SECRET_TLS_KEY_FIELD, "keyData".getBytes());
-        }});
+                put(KubernetesConstants.SECRET_TLS_CRT_FIELD, "certData".getBytes());
+                put(KubernetesConstants.SECRET_TLS_KEY_FIELD, "keyData".getBytes());
+            }});
 
         TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
 
@@ -844,9 +844,9 @@ public class KubernetesModelConverterTest {
     void secret2TlsCertificateTestEmptyDataShouldReturnTlsCertificateWithoutCertAndKey() {
         V1Secret secret = new V1Secret();
         secret.setMetadata(new V1ObjectMeta() {{
-            setName("test-secret");
-            setResourceVersion("123");
-        }});
+                setName("test-secret");
+                setResourceVersion("123");
+            }});
         secret.setData(Collections.emptyMap());
 
         TlsCertificate tlsCertificate = converter.secret2TlsCertificate(secret);
@@ -1251,8 +1251,8 @@ public class KubernetesModelConverterTest {
         List<MatchRule> matchRules = new ArrayList<>();
         MatchRule rule = new MatchRule();
         rule.setDomain(new ArrayList<String>() {{
-            add("higress.cn");
-        }});
+                add("higress.cn");
+            }});
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
@@ -1270,8 +1270,8 @@ public class KubernetesModelConverterTest {
         List<MatchRule> matchRules = new ArrayList<>();
         MatchRule rule = new MatchRule();
         rule.setDomain(new ArrayList<String>() {{
-            add("higress.cn");
-        }});
+                add("higress.cn");
+            }});
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
@@ -1289,8 +1289,8 @@ public class KubernetesModelConverterTest {
         List<MatchRule> matchRules = new ArrayList<>();
         MatchRule rule = new MatchRule();
         rule.setIngress(new ArrayList<String>() {{
-            add("test-route");
-        }});
+                add("test-route");
+            }});
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
@@ -1308,8 +1308,8 @@ public class KubernetesModelConverterTest {
         List<MatchRule> matchRules = new ArrayList<>();
         MatchRule rule = new MatchRule();
         rule.setIngress(new ArrayList<String>() {{
-            add("test-route");
-        }});
+                add("test-route");
+            }});
         matchRules.add(rule);
         spec.setMatchRules(matchRules);
         cr.setSpec(spec);
@@ -1688,8 +1688,8 @@ public class KubernetesModelConverterTest {
         metadata.setName("test-ingress");
         metadata.setResourceVersion("1");
         metadata.setAnnotations(new HashMap<String, String>() {{
-            put("higress.cn", "annotation-value");
-        }});
+                put("higress.cn", "annotation-value");
+            }});
 
         V1Ingress ingress = new V1Ingress();
         ingress.setMetadata(metadata);


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
This PR is mainly to increase the unit test coverage of `KubernetesModelConverter`
此 PR 主要是为了增加 `KubernetesModelConverter` 的单元测试覆盖率

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #97

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Not applicable
不适用该选项


### Ⅳ. Describe how to verify it

- All unit test functions are considered passed if they pass
所有单元测试函数如果通过，则视为通过
### Ⅴ. Special notes for reviews
- The newly added unit tests now provide full coverage for all public functions.
 新添加的单元测试，已经覆盖所有的`public`函数
- Detailed unit test coverage changes are shown in the following table
详细的单元测试覆盖率变化如下表所示

  | |Amount| class,% |Method,% |Line,% |Branch,% |
  | ---- | ---- | ---- | ---- | ---- | ---- |
  | Original data |26| 50% (1/2)|47% (34/72)|32% (291/893)|24% (142/569)
  | After addition |92| 100% (2/2)|90% (65/72)|76% (684/893)|57% (328/569)
