### PR TITLE
feat: 域名管理页面与域名策略页面插件启用状态展示  

### DIFF
--- a/frontend/src/interfaces/domain.ts
+++ b/frontend/src/interfaces/domain.ts
@@ -1,3 +1,7 @@
+import { getDomainPluginInstance, getDomainPluginInstances } from "@/services";
+import message from "antd/lib/message";
+import { WasmPluginData } from "./route";
+
 export interface Domain {
   name: string;
   version?: string;
@@ -25,3 +29,23 @@ export interface DomainResponse {
 }
 
 export const DEFAULT_DOMAIN = "higress-default-domain";
+
+export const fetchPluginsByDomain = async (record: Domain): Promise<WasmPluginData[]> => {
+  const data: Record<string, WasmPluginData[]> = {};
+  try {
+    const response = await getDomainPluginInstances(record.name);
+    const plugins = response.map((plugin: { pluginName: any; description: any; enabled: any; internal: any }) => {
+      return {
+        ...plugin,
+        name: plugin.pluginName,
+        enabled: plugin.enabled,
+        internal: plugin.internal,
+      };
+    });
+    data[record.name] = plugins || [];
+  } catch (error) {
+    message.error(`Failed to fetch strategies: ${error.message || error}`);
+  }
+
+  return data[record.name] || [];
+};

--- a/frontend/src/pages/plugin/components/PluginList/index.tsx
+++ b/frontend/src/pages/plugin/components/PluginList/index.tsx
@@ -9,6 +9,7 @@ import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'r
 import { useTranslation } from 'react-i18next';
 import { BUILTIN_ROUTE_PLUGIN_LIST, DEFAULT_PLUGIN_IMG } from './constant';
 import { getI18nValue, QueryType } from '../../utils';
+import { fetchPluginsByDomain } from '@/interfaces/domain';
 
 const { Paragraph } = Typography;
 const { Meta } = Card;
@@ -78,6 +79,19 @@ const PluginList = forwardRef((props: Props, ref) => {
           });
           plugins = builtInPlugins.concat(updatedPlugins)
         }
+      } else if (type === QueryType.DOMAIN) {
+        const domainName = searchParams.get('name');
+        if (domainName) {
+          const pluginsByDomain = await fetchPluginsByDomain({ name: domainName });
+          const updatedPlugins = result.map((plugin: { name: string }) => {
+            const foundPlugin = pluginsByDomain.find((p) => p.name === plugin.name);
+            return {
+              ...plugin,
+              enabled: foundPlugin ? foundPlugin.enabled : false,
+            };
+          });
+          plugins = updatedPlugins;
+        }
       }
       setPluginList(plugins);
     },
@@ -146,7 +160,7 @@ const PluginList = forwardRef((props: Props, ref) => {
     <Row gutter={[16, 16]}>
       {pluginList.map((item) => {
         const key = item.key || `${item.name}:${item.imageVersion}`;
-        const showTag = type === QueryType.ROUTE;
+        const showTag = type === QueryType.ROUTE || type === QueryType.DOMAIN;
         return (
           <Col span={6} key={key} xl={6} lg={12} md={12} sm={12} xs={24}>
             <Card

--- a/frontend/src/pages/plugin/index.tsx
+++ b/frontend/src/pages/plugin/index.tsx
@@ -76,22 +76,20 @@ export default function RouterConfig() {
       updateWasmPlugin(val.name, val).then(() => {
         message.success(t('plugins.updateSuccess'));
         formOperatorBack();
-        listRef.current?.refresh();
       });
     } else {
       createWasmPlugin(val).then(() => {
         message.success(t('plugins.addSuccess'));
         formOperatorBack();
-        listRef.current?.refresh();
       });
     }
   };
 
   const init = () => {
-    if (name && type === 'route') {
-      loadRouteDetail(name)
-      listRef.current?.refresh();
+    if (name && type === QueryType.ROUTE) {
+      loadRouteDetail(name);
     }
+    listRef.current?.refresh();
   };
 
   useEffect(() => {

--- a/frontend/src/services/plugin.ts
+++ b/frontend/src/services/plugin.ts
@@ -55,6 +55,11 @@ export const updateRoutePluginInstance = (params: { name: string; pluginName: st
   return request.put<any, any>(`/v1/routes/${name}/plugin-instances/${pluginName}`, payload);
 };
 
+// 获取指定域名的插件配置列表
+export const getDomainPluginInstances = (name: string) => {
+  return request.get<any, any>(`/v1/domains/${name}/plugin-instances`);
+};
+
 // 获取指定域名的指定插件配置
 export const getDomainPluginInstance = (params: { name: string; pluginName: string }) => {
   const { name, pluginName } = params;


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
1. 域名管理列表中展示已启用插件列表
![image](https://github.com/user-attachments/assets/c91a8bfc-51dc-48cb-b1e1-0337b20b09bc)
2. 域名策略页面展示插件启用状态
![image](https://github.com/user-attachments/assets/d1953147-aca9-45ca-87d8-a03f68393f12)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
https://github.com/higress-group/higress-console/pull/429
按要求完成了域名粒度的插件状态展示