### PR TITLE
fix: Use failStrategy FAILED_OPEN in all generated WasmPlugin resources

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -72,6 +72,7 @@ import com.alibaba.higress.sdk.model.route.UpstreamService;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridgeSpec;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1RegistryConfig;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.FailStrategy;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.MatchRule;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.PluginPhase;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
@@ -449,6 +450,7 @@ public class KubernetesModelConverter {
         spec.setPhase(plugin.getPhase());
         spec.setPriority(plugin.getPriority());
         spec.setUrl(buildImageUrl(plugin.getImageRepository(), plugin.getImageVersion()));
+        setDefaultValues(spec);
         cr.setSpec(spec);
 
         return cr;
@@ -479,6 +481,7 @@ public class KubernetesModelConverter {
             dstSpec.getMatchRules().addAll(srcSpec.getMatchRules());
         }
         sortWasmPluginMatchRules(dstSpec.getMatchRules());
+        setDefaultValues(dstSpec);
     }
 
     public List<WasmPluginInstance> getWasmPluginInstancesFromCr(V1alpha1WasmPlugin plugin) {
@@ -727,6 +730,7 @@ public class KubernetesModelConverter {
                 throw new IllegalArgumentException("Unsupported scope: " + scope);
         }
         sortWasmPluginMatchRules(matchRules);
+        setDefaultValues(spec);
     }
 
     public boolean removeWasmPluginInstanceFromCr(V1alpha1WasmPlugin cr, WasmPluginInstanceScope scope, String target) {
@@ -865,6 +869,10 @@ public class KubernetesModelConverter {
             return 0;
         }
         return hasDomain1 ? compareStringLists(r1.getDomain(), r2.getDomain()) : 0;
+    }
+
+    private static void setDefaultValues(V1alpha1WasmPluginSpec spec) {
+        spec.setFailStrategy(FailStrategy.FAIL_OPEN.getName());
     }
 
     private static int compareStringLists(List<String> l1, List<String> l2) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/wasm/FailStrategy.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/wasm/FailStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.service.kubernetes.crd.wasm;
+
+public enum FailStrategy {
+
+    /**
+     * A fatal error in the binary fetching or during the plugin execution causes all subsequent requests to fail with
+     * 5xx.
+     */
+    FAIL_CLOSE("FAIL_CLOSE", 0),
+
+    /**
+     * Enables the fail open behavior for the Wasm plugin fatal errors to bypass the plugin execution. A fatal error can
+     * be a failure to fetch the remote binary, an exception, or abort() on the VM. This flag is not recommended for the
+     * authentication or the authorization plugins.
+     */
+    FAIL_OPEN("FAIL_OPEN", 1);
+
+    private final String name;
+    private final int value;
+
+    FailStrategy(String name, int value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/wasm/V1alpha1WasmPluginSpec.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/wasm/V1alpha1WasmPluginSpec.java
@@ -39,4 +39,6 @@ public class V1alpha1WasmPluginSpec {
     private String url;
 
     private String verificationKey;
+
+    private String failStrategy;
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

When user creates a new Wasm plugin config or updates an existed Wasm plugin config in the console, the `failStrategy` field in the generated WasmPlugin resource will be set to `FAILED_OPEN`.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
