### PR TITLE
fix: Remove two redundant envs

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -34,10 +34,6 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: JAVA_HOME
-              value: /usr/local/openjdk-18
-            - name: LANG
-              value: C.UTF-8
             - name: HIGRESS_CONSOLE_NS
               value: {{ .Release.Namespace }}
             - name: HIGRESS_CONSOLE_SECRET_NAME


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Remove two redundant envs, which are already defined in the base image:
- JAVA_HOME
- LANG

![image](https://github.com/user-attachments/assets/78e0ff38-286c-4b15-a294-2533de80b8b2)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
