### PR TITLE
feat: add search filter for routes in the route management page

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -466,6 +466,7 @@
     "editRoute": "Edit Route",
     "deleteConfirmation": "Are you sure you want to delete <1>{{currentRouteName}}</1>?",
     "noCustomIngresses": "Note: Only routes created from the console are listed above.",
+    "routeSearchPlaceholder": "Search routes by route name, domain, routing conditions and target service.",
     "factorGroup": {
       "columns": {
         "key": "Key",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -465,6 +465,7 @@
     "editRoute": "编辑路由",
     "deleteConfirmation": "确定删除 <1>{{currentRouteName}}</1> 吗？",
     "noCustomIngresses": "注：列表中仅包含通过控制台页面创建的路由配置。",
+    "routeSearchPlaceholder": "根据路由名称、域名、路由条件和目标服务搜索路由",
     "factorGroup": {
       "columns": {
         "key": "Key",

--- a/frontend/src/pages/route/index.tsx
+++ b/frontend/src/pages/route/index.tsx
@@ -10,10 +10,10 @@ import { addGatewayRoute, deleteGatewayRoute, getGatewayRoutes, updateGatewayRou
 import store from '@/store';
 import switches from '@/switches';
 import { isInternalResource } from '@/utils';
-import { ExclamationCircleOutlined, RedoOutlined } from '@ant-design/icons';
+import { ExclamationCircleOutlined, RedoOutlined, SearchOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import { useRequest } from 'ahooks';
-import { Alert, Button, Col, Drawer, Form, Modal, Row, Space, Table, Typography } from 'antd';
+import { Alert, Button, Col, Drawer, Form, Input, Modal, Row, Space, Table, Typography } from 'antd';
 import { history } from 'ice';
 import React, { useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -110,6 +110,7 @@ const RouteList: React.FC = () => {
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [currentRoute, setCurrentRoute] = useState<Route | null>();
   const [openDrawer, setOpenDrawer] = useState(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const formRef = useRef(null);
 
   const getRouteList = async (factor): Promise<RouteResponse> => getGatewayRoutes(factor);
@@ -223,6 +224,25 @@ const RouteList: React.FC = () => {
     setCurrentRoute(null);
   };
 
+  const onSearch = () => {
+    const { searchVal } = form.getFieldsValue();
+    setIsLoading(true);
+    const filteredData = dataSource.filter((item) => {
+      const nameMatch = item.name?.includes(searchVal);
+      const domainsMatch = item.domains?.some(domain => domain.includes(searchVal));
+      const pathMatch = item.path?.matchValue?.includes(searchVal);
+      const servicesMatch = item.services?.some(service => service.name?.includes(searchVal));
+      return nameMatch || domainsMatch || pathMatch || servicesMatch;
+    });
+    setDataSource(filteredData);
+    setIsLoading(false);
+  };
+
+  const onReset = () => {
+    form.resetFields()
+    refresh()
+  };
+
   return (
     <PageContainer>
       {
@@ -249,12 +269,30 @@ const RouteList: React.FC = () => {
         }}
       >
         <Row gutter={24}>
-          <Col span={4}>
+          <Col span={14}>
+            <Form.Item name="searchVal">
+              <Input
+                allowClear
+                placeholder={t('route.routeSearchPlaceholder') || ''}
+                prefix={<SearchOutlined />}
+                onPressEnter={onSearch}
+              />
+            </Form.Item>
+          </Col>
+          <Col span={10} style={{ textAlign: 'right' }}>
             <Button type="primary" onClick={onShowDrawer} disabled={!routeManagementSupported}>
               {t('route.createRoute')}
             </Button>
-          </Col>
-          <Col span={20} style={{ textAlign: 'right' }}>
+            <Button
+              style={{ margin: '0 0 0 8px' }}
+              type="primary"
+              onClick={onSearch}
+            >
+              {t('misc.search')}
+            </Button>
+            <Button style={{ margin: '0 8px' }} onClick={onReset}>
+              {t('misc.reset')}
+            </Button>
             <Button icon={<RedoOutlined />} onClick={refresh} />
           </Col>
         </Row>


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

add search filter for routes in the route management page.
A service associated with a route belongs to multiple namespaces. Is it necessary to display namespaces and filter by namespace as described in the https://github.com/alibaba/higress/issues/1659? I can try to continue adding this functionality in this PR.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix: https://github.com/alibaba/higress/issues/1659


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
![image](https://github.com/user-attachments/assets/ecbb60fd-1e05-46f2-a726-89a040f52fef)
![image](https://github.com/user-attachments/assets/b636c137-bae5-4e32-bd3b-cad13b0cd31c)


### Ⅴ. Special notes for reviews
