### PR TITLE
feat: Support customizing image URL of built-in plugins

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/WasmPluginsController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/WasmPluginsController.java
@@ -107,8 +107,7 @@ public class WasmPluginsController {
             throw new ValidationException("Plugin name in the URL doesn't match the one in the body.");
         }
         plugin.validate();
-        WasmPlugin updatedPlugin = Boolean.TRUE.equals(plugin.getBuiltIn())
-            ? wasmPluginService.updateBuiltIn(plugin.getName(), plugin.getImageVersion())
+        WasmPlugin updatedPlugin = Boolean.TRUE.equals(plugin.getBuiltIn()) ? wasmPluginService.updateBuiltIn(plugin)
             : wasmPluginService.updateCustom(plugin);
         return ControllerUtil.buildResponseEntity(updatedPlugin);
     }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/WasmPlugin.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/WasmPlugin.java
@@ -86,9 +86,5 @@ public class WasmPlugin implements VersionedDto {
         if (StringUtils.isBlank(imageRepository)) {
             throw new ValidationException("imageRepository cannot be blank.");
         }
-
-        if (StringUtils.isBlank(imageVersion)) {
-            throw new ValidationException("imageVersion cannot be blank.");
-        }
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginService.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginService.java
@@ -30,7 +30,7 @@ public interface WasmPluginService {
 
     String queryReadme(String name, String language);
 
-    WasmPlugin updateBuiltIn(String name, String imageVersion);
+    WasmPlugin updateBuiltIn(WasmPlugin plugin);
 
     WasmPlugin addCustom(WasmPlugin plugin);
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/ImageUrl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/ImageUrl.java
@@ -12,8 +12,11 @@
  */
 package com.alibaba.higress.sdk.service.kubernetes;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.alibaba.higress.sdk.constant.CommonKey;
 import com.alibaba.higress.sdk.constant.Separators;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,7 +32,7 @@ public class ImageUrl {
     private String tag;
 
     public String toUrlString() {
-        return tag != null ? repository + ":" + tag : repository;
+        return StringUtils.isNotBlank(tag) ? repository + ":" + tag : repository;
     }
 
     public static ImageUrl parse(String url) {
@@ -38,6 +41,10 @@ public class ImageUrl {
             return new ImageUrl(url, null);
         }
         int protocolIndex = url.indexOf(CommonKey.PROTOCOL_KEYWORD);
+        if (protocolIndex != -1 && !url.startsWith(CommonKey.OCI_PROTOCOL)) {
+            // Not an OCI image URL, maybe an http:// or file:// URL
+            return new ImageUrl(url, null);
+        }
         if (colonIndex <= protocolIndex) {
             return new ImageUrl(url, null);
         }

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/ImageUrlTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/ImageUrlTest.java
@@ -34,7 +34,7 @@ public class ImageUrlTest {
         Assertions.assertEquals("oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block",
             urlObj.getRepository());
         Assertions.assertEquals("", urlObj.getTag());
-        Assertions.assertEquals(url, urlObj.toUrlString());
+        Assertions.assertEquals(url.substring(0, url.length() - 1), urlObj.toUrlString());
     }
 
     @Test
@@ -53,6 +53,56 @@ public class ImageUrlTest {
         ImageUrl urlObj = ImageUrl.parse(url);
         Assertions.assertEquals("higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block",
             urlObj.getRepository());
+        Assertions.assertNull(urlObj.getTag());
+        Assertions.assertEquals(url, urlObj.toUrlString());
+    }
+
+    @Test
+    public void parseImageUrlHttpsProtocolNoPort() {
+        String url = "https://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block.wasm";
+        ImageUrl urlObj = ImageUrl.parse(url);
+        Assertions.assertEquals("https://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block.wasm",
+                urlObj.getRepository());
+        Assertions.assertNull(urlObj.getTag());
+        Assertions.assertEquals(url, urlObj.toUrlString());
+    }
+
+    @Test
+    public void parseImageUrlHttpsProtocolWithPort() {
+        String url = "https://higress-registry.cn-hangzhou.cr.aliyuncs.com:443/plugins/request-block.wasm";
+        ImageUrl urlObj = ImageUrl.parse(url);
+        Assertions.assertEquals("https://higress-registry.cn-hangzhou.cr.aliyuncs.com:443/plugins/request-block.wasm",
+                urlObj.getRepository());
+        Assertions.assertNull(urlObj.getTag());
+        Assertions.assertEquals(url, urlObj.toUrlString());
+    }
+
+    @Test
+    public void parseImageUrlHttpProtocolNoPort() {
+        String url = "http://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block.wasm";
+        ImageUrl urlObj = ImageUrl.parse(url);
+        Assertions.assertEquals("http://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block.wasm",
+                urlObj.getRepository());
+        Assertions.assertNull(urlObj.getTag());
+        Assertions.assertEquals(url, urlObj.toUrlString());
+    }
+
+    @Test
+    public void parseImageUrlHttpProtocolWithPort() {
+        String url = "http://higress-registry.cn-hangzhou.cr.aliyuncs.com:80/plugins/request-block.wasm";
+        ImageUrl urlObj = ImageUrl.parse(url);
+        Assertions.assertEquals("http://higress-registry.cn-hangzhou.cr.aliyuncs.com:80/plugins/request-block.wasm",
+                urlObj.getRepository());
+        Assertions.assertNull(urlObj.getTag());
+        Assertions.assertEquals(url, urlObj.toUrlString());
+    }
+
+    @Test
+    public void parseImageUrlFileProtocol() {
+        String url = "files://opt/plugins/request-block.wasm";
+        ImageUrl urlObj = ImageUrl.parse(url);
+        Assertions.assertEquals("files://opt/plugins/request-block.wasm",
+                urlObj.getRepository());
         Assertions.assertNull(urlObj.getTag());
         Assertions.assertEquals(url, urlObj.toUrlString());
     }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support customizing image URL of built-in plugins with two ways:

1. Global customization
   - User can add an env variable `HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN` or Java property `higress-admin.wasmplugin.custom-image-url-pattern` when starting the console. The value can contain two placeholders, `${name}` and `${version}`, which will be replaced with actual plugin metadata field values.
2. Specified customization
   - User can edit built-in plugins on the console webpage and change the image URL.
   - ![image](https://github.com/user-attachments/assets/4b5b94f5-7197-4e85-b099-4662a7182188)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
