### PR TITLE
fix: Only show domains with route in the MCP domain list for Nacos 3.x

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -493,7 +493,8 @@
       "mcpServerBaseUrlRequired": "Please input MCP server route path prefix",
       "mcpServerBaseUrlBadFormat": "Invalid MCP server route path prefix, which must begin with a \"/\".",
       "mcpServerExportDomains": "MCP Server Domains",
-      "mcpServerExportDomainsPlaceholder": "If left empty, MCP server will be activated on any domain."
+      "mcpServerExportDomainsPlaceholder": "If left empty, MCP server will be activated on any domain.",
+      "mcpServerExportDomainsOnlyDomainsWithRoute": "Only domains with at least one route are listed."
     }
   },
   "route": {

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -493,7 +493,8 @@
       "mcpServerBaseUrlRequired": "请输入MCP Server路由路径前缀",
       "mcpServerBaseUrlBadFormat": "MCP Server路由路径前缀格式不正确。请使用“/”开头。",
       "mcpServerExportDomains": "关联MCP Server的域名",
-      "mcpServerExportDomainsPlaceholder": "留空表示关联全部域名"
+      "mcpServerExportDomainsPlaceholder": "留空表示关联全部域名",
+      "mcpServerExportDomainsOnlyDomainsWithRoute": "仅支持关联已经配置了路由的域名。"
     }
   },
   "route": {

--- a/frontend/src/pages/service-source/components/SourceForm/index.tsx
+++ b/frontend/src/pages/service-source/components/SourceForm/index.tsx
@@ -1,8 +1,8 @@
 import { OptionItem } from '@/interfaces/common';
-import { DEFAULT_DOMAIN, Domain } from '@/interfaces/domain';
+import { DEFAULT_DOMAIN } from '@/interfaces/domain';
+import { Route } from '@/interfaces/route';
 import { getServiceSourceTypeConfig, isNacosType, ServiceProtocols, ServiceSourceTypeConfig, ServiceSourceTypes } from '@/interfaces/service-source';
-import { HistoryButton, RedoOutlinedBtn } from '@/pages/ai/components/RouteForm/Components';
-import { getGatewayDomains } from '@/services';
+import { getGatewayRoutes } from '@/services';
 import { Form, Input, Select } from 'antd';
 import TextArea from 'antd/lib/input/TextArea';
 import { useRequest } from 'ice';
@@ -29,15 +29,15 @@ const SourceForm: React.FC = forwardRef((props, ref) => {
   const [usingTlsProtocol, setUsingTlsProtocol] = useState<boolean>();
 
   const [domainOptions, setDomainOptions] = useState<OptionItem[]>();
-  const domainsResult = useRequest(getGatewayDomains, {
+  const domainsResult = useRequest(getGatewayRoutes, {
     manual: true,
-    onSuccess: (domains: Domain[]) => {
-      const _domainOptions: OptionItem[] = [];
-      domains && domains.forEach(domain => {
-        const { name } = domain;
-        name !== DEFAULT_DOMAIN && _domainOptions.push({ label: name, value: name });
+    onSuccess: (routes: Route[]) => {
+      const domainsWithRoute = new Set<string>();
+      routes && routes.forEach(route => {
+        const { domains } = route;
+        domains && domains.forEach(domain => domainsWithRoute.add(domain));
       });
-      setDomainOptions(_domainOptions);
+      setDomainOptions([...domainsWithRoute.values()].map(domain => ({ label: domain, value: domain })));
     },
   });
 
@@ -598,7 +598,7 @@ const SourceForm: React.FC = forwardRef((props, ref) => {
                     label={t('serviceSource.serviceSourceForm.mcpServerExportDomains')}
                     name={['properties', 'mcpServerExportDomains']}
                     style={{ flex: 1, marginRight: '8px' }}
-                    extra={(<HistoryButton text={t("domain.createDomain")} path={"/domain"} />)}
+                    extra={t("serviceSource.serviceSourceForm.mcpServerExportDomainsOnlyDomainsWithRoute")}
                   >
                     <Select
                       showSearch
@@ -608,7 +608,6 @@ const SourceForm: React.FC = forwardRef((props, ref) => {
                       options={domainOptions || []}
                     />
                   </Form.Item>
-                  <RedoOutlinedBtn getList={domainsResult} />
                 </div>
               </>
             )


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Only show domains with route in the MCP domain list for Nacos 3.x.

#### Configurations

![image](https://github.com/user-attachments/assets/7889f67a-c86f-4f91-89d9-aed8a23f1466)

![image](https://github.com/user-attachments/assets/5cfecabc-2c6d-4a7c-b3fa-e29e228c3044)

#### Before Fix

![image](https://github.com/user-attachments/assets/ccc8c513-1d34-486a-a7ad-1b27975e38b2)

![image](https://github.com/user-attachments/assets/17d1622c-0338-4880-b034-2dbc2ffe98f0)

#### After Fix

![image](https://github.com/user-attachments/assets/b3dc6557-8b5e-49a9-aacc-d503ec4de4f7)

![image](https://github.com/user-attachments/assets/50f7c739-81e8-4acf-aff1-2d269dc6a199)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/2174

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
