### PR TITLE
feat: Support a new LLM provider type, AWS Bedrock

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProviderType.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProviderType.java
@@ -73,4 +73,6 @@ public final class LlmProviderType {
     public static final String COZE = "coze";
 
     public static final String TOGETHER_AI = "together-ai";
+
+    public static final String BEDROCK = "bedrock";
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/BedrockLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/BedrockLlmProviderHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.service.ai;
+
+import java.util.Map;
+
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.ai.LlmProviderType;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
+
+public class BedrockLlmProviderHandler extends AbstractLlmProviderHandler {
+
+    private static final String AWS_ACCESS_KEY_KEY = "awsAccessKey";
+    private static final String AWS_SECRET_KEY_KEY = "awsSecretKey";
+    private static final String AWS_REGION_KEY = "awsRegion";
+
+    private static final String DOMAIN_FORMAT = "bedrock-runtime.%s.amazonaws.com";
+
+    @Override
+    public String getType() {
+        return LlmProviderType.BEDROCK;
+    }
+
+    @Override
+    public void normalizeConfigs(Map<String, Object> configurations) {
+        if (MapUtils.isEmpty(configurations)) {
+            throw new ValidationException("Missing Bedrock specific configurations.");
+        }
+
+        String region = MapUtils.getString(configurations, AWS_REGION_KEY);
+        if (StringUtils.isEmpty(region)) {
+            throw new ValidationException(AWS_REGION_KEY + " cannot be empty.");
+        }
+
+        String accessKey = MapUtils.getString(configurations, AWS_ACCESS_KEY_KEY);
+        if (StringUtils.isEmpty(accessKey)) {
+            throw new ValidationException(AWS_ACCESS_KEY_KEY + " cannot be empty.");
+        }
+
+        String secretKey = MapUtils.getString(configurations, AWS_SECRET_KEY_KEY);
+        if (StringUtils.isEmpty(secretKey)) {
+            throw new ValidationException(AWS_SECRET_KEY_KEY + " cannot be empty.");
+        }
+    }
+
+    @Override
+    protected String getServiceRegistryType(Map<String, Object> providerConfig) {
+        return V1McpBridge.REGISTRY_TYPE_DNS;
+    }
+
+    @Override
+    protected String getServiceDomain(Map<String, Object> providerConfig) {
+        String region = MapUtils.getString(providerConfig, AWS_REGION_KEY);
+        if (StringUtils.isEmpty(region)) {
+            throw new ValidationException(AWS_REGION_KEY + " cannot be empty.");
+        }
+        return String.format(DOMAIN_FORMAT, region);
+    }
+
+    @Override
+    protected int getServicePort(Map<String, Object> providerConfig) {
+        return 443;
+    }
+
+    @Override
+    protected String getServiceProtocol(Map<String, Object> providerConfig) {
+        return V1McpBridge.PROTOCOL_HTTPS;
+    }
+}

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
@@ -78,8 +78,8 @@ public class LlmProviderServiceImpl implements LlmProviderService {
             new DefaultLlmProviderHandler(LlmProviderType.COHERE, "api.cohere.com", 443, V1McpBridge.PROTOCOL_HTTPS),
             new DefaultLlmProviderHandler(LlmProviderType.DOUBAO, "ark.cn-beijing.volces.com", 443,
                 V1McpBridge.PROTOCOL_HTTPS),
-            new DefaultLlmProviderHandler(LlmProviderType.COZE, "api.coze.cn", 443, V1McpBridge.PROTOCOL_HTTPS))
-            .collect(Collectors.toMap(LlmProviderHandler::getType, p -> p));
+            new DefaultLlmProviderHandler(LlmProviderType.COZE, "api.coze.cn", 443, V1McpBridge.PROTOCOL_HTTPS),
+            new BedrockLlmProviderHandler()).collect(Collectors.toMap(LlmProviderHandler::getType, p -> p));
     }
 
     private final ServiceSourceService serviceSourceService;

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -239,7 +239,10 @@
         "ollamaServerHost": "Ollama Service Host",
         "ollamaServerPort": "Ollama Service Port",
         "openaiServerType": "OpenAI Service Type",
-        "openaiCustomUrl": "Custom OpenAI Service Base URL"
+        "openaiCustomUrl": "Custom OpenAI Service Base URL",
+        "awsRegion": "AWS Region",
+        "awsAccessKey": "AWS Access Key ID",
+        "awsSecretKey": "AWS Secret Access Key"
       },
       "rules": {
         "tokenRequired": "Please input auth token",
@@ -254,7 +257,10 @@
         "azureServiceUrlRequired": "Please input Azure service URL",
         "ollamaServerHostRequired": "Please input Ollama service host",
         "ollamaServerPortRequired": "Please input Ollama service port",
-        "openaiCustomUrlRequired": "Please input a valid custom OpenAI service base URL"
+        "openaiCustomUrlRequired": "Please input a valid custom OpenAI service base URL",
+        "awsRegionRequired": "Please input AWS Region",
+        "awsAccessKeyRequired": "Please input AWS Access Key ID",
+        "awsSecretKeyRequired": "Please input AWS Secret Access Key"
       },
       "placeholder": {
         "azureServiceUrlPlaceholder": "It shall contain \"/chat/completions\" in the path and \"api-version\" in the query string",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -239,7 +239,10 @@
         "ollamaServerHost": "Ollama 服务主机名",
         "ollamaServerPort": "Ollama 服务端口",
         "openaiServerType": "OpenAI 服务类型",
-        "openaiCustomUrl": "自定义 OpenAI 服务 BaseURL"
+        "openaiCustomUrl": "自定义 OpenAI 服务 BaseURL",
+        "awsRegion": "AWS Region",
+        "awsAccessKey": "AWS Access Key ID",
+        "awsSecretKey": "AWS Secret Access Key"
       },
       "rules": {
         "tokenRequired": "请输入凭证",
@@ -254,7 +257,10 @@
         "azureServiceUrlRequired": "请输入 Azure 服务 URL",
         "ollamaServerHostRequired": "请输入 Ollama 服务主机名",
         "ollamaServerPortRequired": "请输入 Ollama 服务端口",
-        "openaiCustomUrlRequired": "请输入合法的自定义 OpenAI 服务 BaseURL"
+        "openaiCustomUrlRequired": "请输入合法的自定义 OpenAI 服务 BaseURL",
+        "awsRegionRequired": "请输入 AWS Region",
+        "awsAccessKeyRequired": "请输入 AWS Access Key ID",
+        "awsSecretKeyRequired": "请输入 AWS Secret Access Key"
       },
       "placeholder": {
         "azureServiceUrlPlaceholder": "需包含“/chat/completions”路径和“api-version”查询参数",

--- a/frontend/src/pages/ai/components/RouteForm/index.tsx
+++ b/frontend/src/pages/ai/components/RouteForm/index.tsx
@@ -211,7 +211,7 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
     try { // 通过 【服务名称】 来筛查满足 【目标模型 预定义】 的下拉选项
       const _list = aiModelProviders.filter(item => item.value.toUpperCase().indexOf(providerName.toUpperCase()) !== -1);
       if (_list.length) {
-        const _filterList = _list.map(item => item.targetModelList);
+        const _filterList = _list.map(item => item.targetModelList || []);
         return _filterList.flatMap(item => item)
       }
       return [];

--- a/frontend/src/pages/ai/configs.tsx
+++ b/frontend/src/pages/ai/configs.tsx
@@ -42,7 +42,7 @@ export const aiModelProviders = [
   {
     label: 'Qwen',
     value: 'qwen',
-    serviceAddress: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    serviceAddress: 'https://dashscope.aliyuncs.com/api/v1/services/aigc',
     modelNamePattern: 'qwen-*',
     targetModelList: [
       {
@@ -518,4 +518,58 @@ export const aiModelProviders = [
     serviceAddress: 'https://api.together.xyz',
     targetModelList: [],
   },
+  {
+    label: 'AWS Bedrock',
+    value: 'bedrock',
+    availableRegions: [
+      'af-south-1',
+      'ap-east-1',
+      'ap-northeast-1',
+      'ap-northeast-2',
+      'ap-northeast-3',
+      'ap-south-1',
+      'ap-south-2',
+      'ap-southeast-1',
+      'ap-southeast-2',
+      'ap-southeast-3',
+      'ap-southeast-4',
+      'ap-southeast-5',
+      'ap-southeast-7',
+      'ca-central-1',
+      'ca-west-1',
+      'eu-central-1',
+      'eu-central-2',
+      'eu-north-1',
+      'eu-south-1',
+      'eu-south-2',
+      'eu-west-1',
+      'eu-west-2',
+      'eu-west-3',
+      'il-central-1',
+      'me-central-1',
+      'me-south-1',
+      'mx-central-1',
+      'sa-east-1',
+      'us-east-1',
+      'us-east-2',
+      'us-west-1',
+      'us-west-2',
+    ],
+    useCustomCredentials: true,
+    getCredentialsForDisplay: (record): string[] => {
+      if (!record.rawConfigs) {
+        return [];
+      }
+      const accessKey = record.rawConfigs.awsAccessKey;
+      const secretKey = record.rawConfigs.awsSecretKey;
+      return accessKey && secretKey ? [`${accessKey}:${secretKey}`] : [];
+    },
+    getProviderEndpoints: (record): string[] => {
+      const region = record.rawConfigs && record.rawConfigs.awsRegion;
+      return region && [`https://bedrock-runtime.${region}.amazonaws.com`] || [];
+    },
+    targetModelList: [],
+  },
 ];
+
+aiModelProviders.find(p => p.value === 'bedrock')?.availableRegions?.sort();

--- a/frontend/src/pages/ai/provider.tsx
+++ b/frontend/src/pages/ai/provider.tsx
@@ -81,7 +81,10 @@ const LlmProviderList: React.FC = () => {
           value = providerConfig.getProviderEndpoints(record);
         }
         if (!Array.isArray(value) || !value.length) {
-          return '-';
+          if (!providerConfig?.serviceAddress) {
+            return '-';
+          }
+          value = [providerConfig.serviceAddress];
         }
         return value.map((token) => <span>{token}</span>).reduce((prev, curr) => [prev, <br />, curr]);
       },
@@ -90,7 +93,11 @@ const LlmProviderList: React.FC = () => {
       title: t('llmProvider.columns.tokens'),
       dataIndex: 'tokens',
       key: 'tokens',
-      render: (value) => {
+      render: (value, record) => {
+        const providerConfig = aiModelProviders.find(p => p.value === record.type);
+        if (providerConfig && providerConfig.useCustomCredentials) {
+          value = providerConfig.getCredentialsForDisplay(record);
+        }
         if (!Array.isArray(value) || !value.length) {
           return '-';
         }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

1. Support a new LLM provider type, AWS Bedrock.
2. Allow showing the default endpoint of each LLM provider in the list.
3. Change the default endpoint of Qwen since the compatibility mode isn't enabled by default.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
