### PR TITLE
fix: Fix the OpenAPI doc generation job

### DIFF
--- a/.github/workflows/deploy-to-oss.yaml
+++ b/.github/workflows/deploy-to-oss.yaml
@@ -58,12 +58,12 @@ jobs:
         uses: engineerd/setup-kind@v0.6.2
         with:
           name: higress
-          version: "v0.24.0"          
+          version: "v0.24.0"
 
       - name: Build Higress Console API Docs
         run: |
           helm repo add higress.io https://higress.cn/helm-charts
-          helm install higress-console -n higress-system higress.io/higress-console \
+          helm install higress -n higress-system higress.io/higress \
             --create-namespace --set global.local=true
           mvn clean verify -f ./backend/pom.xml -Papi-docs
 

--- a/backend/console/pom.xml
+++ b/backend/console/pom.xml
@@ -214,6 +214,12 @@
 									<goal>start</goal>
 									<goal>stop</goal>
 								</goals>
+								<configuration>
+									<jvmArguments>
+										-Dspringdoc.api-docs.enabled=true
+										-Dspringdoc.swagger-ui.enabled=true
+									</jvmArguments>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix the OpenAPI doc generation job.

1. Install the full higress instead of higress-console, since the initialization of higress console requires WasmPlugin CRD.
2. Enable SpringDoc when executing the OpenAPI doc generation plugin, because we have it disabled by default now.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
