### PR TITLE
fix: Update the title of credential field in basic auth plugin

### DIFF
--- a/backend/sdk/src/main/resources/plugins/basic-auth/spec.yaml
+++ b/backend/sdk/src/main/resources/plugins/basic-auth/spec.yaml
@@ -113,12 +113,12 @@ spec:
                   - consumer1
               credential:
                 type: string
-                title: 访问凭证
+                title: 访问凭证（示例：username:password）
                 x-title-i18n:
-                  en-US: Credential
-                description: 该调用方的访问凭证
+                  en-US: Credential (e.g., username:password)
+                description: 该调用方的访问凭证（示例：username:password）
                 x-description-i18n:
-                  en-US: The credential of the consumer
+                  en-US: The credential of the consumer (e.g., username:password)
                 example:
                   - admin:123456
             required:


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Add a sample to the title field of credential field in basic auth plugin, so user can know how to set the value.

![image](https://github.com/user-attachments/assets/1290697e-47a3-49ac-9ba5-1cbce9cbf33e)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
