### PR TITLE
chore: Add K8s API response details when logging a K8s ApiException

### DIFF
--- a/backend/console/src/main/resources/application.properties
+++ b/backend/console/src/main/resources/application.properties
@@ -24,3 +24,6 @@ server.compression.enabled=true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,text/css,text/javascript,application/javascript
 server.compression.min-response-size=2048
 server.compression.excluded-user-agents=MSIE 6.0,UCBrowser
+
+# Add %mdc (Mapped Diagnostic Context) based on the Spring Boot default logging pattern found in org.springframework.boot.logging.logback.DefaultLogbackConfiguration
+logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(70396){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} {%mdc} %clr(:){faint} %m%n%wEx


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

The K8s ApiException itself usually doesn't contain any message, resulting an empty info logged. Adding some response details would help the issue diagnostics. And an extra trace ID is added to co-relate these two log entries.

![image](https://github.com/user-attachments/assets/d7b1d57c-7f11-4c9a-9e34-bbc08549826f)

![image](https://github.com/user-attachments/assets/1edfa73d-19db-4e37-9e3c-62b8014209f4)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
