### PR TITLE
feat: Enable ai-statistics plugin for AI routes by default

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiStatisticsConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiStatisticsConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.constant.plugin.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AiStatisticsConfig {
+
+    public static final String ATTRIBUTES = "attributes";
+
+    public static final String KEY = "key";
+    public static final String VALUE_SOURCE = "value_source";
+    public static final String VALUE = "value";
+    public static final String RULE = "rule";
+    public static final String APPLY_TO_LOG = "apply_to_log";
+    public static final String APPLY_TO_SPAN = "apply_to_span";
+
+    public static class ValueSource {
+
+        public static final String FIXED_VALUE = "fixed_value";
+        public static final String REQUEST_HEADER = "request_header";
+        public static final String REQUEST_BODY = "request_body";
+        public static final String RESPONSE_HEADER = "response_header";
+        public static final String RESPONSE_BODY = "response_body";
+        public static final String RESPONSE_STREAMING_BODY = "response_streaming_body";
+    }
+
+    public static class Rule {
+
+        public static final String FIRST = "first";
+        public static final String REPLACE = "replace";
+        public static final String APPEND = "append";
+    }
+
+    public static Map<String, Object> buildAttribute(String key, String valueSource, String value, String rule,
+        Boolean applyToLog, Boolean applyToSpan) {
+        Map<String, Object> attribute = new HashMap<>();
+        if (key != null) {
+            key = key.trim();
+            attribute.put(KEY, key);
+        }
+        if (valueSource != null) {
+            attribute.put(VALUE_SOURCE, valueSource);
+        }
+        if (value != null) {
+            attribute.put(VALUE, value);
+        }
+        if (rule != null) {
+            attribute.put(RULE, rule);
+        }
+        if (applyToLog != null) {
+            attribute.put(APPLY_TO_LOG, applyToLog);
+        }
+        if (applyToSpan != null) {
+            attribute.put(APPLY_TO_SPAN, applyToSpan);
+        }
+        return attribute;
+    }
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Enable ai-statistics plugin for AI routes by default.

![image](https://github.com/user-attachments/assets/5e84a11c-42b4-4996-ab09-5ff5a0f64d8c)

![image](https://github.com/user-attachments/assets/86b74033-756a-44e4-a133-3c6ce7dd484e)

```yaml
apiVersion: extensions.higress.io/v1alpha1
kind: WasmPlugin
metadata:
  annotations:
    higress.io/wasm-plugin-description: Provides statistics of token usage, including
      logs, monitoring, and alerts.
    higress.io/wasm-plugin-icon: https://img.alicdn.com/imgextra/i1/O1CN018iKKih1iVx287RltL_!!6000000004419-2-tps-42-42.png
    higress.io/wasm-plugin-title: AI Statistics
  creationTimestamp: "2025-01-14T04:18:57Z"
  generation: 2
  labels:
    higress.io/resource-definer: higress
    higress.io/wasm-plugin-built-in: "true"
    higress.io/wasm-plugin-category: ai
    higress.io/wasm-plugin-name: ai-statistics
    higress.io/wasm-plugin-version: 1.0.0
  name: ai-statistics-1.0.0
  namespace: higress-system
  resourceVersion: "2945137"
  uid: bde30c13-b17d-4611-977a-ad52b0e228bd
spec:
  defaultConfigDisable: true
  failStrategy: FAIL_OPEN
  matchRules:
  - config:
      attributes:
      - apply_to_log: true
        key: question
        value: messages.@reverse.0.content
        value_source: request_body
      - apply_to_log: true
        key: answer
        rule: append
        value: choices.0.delta.content
        value_source: response_streaming_body
      - apply_to_log: true
        key: answer
        value: choices.0.message.content
        value_source: response_body
    configDisable: false
    ingress:
    - ai-route-qwen.internal
  - config:
      attributes:
      - apply_to_log: true
        key: question
        value: messages.@reverse.0.content
        value_source: request_body
      - apply_to_log: true
        key: answer
        rule: append
        value: choices.0.delta.content
        value_source: response_streaming_body
      - apply_to_log: true
        key: answer
        value: choices.0.message.content
        value_source: response_body
    configDisable: false
    ingress:
    - ai-route-qwen.fallback.internal
  phase: UNSPECIFIED_PHASE
  priority: 900
  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-statistics:1.0.0
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
