### PR TITLE
fix: Only show ingress related notes when ingress is enabled

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,6 +1,7 @@
 Use the following command to access the console:
   hgctl dashboard console
 
+{{ if .Values.ingress.enabled -}}
 Because you choose to create an Ingress resource for Higress Console, you can use the following URL to access it as well:
 {{- range $path := .Values.ingress.paths }}
   http{{ if $.Values.ingress.tlsSecretName }}s{{ end }}://{{ $.Values.ingress.domain }}{{ .path }}
@@ -8,4 +9,5 @@ Because you choose to create an Ingress resource for Higress Console, you can us
 {{- if or .Values.global.local .Values.global.kind }}
 And since Higress Console is running in local mode, you may need to add the following line into your hosts file before accessing it:
   127.0.0.1 {{ $.Values.ingress.domain }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

#### Ingress not enabled (default)

![image](https://github.com/user-attachments/assets/3a2ff2d7-9e14-4469-8e20-a52f35f5c06e)

#### Ingress enabled

![image](https://github.com/user-attachments/assets/01ff5d08-607e-4454-bc2f-c098b4402a43)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
