### PR TITLE
fix: Set the defaultConfigDisable of WasmPlugin CR to false by default

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -873,6 +873,10 @@ public class KubernetesModelConverter {
 
     private static void setDefaultValues(V1alpha1WasmPluginSpec spec) {
         spec.setFailStrategy(FailStrategy.FAIL_OPEN.getName());
+
+        if (spec.getDefaultConfigDisable() == null){
+            spec.setDefaultConfigDisable(true);
+        }
     }
 
     private static int compareStringLists(List<String> l1, List<String> l2) {

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
@@ -324,7 +324,7 @@ public class WasmPluginInstanceServiceTest {
         V1alpha1WasmPlugin cr = crCaptor.getValue();
         Assertions.assertNotNull(cr);
         Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_INTERNAL_CR_NAME, cr.getMetadata().getName());
-        Assertions.assertNull(cr.getSpec().getDefaultConfigDisable());
+        Assertions.assertTrue(cr.getSpec().getDefaultConfigDisable());
         Assertions.assertNull(cr.getSpec().getDefaultConfig());
         Assertions.assertEquals(1, cr.getSpec().getMatchRules().size());
         MatchRule rule = cr.getSpec().getMatchRules().get(0);


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Set the defaultConfigDisable of WasmPlugin CR to false by default, so it won't break the WasmPlugin config pushing if user only configures plugin in route or domain level.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/alibaba/higress/issues/1517

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
