### PR TITLE
fix: Fix namespace in envoyfilter-route-fallback.yaml template

### DIFF
--- a/backend/sdk/src/main/resources/templates/envoyfilter-route-fallback.yaml
+++ b/backend/sdk/src/main/resources/templates/envoyfilter-route-fallback.yaml
@@ -15,7 +15,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: "${name}"
-  namespace: higress-system
 spec:
   configPatches:
     - applyTo: HTTP_ROUTE


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

The file src/main/resources/templates/envoyfilter-route-fallback.yaml hardcodes the namespace as higress-system. When Higress is started in a different namespace, configuring the AI route fallback will cause some strange issues.

When creating the EnvoyFilter resource using the Kubernetes client, we pass in the namespace parameter. The expected behavior is to use this parameter directly, rather than hardcoding it as higress-system.

Error log

```
2025-04-16 16:17:01.639 ERROR 70396 --- [nio-8080-exec-2] c.a.h.c.aop.ApiStandardizationAspect     {traceId=1e061189-dd27-4b6d-beaa-0eea648e328e} : Related K8s API response: Code=400 Body={"kind":"Status","apiVersion":"v1","metadata":null,"status":"Failure","message":"the namespace of the provided object does not match the namespace sent on the request","reason":"BadRequest","code":400}
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
