### PR TITLE
fix: Add a spacing between two buttons in the ai route list page

### DIFF
--- a/frontend/src/pages/ai/route.tsx
+++ b/frontend/src/pages/ai/route.tsx
@@ -296,6 +296,7 @@ const AiRouteList: React.FC = () => {
           </Col>
           <Col span={10} style={{ textAlign: 'right' }}>
             <Button
+              style={{ margin: '0 8px' }}
               type="primary"
               onClick={onShowDrawer}
             >


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Add a spacing between two buttons in the ai route list page.

Before:

![image](https://github.com/user-attachments/assets/3e6788fa-87f3-41c2-ad60-6f8d5931ddb8)

After:

![image](https://github.com/user-attachments/assets/b79674dd-f06d-4da5-8c43-2f4f755fd561)


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
