### PR TITLE
feat: Add a modal telling user how to refer to token values in Secrets

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -270,6 +270,15 @@
       "openaiServerType": {
         "official": "OpenAI Official Service",
         "custom": "Custom Service"
+      },
+      "secretRefModal": {
+        "entry": "I'd like to use token info stored in a Secret resource.",
+        "title": "How to refer to token info stored in a Secret resource?",
+        "content_brief": "Higress supports referring to a field in a Secret resource when configuring tokens. Details are as following:",
+        "content_sameNs": "If the Secret and Higress share the same namespace:",
+        "content_diffNs": "If the Secret and Higress belong to different namespaces:",
+        "example": "e.g. ",
+        "roleConfig": "Higress can read Secret data in any namespace by default. But if the role configuration is modified, please make sure the ServiceAccount bound to Higress Controller is allowed to read the configured Secret resource."
       }
     },
     "create": "Create AI Service Provider",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -270,6 +270,15 @@
       "openaiServerType": {
         "official": "OpenAI 官方服务",
         "custom": "自定义服务"
+      },
+      "secretRefModal": {
+        "entry": "我想引用保存在 Secret 中的凭证信息",
+        "title": "如何引用保存在 Secret 中的凭证信息？",
+        "content_brief": "Higress 支持在配置凭证信息时直接引用 Secret 中的字段。具体方式如下：",
+        "content_sameNs": "若 Secret 与 Higress 在相同的命名空间：",
+        "content_diffNs": "若 Secret 与 Higress 在不同的命名空间：",
+        "example": "例如：",
+        "roleConfig": "默认配置下，Higress 可以读取任意命名空间下的 Secret 信息。如果你调整过这部分配置，请确保 Higress Controller 的 ServiceAccount 可以读取配置中所引用的 Secret 数据。"
       }
     },
     "create": "创建AI服务提供者",

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -107,11 +107,11 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
     setProviderConfig(value ? aiModelProviders.find(p => p.value === value) : null);
   }
 
-  function opensecretRefModal() {
+  function openSecretRefModal() {
     setSecretRefModalVisible(true);
   }
 
-  function closesecretRefModal() {
+  function closeSecretRefModal() {
     setSecretRefModalVisible(false);
   }
 
@@ -261,7 +261,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
                 />
                 <Form.ErrorList errors={errors} />
                 <div style={{ marginTop: '1rem' }}>
-                  <Link onClick={opensecretRefModal}>{t("llmProvider.providerForm.secretRefModal.entry")}</Link>
+                  <Link onClick={openSecretRefModal}>{t("llmProvider.providerForm.secretRefModal.entry")}</Link>
                 </div>
               </Form.Item>
             </>
@@ -518,10 +518,10 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
       <Modal
         title={t("llmProvider.providerForm.secretRefModal.title")}
         open={secretRefModalVisible}
-        onOk={closesecretRefModal}
-        onCancel={closesecretRefModal}
+        onOk={closeSecretRefModal}
+        onCancel={closeSecretRefModal}
         footer={[
-          <Button key="submit" type="primary" onClick={closesecretRefModal}>
+          <Button key="submit" type="primary" onClick={closeSecretRefModal}>
             OK
           </Button>,
         ]}

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -1,8 +1,10 @@
 import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { AutoComplete, Button, Form, Input, InputNumber, Select, Switch } from 'antd';
+import { AutoComplete, Button, Form, Input, InputNumber, Modal, Select, Switch, Typography } from 'antd';
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { aiModelProviders } from '../../configs';
+
+const { Text, Link } = Typography;
 
 const protocolList = [
   { label: "openai/v1", value: "openai/v1" },
@@ -12,6 +14,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
   const { t } = useTranslation();
   const [form] = Form.useForm();
   const [failoverEnabled, setFailoverEnabled] = useState(false);
+  const [secretRefModalVisible, setSecretRefModalVisible] = useState(false);
   const [providerType, setProviderType] = useState<string | null>();
   const [openaiServerType, setOpenaiServerType] = useState<string | null>();
   const [providerConfig, setProviderConfig] = useState<object | null>();
@@ -102,6 +105,14 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
   function onProviderTypeChanged(value: string | null) {
     setProviderType(value);
     setProviderConfig(value ? aiModelProviders.find(p => p.value === value) : null);
+  }
+
+  function opensecretRefModal() {
+    setSecretRefModalVisible(true);
+  }
+
+  function closesecretRefModal() {
+    setSecretRefModalVisible(false);
   }
 
   return (
@@ -249,6 +260,9 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
                   icon={<PlusOutlined />}
                 />
                 <Form.ErrorList errors={errors} />
+                <div style={{ marginTop: '1rem' }}>
+                  <Link onClick={opensecretRefModal}>{t("llmProvider.providerForm.secretRefModal.entry")}</Link>
+                </div>
               </Form.Item>
             </>
           )}
@@ -500,6 +514,39 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
           </>
           : null
       }
+
+      <Modal
+        title={t("llmProvider.providerForm.secretRefModal.title")}
+        open={secretRefModalVisible}
+        onOk={closesecretRefModal}
+        onCancel={closesecretRefModal}
+        footer={[
+          <Button key="submit" type="primary" onClick={closesecretRefModal}>
+            OK
+          </Button>,
+        ]}
+      >
+        {t("llmProvider.providerForm.secretRefModal.content_brief")}
+        <ul style={{ margin: '1rem 0' }}>
+          <li>
+            {t("llmProvider.providerForm.secretRefModal.content_sameNs")}
+            <br />
+            <Text code>{'${secret.secret-name.field-name}'}</Text>
+            <br />
+            {t("llmProvider.providerForm.secretRefModal.example")}
+            <Text code>{'${secret.my-token-secret.openai-token}'}</Text>
+          </li>
+          <li>
+            {t("llmProvider.providerForm.secretRefModal.content_diffNs")}
+            <br />
+            <Text code>{'${secret.ns-name/secret-name.field-name}'}</Text>
+            <br />
+            {t("llmProvider.providerForm.secretRefModal.example")}
+            <Text code>{'${secret.ai-ns/my-token-secret.openai-token}'}</Text>
+          </li>
+        </ul>
+        {t("llmProvider.providerForm.secretRefModal.roleConfig")}
+      </Modal>
     </Form>
   );
 });


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Add a modal telling user how to refer to token values in Secrets.

![image](https://github.com/user-attachments/assets/42847e2f-953d-4d75-bfee-12339dc588ad)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/2140

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
