### PR TITLE
fix: Make sure AI route fallback resources can be deleted correctly

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -796,12 +796,16 @@ public class KubernetesModelConverter {
                 continue;
             }
 
+            boolean removeRule = false;
+
             for (Map.Entry<WasmPluginInstanceScope, String> entry : targets.entrySet()) {
                 List<String> targetsInRule = Objects.requireNonNull(getTargetsByScope(rule, entry.getKey()));
-                targetsInRule.remove(entry.getValue());
+                if (targetsInRule.remove(entry.getValue()) && targetsInRule.isEmpty()) {
+                    removeRule = true;
+                }
             }
 
-            if (rule.hasKey()) {
+            if (removeRule) {
                 it.remove();
             }
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/wasm/MatchRule.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/wasm/MatchRule.java
@@ -56,7 +56,7 @@ public class MatchRule {
             && equalsUnordered(service, rule.service);
     }
 
-    public boolean hasKey() {
+    public boolean isEmpty() {
         return CollectionUtils.isEmpty(domain) && CollectionUtils.isEmpty(ingress) && CollectionUtils.isEmpty(service);
     }
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Delete AI route fallback configurations, including EnvoyFilter, WasmPlugin configurations, Ingresses, when disabling fallback feature or deleting an AI route with fallback enabled.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
