### PR TITLE
feat: Support configuring multiple key-auth credentials in one consumer

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/KeyAuthConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/KeyAuthConfig.java
@@ -16,6 +16,8 @@ public class KeyAuthConfig {
 
     public static final String CONSUMERS = "consumers";
     public static final String CONSUMER_NAME = "name";
+    public static final String CONSUMER_CREDENTIALS = "credentials";
+    @Deprecated
     public static final String CONSUMER_CREDENTIAL = "credential";
 
     public static final String KEYS = "keys";

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/consumer/KeyAuthCredential.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/consumer/KeyAuthCredential.java
@@ -12,8 +12,11 @@
  */
 package com.alibaba.higress.sdk.model.consumer;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.higress.sdk.exception.ValidationException;
@@ -38,14 +41,14 @@ public class KeyAuthCredential extends Credential {
     private String source;
     @Schema(description = "Credential Key. Required when source is HEADER or QUERY")
     private String key;
-    @Schema(description = "Credential Value")
-    private String value;
+    @Schema(description = "Credential Values")
+    private List<String> values;
 
-    public KeyAuthCredential(String type, String source, String key, String value) {
+    public KeyAuthCredential(String type, String source, String key, List<String> values) {
         super(type);
         this.source = source;
         this.key = key;
-        this.value = value;
+        this.values = values != null ? new ArrayList<>(values) : null;
     }
 
     @Override
@@ -76,7 +79,7 @@ public class KeyAuthCredential extends Credential {
             throw new ValidationException("key cannot be blank.");
         }
 
-        if (!forUpdate && StringUtils.isBlank(value)) {
+        if (!forUpdate && CollectionUtils.isEmpty(values)) {
             throw new ValidationException("value cannot be blank.");
         }
     }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/ConsumerServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/ConsumerServiceImpl.java
@@ -35,6 +35,7 @@ import com.alibaba.higress.sdk.model.WasmPluginInstance;
 import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
 import com.alibaba.higress.sdk.model.consumer.AllowList;
 import com.alibaba.higress.sdk.model.consumer.Consumer;
+import com.alibaba.higress.sdk.model.consumer.Credential;
 import com.alibaba.higress.sdk.service.WasmPluginInstanceService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -226,7 +227,9 @@ public class ConsumerServiceImpl implements ConsumerService {
             for (Consumer consumer : extractedConsumers) {
                 Consumer existedConsumer = consumers.putIfAbsent(consumer.getName(), consumer);
                 if (existedConsumer != null) {
-                    existedConsumer.getCredentials().addAll(consumer.getCredentials());
+                    List<Credential> credentials = new ArrayList<>(existedConsumer.getCredentials());
+                    credentials.addAll(consumer.getCredentials());
+                    existedConsumer.setCredentials(credentials);
                 }
             }
         }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/KeyAuthCredentialHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/KeyAuthCredentialHandler.java
@@ -15,6 +15,7 @@ package com.alibaba.higress.sdk.service.consumer;
 import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.ALLOW;
 import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.CONSUMERS;
 import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.CONSUMER_CREDENTIAL;
+import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.CONSUMER_CREDENTIALS;
 import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.CONSUMER_NAME;
 import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.GLOBAL_AUTH;
 import static com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig.IN_HEADER;
@@ -163,7 +164,7 @@ class KeyAuthCredentialHandler implements CredentialHandler {
             throw new IllegalArgumentException("Invalid key auth credential source: " + keyAuthCredential.getSource());
         }
         String key = keyAuthCredential.getKey();
-        String credential = keyAuthCredential.getValue();
+        List<String> credentials = keyAuthCredential.getValues();
         switch (sourceEnum) {
             case BEARER:
             case HEADER:
@@ -171,7 +172,7 @@ class KeyAuthCredentialHandler implements CredentialHandler {
                 consumerConfig.put(IN_QUERY, false);
                 if (sourceEnum == KeyAuthCredentialSource.BEARER) {
                     key = HttpHeaders.AUTHORIZATION;
-                    credential = BEARER_TOKEN_PREFIX + keyAuthCredential.getValue();
+                    credentials = credentials.stream().map(c -> BEARER_TOKEN_PREFIX + c).toList();
                 }
                 break;
             case QUERY:
@@ -183,7 +184,8 @@ class KeyAuthCredentialHandler implements CredentialHandler {
                     "Unsupported key auth credential source: " + keyAuthCredential.getSource());
         }
         consumerConfig.put(KEYS, List.of(key));
-        consumerConfig.put(CONSUMER_CREDENTIAL, credential);
+        consumerConfig.put(CONSUMER_CREDENTIALS, credentials);
+        consumerConfig.remove(CONSUMER_CREDENTIAL);
 
         configurations.put(CONSUMERS, consumers);
         configurations.put(GLOBAL_AUTH, false);
@@ -256,14 +258,11 @@ class KeyAuthCredentialHandler implements CredentialHandler {
         return new KeyAuthCredential(
             StringUtils.firstNonBlank(keyAuthCredential.getSource(), existedCredential.getSource()),
             StringUtils.firstNonBlank(keyAuthCredential.getKey(), existedCredential.getKey()),
-            StringUtils.firstNonBlank(keyAuthCredential.getValue(), existedCredential.getValue()));
+            CollectionUtils.isNotEmpty(keyAuthCredential.getValues()) ? keyAuthCredential.getValues()
+                : existedCredential.getValues());
     }
 
     private static KeyAuthCredential parseCredential(Map<String, Object> consumerMap) {
-        String credential = MapUtils.getString(consumerMap, CONSUMER_CREDENTIAL);
-        if (StringUtils.isBlank(credential)) {
-            return null;
-        }
 
         Object keyObj = MapUtils.getObject(consumerMap, KEYS);
         if (!(keyObj instanceof List<?> keyList) || keyList.isEmpty()) {
@@ -286,12 +285,30 @@ class KeyAuthCredentialHandler implements CredentialHandler {
         Boolean inHeader = MapUtils.getBoolean(consumerMap, IN_HEADER);
         Boolean inQuery = MapUtils.getBoolean(consumerMap, IN_QUERY);
 
+        List<String> credentials = new ArrayList<>();
+        Object credentialsObj = consumerMap.get(CONSUMER_CREDENTIALS);
+        if (credentialsObj instanceof List<?> credentialsList) {
+            for (Object credentialObj : credentialsList) {
+                if (credentialObj instanceof String credential) {
+                    credentials.add(credential);
+                }
+            }
+        }
+        {
+            // TODO: To be removed later.
+            String credential = MapUtils.getString(consumerMap, CONSUMER_CREDENTIAL);
+            if (StringUtils.isNotBlank(credential) && !credentials.contains(credential)) {
+                credentials.add(credential);
+            }
+        }
+
         KeyAuthCredentialSource source;
         if (Boolean.TRUE.equals(inHeader)) {
-            if (HttpHeaders.AUTHORIZATION.equals(key) && credential.startsWith(BEARER_TOKEN_PREFIX)) {
+            if (HttpHeaders.AUTHORIZATION.equals(key)
+                && credentials.stream().allMatch(c -> c.startsWith(BEARER_TOKEN_PREFIX))) {
                 source = KeyAuthCredentialSource.BEARER;
                 key = null;
-                credential = credential.substring(BEARER_TOKEN_PREFIX.length()).trim();
+                credentials.replaceAll(s -> s.substring(BEARER_TOKEN_PREFIX.length()).trim());
             } else {
                 source = KeyAuthCredentialSource.HEADER;
             }
@@ -300,6 +317,6 @@ class KeyAuthCredentialHandler implements CredentialHandler {
         } else {
             return null;
         }
-        return new KeyAuthCredential(source.name(), key, credential);
+        return new KeyAuthCredential(source.name(), key, credentials);
     }
 }

--- a/frontend/src/pages/consumer/index.tsx
+++ b/frontend/src/pages/consumer/index.tsx
@@ -62,7 +62,7 @@ const ConsumerList: React.FC = () => {
             {
               supportedCredentialTypes.map(function (type) {
                 const setting = credentialTypeDisplaySettings[type] || { name: type, color: '' };
-                return (<Tag color={setting.color}>{setting.name}</Tag>);
+                return (<Tag color={setting.color} key={type}>{setting.name}</Tag>);
               })
             }
           </>
@@ -100,6 +100,7 @@ const ConsumerList: React.FC = () => {
       consumers.sort((i1, i2) => {
         return i1.name.localeCompare(i2.name);
       })
+      consumers.forEach(c => c.key = c.key || c.name);
       setDataSource(consumers);
     },
   });


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support configuring multiple key-auth credentials in one consumer.

![image](https://github.com/user-attachments/assets/947540c5-3eee-4fd7-af3b-b731341b9b82)

Support reading existed configurations with "credential" key, but only write configs to the new "credentials" key.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
