### PR TITLE
fix: Fix the pod env customization in the helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: higress-console
 description: Management console for Higress
 type: application
-version: 1.4.6
+version: 2.1.0
 sources:
   - https://github.com/higress-group/higress-console
-appVersion: "1.4.6"
+appVersion: "2.1.0"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -68,9 +68,11 @@ spec:
               value: "{{ .Values.swagger.enabled }}"
             - name: SPRINGDOC_SWAGGER_UI_ENABLED
               value: "{{ .Values.swagger.enabled }}"
-            {{- range $key, $val := .Values.global.env }}
+            {{- if .Values.podEnvs }}
+            {{- range $key, $val := .Values.podEnvs }}
             - name: {{ $key }}
               value: {{ $val | quote }}
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,8 +3,6 @@ global:
   kind: false # Deprecated. Please use "global.local" instead. Will be removed later.
   ingressClass: "higress"
   watchNamespace: ""
-  # Customized Pod environment variables
-  env: []
 
   proxy:
     # -- CAUTION: It is important to ensure that all Istio helm charts specify the same clusterDomain value
@@ -63,6 +61,8 @@ image:
 
 imagePullSecrets: []
 name: ""
+
+podEnvs: {}
 
 podAnnotations: {}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

The current pod env customization method doesn't work, because the default value of `global.env` is a list, but used as a map (see the error screenshot below). And add `env` to `global` isn't a good idea. So I move it to a separate variable, `podEnvs`.

![image](https://github.com/user-attachments/assets/4c7bcb0a-4230-4c3d-986f-5e0c1be40e08)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
