### PR TITLE
fix: Fix the incorrect upstream  port value used when the ollama instance uses a custom port

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
@@ -123,7 +123,7 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
     }
 
     @Override
-    public void validateConfig(Map<String, Object> configurations) {}
+    public void normalizeConfigs(Map<String, Object> configurations) {}
 
     @Override
     public ServiceSource buildServiceSource(String providerName, Map<String, Object> providerConfig) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AzureLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AzureLlmProviderHandler.java
@@ -34,7 +34,7 @@ public class AzureLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    public void validateConfig(Map<String, Object> configurations) {
+    public void normalizeConfigs(Map<String, Object> configurations) {
         if (MapUtils.isEmpty(configurations)) {
             throw new ValidationException("Missing Azure specific configurations.");
         }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderHandler.java
@@ -30,7 +30,11 @@ interface LlmProviderHandler {
 
     void saveConfig(LlmProvider provider, Map<String, Object> configurations);
 
-    void validateConfig(Map<String, Object> configurations);
+    /**
+     * Validate the provider configurations and normalize configuration values based on the provider type.
+     * @param configurations provider configurations
+     */
+    void normalizeConfigs(Map<String, Object> configurations);
 
     ServiceSource buildServiceSource(String providerName, Map<String, Object> providerConfig);
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
@@ -98,7 +98,7 @@ public class LlmProviderServiceImpl implements LlmProviderService {
             throw new ValidationException("Provider type " + provider.getType() + " is not supported");
         }
 
-        handler.validateConfig(provider.getRawConfigs());
+        handler.normalizeConfigs(provider.getRawConfigs());
 
         fillDefaultValues(provider);
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OllamaLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OllamaLlmProviderHandler.java
@@ -35,7 +35,7 @@ public class OllamaLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    public void validateConfig(Map<String, Object> configurations) {
+    public void normalizeConfigs(Map<String, Object> configurations) {
         if (MapUtils.isEmpty(configurations)) {
             throw new ValidationException("Missing Azure specific configurations.");
         }
@@ -50,6 +50,7 @@ public class OllamaLlmProviderHandler extends AbstractLlmProviderHandler {
         if (!ValidateUtil.checkPort(serverPort)) {
             throw new ValidationException(SERVER_PORT_KEY + " must be a valid port number.");
         }
+        configurations.put(SERVER_PORT_KEY, serverPort);
     }
 
     @Override
@@ -77,11 +78,12 @@ public class OllamaLlmProviderHandler extends AbstractLlmProviderHandler {
         if (MapUtils.isEmpty(providerConfig)) {
             return DEFAULT_PORT;
         }
-        Object serverPortObj = providerConfig.get(SERVER_PORT_KEY);
-        if (!(serverPortObj instanceof Integer serverPort) || !ValidateUtil.checkPort(serverPort)) {
+        try {
+            int serverPort = getIntConfig(providerConfig, SERVER_PORT_KEY);
+            return ValidateUtil.checkPort(serverPort) ? serverPort : DEFAULT_PORT;
+        } catch (ValidationException ve) {
             return DEFAULT_PORT;
         }
-        return serverPort;
     }
 
     @Override

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OpenaiLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OpenaiLlmProviderHandler.java
@@ -40,7 +40,7 @@ public class OpenaiLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    public void validateConfig(Map<String, Object> configurations) {
+    public void normalizeConfigs(Map<String, Object> configurations) {
         if (MapUtils.isEmpty(configurations)) {
             return;
         }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Previously, the ollamaServerPort in the configuration map is a string, causing `serverPortObj instanceof Integer serverPort` check fails, resulting a DEFAULT_PORT of 11434 used in the generated McpBridge registry.

Here we rename the `validationConfig` method to `normalizeConfig`, giving it more responsibility to fix value types and generate additional configurations besides the original validation responsibility.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
