### PR TITLE
fix: Allow user to input any URL as a custom OpenAI endpoint

### DIFF
--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -277,7 +277,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
                   rules={[
                     {
                       required: true,
-                      pattern: /http(s)?:\/\/.+\/v1\/chat\/completions/,
+                      pattern: /http(s)?:\/\/.+/,
                       message: t('llmProvider.providerForm.rules.openaiCustomUrlRequired'),
                     },
                   ]}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Allow user to input any URL as a custom OpenAI endpoint.

![image](https://github.com/user-attachments/assets/3dcbb64c-a2e2-4166-a958-8573eeb3dc3c)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
