### PR TITLE
If service discovery from the registry is not used, the architecture allows decoupling from the Higress Controller.

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/config/SdkConfig.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/config/SdkConfig.java
@@ -70,6 +70,9 @@ public class SdkConfig {
     @Value("${" + SystemConfigKey.CONTROLLER_ACCESS_TOKEN_KEY + ":}")
     private String controllerAccessToken;
 
+    @Value("${" + SystemConfigKey.CLUSTER_DOMAIN_SUFFIX + ":" + HigressConstants.CLUSTER_DOMAIN_SUFFIX_DEFAULT + "}")
+    private String clusterDomainSuffix;
+
     private HigressServiceProvider serviceProvider;
 
     @PostConstruct
@@ -81,6 +84,7 @@ public class SdkConfig {
                 .withControllerServiceName(controllerServiceName).withControllerServiceHost(controllerServiceHost)
                 .withControllerServicePort(controllerServicePort).withControllerJwtPolicy(controllerJwtPolicy)
                 .withControllerAccessToken(controllerAccessToken)
+                .withClusterDomainSuffix(clusterDomainSuffix)
                 .withWasmPluginServiceConfig(WasmPluginServiceConfig.buildFromEnv()).build();
         serviceProvider = HigressServiceProvider.create(config);
     }

--- a/backend/console/src/main/java/com/alibaba/higress/console/constant/SystemConfigKey.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/constant/SystemConfigKey.java
@@ -116,4 +116,6 @@ public class SystemConfigKey {
     public static final String AI_PROXY_SOCKET_TIMEOUT_KEY = CONFIG_KEY_PREFIX + "ai-proxy.socket-timeout";
 
     public static final int AI_PROXY_SOCKET_TIMEOUT_DEFAULT = 2 * 60 * 1000;
+
+    public static final String CLUSTER_DOMAIN_SUFFIX = "CLUSTER_DOMAIN_SUFFIX";
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
@@ -39,19 +39,25 @@ public class HigressServiceConfig {
     private final String controllerAccessToken;
     private final WasmPluginServiceConfig wasmPluginServiceConfig;
     /**
-     * Regarding the service list interface, does it depend on the controller.
+     * Does the service list interface support registry?
+     *
      * <p>
-     * If true, the service list interface will depend on the controller api.
+     * If null, use the default value. {@link HigressConstants#SERVICE_LIST_SUPPORT_REGISTRY_DEFAULT}
+     * </p>
+     * <p>
+     * If true, the service list interface will support registry and depend on the controller API.
      * {@link com.alibaba.higress.sdk.service.ServiceServiceImpl}
      * </p>
      * <p>
-     * If false, the service list implementation will interaction with the api server
-     * directly.{@link com.alibaba.higress.sdk.service.ServiceServiceByApiServerImpl} Under the current configuration,
+     * If false, the service list implementation will not support registry and will interact with the API server
+     * directly. {@link com.alibaba.higress.sdk.service.ServiceServiceByApiServerImpl} Under the current configuration,
      * there is no need for the capability of service discovery. The sources related to the registry in the service
      * sources will be disabled
      * </p>
+     * 
      */
     private final Boolean serviceListSupportRegistry;
+    private final String clusterDomainSuffix;
 
     /**
      * @deprecated use {@link #getControllerWatchedIngressClassName()} instead
@@ -77,6 +83,7 @@ public class HigressServiceConfig {
         private String controllerAccessToken;
         private WasmPluginServiceConfig wasmPluginServiceConfig;
         private Boolean serviceListSupportRegistry;
+        private String clusterDomainSuffix;
 
         private Builder() {}
 
@@ -87,6 +94,11 @@ public class HigressServiceConfig {
 
         public Builder withServiceListSupportRegistry(Boolean serviceListSupportRegistry) {
             this.serviceListSupportRegistry = serviceListSupportRegistry;
+            return this;
+        }
+
+        public Builder withClusterDomainSuffix(String clusterDomainSuffix) {
+            this.clusterDomainSuffix = clusterDomainSuffix;
             return this;
         }
 
@@ -154,7 +166,8 @@ public class HigressServiceConfig {
                 controllerAccessToken,
                 Objects.isNull(wasmPluginServiceConfig) ? new WasmPluginServiceConfig() : wasmPluginServiceConfig,
                 Optional.ofNullable(serviceListSupportRegistry)
-                    .orElse(HigressConstants.SERVICE_LIST_SUPPORT_REGISTRY_DEFAULT));
+                    .orElse(HigressConstants.SERVICE_LIST_SUPPORT_REGISTRY_DEFAULT),
+                StringUtils.firstNonEmpty(clusterDomainSuffix, HigressConstants.CLUSTER_DOMAIN_SUFFIX_DEFAULT));
         }
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
@@ -12,11 +12,13 @@
  */
 package com.alibaba.higress.sdk.config;
 
-import com.alibaba.higress.sdk.constant.HigressConstants;
-import lombok.Data;
+import java.util.Optional;
+
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Optional;
+import com.alibaba.higress.sdk.constant.HigressConstants;
+
+import lombok.Data;
 
 /**
  * @author CH3CHO
@@ -34,12 +36,10 @@ public class HigressServiceConfig {
     private final String controllerJwtPolicy;
     private final String controllerAccessToken;
     /**
-     * Regarding the service list interface, does it depend on the controller.
-     * true: ServiceServiceImpl
-     * false: ServiceServiceByApiServerImpl
+     * Regarding the service list interface, does it depend on the controller. true: ServiceServiceImpl false:
+     * ServiceServiceByApiServerImpl
      */
     private final Boolean dependControllerApi;
-
 
     /**
      * @deprecated use {@link #getControllerWatchedIngressClassName()} instead
@@ -65,8 +65,7 @@ public class HigressServiceConfig {
         private String controllerAccessToken;
         private Boolean dependControllerApi;
 
-        private Builder() {
-        }
+        private Builder() {}
 
         public Builder withDependControllerApi(Boolean dependControllerApi) {
             this.dependControllerApi = dependControllerApi;

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
@@ -12,13 +12,11 @@
  */
 package com.alibaba.higress.sdk.config;
 
-import java.util.Optional;
-
+import com.alibaba.higress.sdk.constant.HigressConstants;
+import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
-import com.alibaba.higress.sdk.constant.HigressConstants;
-
-import lombok.Data;
+import java.util.Optional;
 
 /**
  * @author CH3CHO
@@ -35,6 +33,13 @@ public class HigressServiceConfig {
     private final Integer controllerServicePort;
     private final String controllerJwtPolicy;
     private final String controllerAccessToken;
+    /**
+     * Regarding the service list interface, does it depend on the controller.
+     * true: ServiceServiceImpl
+     * false: ServiceServiceByApiServerImpl
+     */
+    private final Boolean dependControllerApi;
+
 
     /**
      * @deprecated use {@link #getControllerWatchedIngressClassName()} instead
@@ -58,8 +63,15 @@ public class HigressServiceConfig {
         private Integer controllerServicePort = HigressConstants.CONTROLLER_SERVICE_PORT_DEFAULT;
         private String controllerJwtPolicy = HigressConstants.CONTROLLER_JWT_POLICY_DEFAULT;
         private String controllerAccessToken;
+        private Boolean dependControllerApi;
 
-        private Builder() {}
+        private Builder() {
+        }
+
+        public Builder withDependControllerApi(Boolean dependControllerApi) {
+            this.dependControllerApi = dependControllerApi;
+            return this;
+        }
 
         public Builder withKubeConfigPath(String kubeConfigPath) {
             this.kubeConfigPath = kubeConfigPath;
@@ -122,7 +134,8 @@ public class HigressServiceConfig {
                 StringUtils.firstNonEmpty(controllerServiceHost, HigressConstants.CONTROLLER_SERVICE_HOST_DEFAULT),
                 Optional.ofNullable(controllerServicePort).orElse(HigressConstants.CONTROLLER_SERVICE_PORT_DEFAULT),
                 StringUtils.firstNonEmpty(controllerJwtPolicy, HigressConstants.CONTROLLER_JWT_POLICY_DEFAULT),
-                controllerAccessToken);
+                controllerAccessToken,
+                Optional.ofNullable(dependControllerApi).orElse(HigressConstants.DEPEND_CONTROLLER_API));
         }
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/config/HigressServiceConfig.java
@@ -39,10 +39,19 @@ public class HigressServiceConfig {
     private final String controllerAccessToken;
     private final WasmPluginServiceConfig wasmPluginServiceConfig;
     /**
-     * Regarding the service list interface, does it depend on the controller. true: ServiceServiceImpl false:
-     * ServiceServiceByApiServerImpl
+     * Regarding the service list interface, does it depend on the controller.
+     * <p>
+     * If true, the service list interface will depend on the controller api.
+     * {@link com.alibaba.higress.sdk.service.ServiceServiceImpl}
+     * </p>
+     * <p>
+     * If false, the service list implementation will interaction with the api server
+     * directly.{@link com.alibaba.higress.sdk.service.ServiceServiceByApiServerImpl} Under the current configuration,
+     * there is no need for the capability of service discovery. The sources related to the registry in the service
+     * sources will be disabled
+     * </p>
      */
-    private final Boolean dependControllerApi;
+    private final Boolean serviceListSupportRegistry;
 
     /**
      * @deprecated use {@link #getControllerWatchedIngressClassName()} instead
@@ -67,7 +76,7 @@ public class HigressServiceConfig {
         private String controllerJwtPolicy = HigressConstants.CONTROLLER_JWT_POLICY_DEFAULT;
         private String controllerAccessToken;
         private WasmPluginServiceConfig wasmPluginServiceConfig;
-        private Boolean dependControllerApi;
+        private Boolean serviceListSupportRegistry;
 
         private Builder() {}
 
@@ -76,8 +85,8 @@ public class HigressServiceConfig {
             return this;
         }
 
-        public Builder withDependControllerApi(Boolean dependControllerApi) {
-            this.dependControllerApi = dependControllerApi;
+        public Builder withServiceListSupportRegistry(Boolean serviceListSupportRegistry) {
+            this.serviceListSupportRegistry = serviceListSupportRegistry;
             return this;
         }
 
@@ -144,7 +153,8 @@ public class HigressServiceConfig {
                 StringUtils.firstNonEmpty(controllerJwtPolicy, HigressConstants.CONTROLLER_JWT_POLICY_DEFAULT),
                 controllerAccessToken,
                 Objects.isNull(wasmPluginServiceConfig) ? new WasmPluginServiceConfig() : wasmPluginServiceConfig,
-                Optional.ofNullable(dependControllerApi).orElse(HigressConstants.DEPEND_CONTROLLER_API));
+                Optional.ofNullable(serviceListSupportRegistry)
+                    .orElse(HigressConstants.SERVICE_LIST_SUPPORT_REGISTRY_DEFAULT));
         }
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
@@ -33,4 +33,5 @@ public class HigressConstants {
         "PLEASE DO NOT EDIT DIRECTLY. This resource is managed by Higress.";
     public static final Set<String> VALID_FALLBACK_RESPONSE_CODES = Sets.newHashSet("4xx", "5xx");
     public static final Boolean SERVICE_LIST_SUPPORT_REGISTRY_DEFAULT = Boolean.TRUE;
+    public static final String CLUSTER_DOMAIN_SUFFIX_DEFAULT = "cluster.local";
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
@@ -19,6 +19,7 @@ public class HigressConstants {
     public static final String CONTROLLER_SERVICE_NAME_DEFAULT = "higress-controller";
     public static final String CONTROLLER_INGRESS_CLASS_NAME_DEFAULT = "higress";
     public static final String NGINX_INGRESS_CLASS_NAME = "nginx";
+    public static final Boolean DEPEND_CONTROLLER_API = Boolean.TRUE;
     public static final String CONTROLLER_SERVICE_HOST_DEFAULT = "localhost";
     public static final int CONTROLLER_SERVICE_PORT_DEFAULT = 15014;
     public static final String CONTROLLER_JWT_POLICY_DEFAULT = KubernetesConstants.JwtPolicy.THIRD_PARTY_JWT;

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
@@ -28,6 +28,7 @@ public class HigressConstants {
     public static final String FALLBACK_ROUTE_NAME_SUFFIX = ".fallback";
     public static final String FALLBACK_FROM_HEADER = "x-higress-fallback-from";
     public static final String MODEL_ROUTING_HEADER = "x-higress-llm-model";
-    public static final String INTERNAL_RESOURCE_COMMENT = "PLEASE DO NOT EDIT DIRECTLY. This resource is managed by Higress.";
+    public static final String INTERNAL_RESOURCE_COMMENT =
+        "PLEASE DO NOT EDIT DIRECTLY. This resource is managed by Higress.";
     public static final Set<String> VALID_FALLBACK_RESPONSE_CODES = Set.of("4xx", "5xx");
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/HigressConstants.java
@@ -21,7 +21,6 @@ public class HigressConstants {
     public static final String CONTROLLER_SERVICE_NAME_DEFAULT = "higress-controller";
     public static final String CONTROLLER_INGRESS_CLASS_NAME_DEFAULT = "higress";
     public static final String NGINX_INGRESS_CLASS_NAME = "nginx";
-    public static final Boolean DEPEND_CONTROLLER_API = Boolean.TRUE;
     public static final String CONTROLLER_SERVICE_HOST_DEFAULT = "localhost";
     public static final int CONTROLLER_SERVICE_PORT_DEFAULT = 15014;
     public static final String CONTROLLER_JWT_POLICY_DEFAULT = KubernetesConstants.JwtPolicy.THIRD_PARTY_JWT;
@@ -33,4 +32,5 @@ public class HigressConstants {
     public static final String INTERNAL_RESOURCE_COMMENT =
         "PLEASE DO NOT EDIT DIRECTLY. This resource is managed by Higress.";
     public static final Set<String> VALID_FALLBACK_RESPONSE_CODES = Sets.newHashSet("4xx", "5xx");
+    public static final Boolean SERVICE_LIST_SUPPORT_REGISTRY_DEFAULT = Boolean.TRUE;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Service.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Service.java
@@ -35,7 +35,5 @@ public class Service {
 
     private List<String> endpoints;
 
-    private String type;
-
     private String protocol;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Service.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Service.java
@@ -12,12 +12,12 @@
  */
 package com.alibaba.higress.sdk.model;
 
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @Builder
@@ -34,4 +34,8 @@ public class Service {
     private Integer version;
 
     private List<String> endpoints;
+
+    private String type;
+
+    private String protocol;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Service.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Service.java
@@ -12,12 +12,12 @@
  */
 package com.alibaba.higress.sdk.model;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Data
 @Builder

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/HigressServiceProviderImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/HigressServiceProviderImpl.java
@@ -14,6 +14,8 @@ package com.alibaba.higress.sdk.service;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.alibaba.higress.sdk.config.HigressServiceConfig;
 import com.alibaba.higress.sdk.service.ai.AiRouteService;
 import com.alibaba.higress.sdk.service.ai.AiRouteServiceImpl;
@@ -23,7 +25,6 @@ import com.alibaba.higress.sdk.service.consumer.ConsumerService;
 import com.alibaba.higress.sdk.service.consumer.ConsumerServiceImpl;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
-import org.apache.commons.lang3.BooleanUtils;
 
 /**
  * @author CH3CHO

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/HigressServiceProviderImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/HigressServiceProviderImpl.java
@@ -47,7 +47,7 @@ class HigressServiceProviderImpl implements HigressServiceProvider {
     HigressServiceProviderImpl(HigressServiceConfig config) throws IOException {
         kubernetesClientService = new KubernetesClientService(config);
         kubernetesModelConverter = new KubernetesModelConverter(kubernetesClientService);
-        if (BooleanUtils.isTrue(config.getDependControllerApi())) {
+        if (BooleanUtils.isTrue(config.getServiceListSupportRegistry())) {
             serviceService = new ServiceServiceImpl(kubernetesClientService);
         } else {
             serviceService = new ServiceServiceByApiServerImpl(kubernetesClientService, kubernetesModelConverter);

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/HigressServiceProviderImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/HigressServiceProviderImpl.java
@@ -23,6 +23,7 @@ import com.alibaba.higress.sdk.service.consumer.ConsumerService;
 import com.alibaba.higress.sdk.service.consumer.ConsumerServiceImpl;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
+import org.apache.commons.lang3.BooleanUtils;
 
 /**
  * @author CH3CHO
@@ -45,7 +46,11 @@ class HigressServiceProviderImpl implements HigressServiceProvider {
     HigressServiceProviderImpl(HigressServiceConfig config) throws IOException {
         kubernetesClientService = new KubernetesClientService(config);
         kubernetesModelConverter = new KubernetesModelConverter(kubernetesClientService);
-        serviceService = new ServiceServiceImpl(kubernetesClientService);
+        if (BooleanUtils.isTrue(config.getDependControllerApi())) {
+            serviceService = new ServiceServiceImpl(kubernetesClientService);
+        } else {
+            serviceService = new ServiceServiceByApiServerImpl(kubernetesClientService, kubernetesModelConverter);
+        }
         serviceSourceService = new ServiceSourceServiceImpl(kubernetesClientService, kubernetesModelConverter);
         tlsCertificateService = new TlsCertificateServiceImpl(kubernetesClientService, kubernetesModelConverter);
         wasmPluginService = new WasmPluginServiceImpl(kubernetesClientService, kubernetesModelConverter);

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
@@ -43,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author lvshui
- * @date 2025/3/8 20:58
  */
 @Slf4j
 public class ServiceServiceByApiServerImpl implements ServiceService {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
@@ -113,7 +113,6 @@ public class ServiceServiceByApiServerImpl implements ServiceService {
                     Service service = new Service();
                     service.setNamespace(MCP_SIMULATE_NS);
                     service.setName(StringUtils.join(r.getName(), Separators.DOT, r.getType()));
-                    service.setType(r.getType());
                     service.setProtocol(r.getProtocol());
                     String[] endPoints =
                         StringUtils.split(r.getDomain(), V1McpBridge.REGISTRY_TYPE_STATIC_DNS_SEPARATOR);

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
@@ -114,8 +114,10 @@ public class ServiceServiceByApiServerImpl implements ServiceService {
                     service.setNamespace(MCP_SIMULATE_NS);
                     service.setName(StringUtils.join(r.getName(), Separators.DOT, r.getType()));
                     service.setProtocol(r.getProtocol());
-                    String[] endPoints =
-                        StringUtils.split(r.getDomain(), V1McpBridge.REGISTRY_TYPE_STATIC_DNS_SEPARATOR);
+                    String[] endPoints = new String[] {};
+                    if (StringUtils.isNotBlank(r.getDomain())) {
+                        endPoints = StringUtils.split(r.getDomain(), V1McpBridge.REGISTRY_TYPE_STATIC_DNS_SEPARATOR);
+                    }
                     service.setEndpoints(Arrays.asList(endPoints));
                     switch (r.getType()) {
                         case V1McpBridge.REGISTRY_TYPE_DNS:

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ServiceServiceByApiServerImpl.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.service;
+
+import com.alibaba.higress.sdk.constant.Separators;
+import com.alibaba.higress.sdk.model.CommonPageQuery;
+import com.alibaba.higress.sdk.model.PaginatedResult;
+import com.alibaba.higress.sdk.model.Service;
+import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
+import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1RegistryConfig;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.kubernetes.client.openapi.models.V1EndpointAddress;
+import io.kubernetes.client.openapi.models.V1Endpoints;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Service;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @author lvshui
+ * @date 2025/3/8 20:58
+ */
+@Slf4j
+public class ServiceServiceByApiServerImpl implements ServiceService {
+    public static final String MCP_SIMULATE_NS = "mcp";
+    private final KubernetesClientService kubernetesClientService;
+    private final KubernetesModelConverter kubernetesModelConverter;
+
+    public ServiceServiceByApiServerImpl(KubernetesClientService kubernetesClientService, KubernetesModelConverter kubernetesModelConverter) {
+        this.kubernetesClientService = kubernetesClientService;
+        this.kubernetesModelConverter = kubernetesModelConverter;
+    }
+
+    @SneakyThrows
+    @Override
+    public PaginatedResult<Service> list(CommonPageQuery query) {
+        List<Service> resultList = Lists.newArrayList();
+
+        List<V1Service> v1Services = kubernetesClientService.listAllServiceList();
+        List<V1Endpoints> v1Endpoints = kubernetesClientService.listAllEndPointsList();
+        final Map<String, V1Endpoints> v1EndpointsMap = Maps.newHashMap();
+        if (CollectionUtils.isNotEmpty(v1Endpoints)) {
+            Map<String, V1Endpoints> v1EndpointsMap1 = v1Endpoints.stream().collect(Collectors.toMap(
+                i -> buildMetaUniqueKey(i.getMetadata()), Function.identity(), (k1, k2) -> k1));
+            v1EndpointsMap.putAll(v1EndpointsMap1);
+        }
+
+        if (CollectionUtils.isNotEmpty(v1Services)) {
+            for (V1Service v1Service : v1Services) {
+                try {
+                    Service service = kubernetesModelConverter.v1Service2Service(v1Service);
+                    String metaUniqueKey = buildMetaUniqueKey(v1Service.getMetadata());
+                    V1Endpoints v1Endpoints1 = null;
+                    if (v1EndpointsMap.containsKey(metaUniqueKey)) {
+                        v1Endpoints1 = v1EndpointsMap.get(metaUniqueKey);
+                    }
+                    if (Objects.nonNull(v1Endpoints1) && CollectionUtils.isNotEmpty(v1Endpoints1.getSubsets())) {
+                        try {
+                            List<String> ipList = v1Endpoints1.getSubsets().stream()
+                                .filter(Objects::nonNull)
+                                .map(v1Subset -> {
+                                    if (v1Subset.getAddresses() != null) {
+                                        return v1Subset.getAddresses().stream().map(V1EndpointAddress::getIp).collect(Collectors.toList());
+                                    }
+                                    return null;
+                                })
+                                .filter(CollectionUtils::isNotEmpty)
+                                .flatMap(List::stream)
+                                .collect(Collectors.toList());
+                            service.setEndpoints(ipList);
+                        } catch (Exception e) {
+                            log.error("deal service endpoints appear error. ", e);
+                        }
+                    }
+                    resultList.add(service);
+                } catch (Exception e) {
+                    log.error("deal service appear error. ", e);
+                }
+            }
+        }
+
+        List<V1McpBridge> v1McpBridges = kubernetesClientService.listMcpBridge();
+        if (CollectionUtils.isNotEmpty(v1McpBridges)) {
+            List<Service> externalServiceList = v1McpBridges.stream()
+                .map(i -> {
+                    List<V1RegistryConfig> registries = i.getSpec().getRegistries();
+                    if (CollectionUtils.isEmpty(registries)) {
+                        return null;
+                    }
+                    return registries.stream()
+                        .map(r -> {
+                            Service service = new Service();
+                            service.setNamespace(MCP_SIMULATE_NS);
+                            service.setName(StringUtils.join(r.getName(), Separators.DOT, r.getType()));
+                            service.setType(r.getType());
+                            service.setProtocol(r.getProtocol());
+                            String[] endPoints = StringUtils.split(r.getDomain(), V1McpBridge.REGISTRY_TYPE_STATIC_DNS_SEPARATOR);
+                            service.setEndpoints(Arrays.asList(endPoints));
+                            switch (r.getType()) {
+                                case V1McpBridge.REGISTRY_TYPE_DNS:
+                                    service.setPort(r.getPort());
+                                    return service;
+                                case V1McpBridge.REGISTRY_TYPE_STATIC:
+                                    service.setPort(V1McpBridge.STATIC_PORT);
+                                    return service;
+                                default:
+                                    return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+                })
+                .filter(CollectionUtils::isNotEmpty)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+            if (CollectionUtils.isNotEmpty(externalServiceList)) {
+                resultList.addAll(externalServiceList);
+            }
+
+        }
+        resultList.sort(Comparator.comparing(Service::getNamespace).thenComparing(Service::getName)
+            .thenComparing(Service::getPort));
+
+        return PaginatedResult.createFromFullList(resultList, query);
+    }
+
+    private String buildMetaUniqueKey(V1ObjectMeta metadata) {
+        return StringUtils.join(metadata.getNamespace(), ".", metadata.getName());
+    }
+}

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesClientService.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesClientService.java
@@ -12,6 +12,28 @@
  */
 package com.alibaba.higress.sdk.service.kubernetes;
 
+import static com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil.buildDomainLabelSelector;
+import static com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil.buildLabelSelector;
+import static com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil.joinLabelSelectors;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.TypeReference;
 import com.alibaba.higress.sdk.config.HigressServiceConfig;
@@ -30,6 +52,7 @@ import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPluginLis
 import com.alibaba.higress.sdk.service.kubernetes.model.IstioEndpointShard;
 import com.alibaba.higress.sdk.service.kubernetes.model.RegistryzService;
 import com.google.common.net.HttpHeaders;
+
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -60,27 +83,6 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Predicate;
-
-import static com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil.buildDomainLabelSelector;
-import static com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil.buildLabelSelector;
-import static com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil.joinLabelSelectors;
 
 @Slf4j
 public class KubernetesClientService {
@@ -227,8 +229,7 @@ public class KubernetesClientService {
             }
             String responseString = new String(response.body().bytes());
             if (StringUtils.isNotEmpty(responseString)) {
-                return JSON.parseObject(responseString, new TypeReference<>() {
-                });
+                return JSON.parseObject(responseString, new TypeReference<>() {});
             }
         }
         return null;
@@ -260,7 +261,8 @@ public class KubernetesClientService {
 
     public List<V1Service> listAllServiceList() throws ApiException {
         CoreV1Api coreV1Api = new CoreV1Api(client);
-        V1ServiceList v1ServiceList = coreV1Api.listServiceForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
+        V1ServiceList v1ServiceList =
+            coreV1Api.listServiceForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
         if (Objects.isNull(v1ServiceList)) {
             return Collections.emptyList();
         }
@@ -275,7 +277,8 @@ public class KubernetesClientService {
     @SneakyThrows
     public List<V1Endpoints> listAllEndPointsList() {
         CoreV1Api coreV1Api = new CoreV1Api(client);
-        V1EndpointsList v1EndpointsList = coreV1Api.listEndpointsForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
+        V1EndpointsList v1EndpointsList =
+            coreV1Api.listEndpointsForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
         if (Objects.isNull(v1EndpointsList)) {
             return Collections.emptyList();
         }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesClientService.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesClientService.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import com.google.common.collect.Lists;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -52,6 +51,7 @@ import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPluginList;
 import com.alibaba.higress.sdk.service.kubernetes.model.IstioEndpointShard;
 import com.alibaba.higress.sdk.service.kubernetes.model.RegistryzService;
+import com.google.common.collect.Lists;
 import com.google.common.net.HttpHeaders;
 
 import io.kubernetes.client.common.KubernetesObject;
@@ -127,6 +127,9 @@ public class KubernetesClientService {
     @Getter
     private boolean ingressV1Supported;
 
+    @Getter
+    private final String clusterDomainSuffix;
+
     public KubernetesClientService(HigressServiceConfig config) throws IOException {
         validateConfig(config);
 
@@ -143,6 +146,7 @@ public class KubernetesClientService {
         this.isIngressWatched = buildIsIngressWatchedPredicate(this.controllerWatchedIngressClassName);
         this.defaultIngressClass = StringUtils.firstNonEmpty(this.controllerWatchedIngressClassName,
             HigressConstants.CONTROLLER_INGRESS_CLASS_NAME_DEFAULT);
+        this.clusterDomainSuffix = config.getClusterDomainSuffix();
 
         if (inClusterMode) {
             client = ClientBuilder.cluster().build();
@@ -230,7 +234,8 @@ public class KubernetesClientService {
             }
             String responseString = new String(response.body().bytes());
             if (StringUtils.isNotEmpty(responseString)) {
-                return JSON.parseObject(responseString, new TypeReference<Map<String, Map<String, IstioEndpointShard>>>() {});
+                return JSON.parseObject(responseString,
+                    new TypeReference<Map<String, Map<String, IstioEndpointShard>>>() {});
             }
         }
         return null;

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -1622,8 +1622,6 @@ public class KubernetesModelConverter {
             result.setVersion(Integer.valueOf(v1Service.getMetadata().getResourceVersion()));
         }
         result.setEndpoints(spec.getClusterIPs());
-        result.setType("Kubernetes");
-
         return result;
     }
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -12,6 +12,69 @@
  */
 package com.alibaba.higress.sdk.service.kubernetes;
 
+import com.alibaba.higress.sdk.constant.CommonKey;
+import com.alibaba.higress.sdk.constant.HigressConstants;
+import com.alibaba.higress.sdk.constant.KubernetesConstants;
+import com.alibaba.higress.sdk.constant.Separators;
+import com.alibaba.higress.sdk.exception.BusinessException;
+import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.Domain;
+import com.alibaba.higress.sdk.model.Route;
+import com.alibaba.higress.sdk.model.Service;
+import com.alibaba.higress.sdk.model.ServiceSource;
+import com.alibaba.higress.sdk.model.TlsCertificate;
+import com.alibaba.higress.sdk.model.WasmPlugin;
+import com.alibaba.higress.sdk.model.WasmPluginInstance;
+import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
+import com.alibaba.higress.sdk.model.ai.AiRoute;
+import com.alibaba.higress.sdk.model.route.CorsConfig;
+import com.alibaba.higress.sdk.model.route.Header;
+import com.alibaba.higress.sdk.model.route.HeaderControlConfig;
+import com.alibaba.higress.sdk.model.route.HeaderControlStageConfig;
+import com.alibaba.higress.sdk.model.route.KeyedRoutePredicate;
+import com.alibaba.higress.sdk.model.route.ProxyNextUpstreamConfig;
+import com.alibaba.higress.sdk.model.route.RewriteConfig;
+import com.alibaba.higress.sdk.model.route.RoutePredicate;
+import com.alibaba.higress.sdk.model.route.RoutePredicateTypeEnum;
+import com.alibaba.higress.sdk.model.route.UpstreamService;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridgeSpec;
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1RegistryConfig;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.FailStrategy;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.ImagePullPolicy;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.MatchRule;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.PluginPhase;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPluginSpec;
+import com.alibaba.higress.sdk.util.MapUtil;
+import com.alibaba.higress.sdk.util.TypeUtil;
+import com.google.common.base.Splitter;
+import com.google.gson.Gson;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1HTTPIngressPath;
+import io.kubernetes.client.openapi.models.V1HTTPIngressRuleValue;
+import io.kubernetes.client.openapi.models.V1Ingress;
+import io.kubernetes.client.openapi.models.V1IngressBackend;
+import io.kubernetes.client.openapi.models.V1IngressRule;
+import io.kubernetes.client.openapi.models.V1IngressSpec;
+import io.kubernetes.client.openapi.models.V1IngressTLS;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1TypedLocalObjectReference;
+import io.kubernetes.client.util.Strings;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.asn1.x509.GeneralName;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.security.auth.x500.X500Principal;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -35,70 +98,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-import javax.security.auth.x500.X500Principal;
-
-import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.ImagePullPolicy;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.asn1.x509.GeneralName;
-
-import com.alibaba.higress.sdk.constant.CommonKey;
-import com.alibaba.higress.sdk.constant.HigressConstants;
-import com.alibaba.higress.sdk.constant.KubernetesConstants;
-import com.alibaba.higress.sdk.constant.Separators;
-import com.alibaba.higress.sdk.exception.BusinessException;
-import com.alibaba.higress.sdk.exception.ValidationException;
-import com.alibaba.higress.sdk.model.Domain;
-import com.alibaba.higress.sdk.model.Route;
-import com.alibaba.higress.sdk.model.ServiceSource;
-import com.alibaba.higress.sdk.model.TlsCertificate;
-import com.alibaba.higress.sdk.model.WasmPlugin;
-import com.alibaba.higress.sdk.model.WasmPluginInstance;
-import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
-import com.alibaba.higress.sdk.model.ai.AiRoute;
-import com.alibaba.higress.sdk.model.route.CorsConfig;
-import com.alibaba.higress.sdk.model.route.Header;
-import com.alibaba.higress.sdk.model.route.HeaderControlConfig;
-import com.alibaba.higress.sdk.model.route.HeaderControlStageConfig;
-import com.alibaba.higress.sdk.model.route.KeyedRoutePredicate;
-import com.alibaba.higress.sdk.model.route.ProxyNextUpstreamConfig;
-import com.alibaba.higress.sdk.model.route.RewriteConfig;
-import com.alibaba.higress.sdk.model.route.RoutePredicate;
-import com.alibaba.higress.sdk.model.route.RoutePredicateTypeEnum;
-import com.alibaba.higress.sdk.model.route.UpstreamService;
-import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
-import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridgeSpec;
-import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1RegistryConfig;
-import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.FailStrategy;
-import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.MatchRule;
-import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.PluginPhase;
-import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
-import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPluginSpec;
-import com.alibaba.higress.sdk.util.MapUtil;
-import com.alibaba.higress.sdk.util.TypeUtil;
-import com.google.common.base.Splitter;
-import com.google.gson.Gson;
-
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
-import io.kubernetes.client.openapi.models.V1HTTPIngressPath;
-import io.kubernetes.client.openapi.models.V1HTTPIngressRuleValue;
-import io.kubernetes.client.openapi.models.V1Ingress;
-import io.kubernetes.client.openapi.models.V1IngressBackend;
-import io.kubernetes.client.openapi.models.V1IngressRule;
-import io.kubernetes.client.openapi.models.V1IngressSpec;
-import io.kubernetes.client.openapi.models.V1IngressTLS;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Secret;
-import io.kubernetes.client.openapi.models.V1TypedLocalObjectReference;
-import io.kubernetes.client.util.Strings;
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * @author CH3CHO
  */
@@ -113,6 +112,7 @@ public class KubernetesModelConverter {
     private static final Integer DEFAULT_WEIGHT = 100;
 
     private static final Gson GSON = new Gson();
+    public static final String K8S_SVC_FQDN_SUFFIX = ".svc.cluster.local";
 
     private final KubernetesClientService kubernetesClientService;
 
@@ -135,7 +135,7 @@ public class KubernetesModelConverter {
                 continue;
             }
             try {
-                supportedAnnotations.add((String)field.get(null));
+                supportedAnnotations.add((String) field.get(null));
             } catch (IllegalAccessException e) {
                 log.error("Failed to get annotation key from field: {}", field.getName(), e);
             }
@@ -683,15 +683,15 @@ public class KubernetesModelConverter {
                 continue;
             }
             if (value instanceof Map) {
-                normalizePluginInstanceConfigurations((Map<String, Object>)value);
+                normalizePluginInstanceConfigurations((Map<String, Object>) value);
             } else if (value instanceof Double d) {
                 if (d == d.intValue()) {
                     entry.setValue(d.intValue());
                 }
             } else if (value instanceof List) {
-                ((List<?>)value).forEach(v -> {
+                ((List<?>) value).forEach(v -> {
                     if (v instanceof Map) {
-                        normalizePluginInstanceConfigurations((Map<String, Object>)v);
+                        normalizePluginInstanceConfigurations((Map<String, Object>) v);
                     }
                 });
             }
@@ -788,7 +788,7 @@ public class KubernetesModelConverter {
         }
 
         boolean changed = false;
-        for (Iterator<MatchRule> it = spec.getMatchRules().listIterator(); it.hasNext();) {
+        for (Iterator<MatchRule> it = spec.getMatchRules().listIterator(); it.hasNext(); ) {
             MatchRule rule = it.next();
 
             boolean matches = true;
@@ -1585,6 +1585,22 @@ public class KubernetesModelConverter {
         }
     }
 
+    public Service v1Service2Service(V1Service v1Service) {
+        Service result = new Service();
+        String fqdn = StringUtils.join(v1Service.getMetadata().getName(), Separators.DOT, v1Service.getMetadata().getNamespace(),
+            K8S_SVC_FQDN_SUFFIX);
+        result.setName(fqdn);
+        result.setNamespace(v1Service.getMetadata().getNamespace());
+        result.setPort(v1Service.getSpec().getPorts().get(0).getPort());
+        if (StringUtils.isNotBlank(v1Service.getMetadata().getResourceVersion())) {
+            result.setVersion(Integer.valueOf(v1Service.getMetadata().getResourceVersion()));
+        }
+        result.setEndpoints(v1Service.getSpec().getClusterIPs());
+        result.setType("Kubernetes");
+
+        return result;
+    }
+
     public ServiceSource v1RegistryConfig2ServiceSource(V1RegistryConfig v1RegistryConfig) {
         ServiceSource serviceSource = new ServiceSource();
         fillServiceSourceInfo(serviceSource, v1RegistryConfig);
@@ -1633,7 +1649,7 @@ public class KubernetesModelConverter {
             return null;
         }
         V1RegistryConfig target = null;
-        for (Iterator<V1RegistryConfig> it = spec.getRegistries().iterator(); it.hasNext();) {
+        for (Iterator<V1RegistryConfig> it = spec.getRegistries().iterator(); it.hasNext(); ) {
             V1RegistryConfig registryConfig = it.next();
             if (registryConfig.getName().equals(name)) {
                 it.remove();
@@ -1709,27 +1725,27 @@ public class KubernetesModelConverter {
             || V1McpBridge.REGISTRY_TYPE_NACOS2.equals(v1RegistryConfig.getType())
             || V1McpBridge.REGISTRY_TYPE_NACOS3.equals(v1RegistryConfig.getType())) {
             v1RegistryConfig.setNacosNamespaceId(
-                (String)Optional.ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_NAMESPACE_ID)).orElse(""));
-            v1RegistryConfig.setNacosGroups((List<String>)Optional
+                (String) Optional.ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_NAMESPACE_ID)).orElse(""));
+            v1RegistryConfig.setNacosGroups((List<String>) Optional
                 .ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_NACOS_GROUPS)).orElse(new ArrayList<>()));
         } else if (V1McpBridge.REGISTRY_TYPE_ZK.equals(v1RegistryConfig.getType())) {
-            v1RegistryConfig.setZkServicesPath((List<String>)Optional
+            v1RegistryConfig.setZkServicesPath((List<String>) Optional
                 .ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_ZK_SERVICES_PATH)).orElse(new ArrayList<>()));
         } else if (V1McpBridge.REGISTRY_TYPE_CONSUL.equals(v1RegistryConfig.getType())) {
             v1RegistryConfig.setConsulDataCenter(
-                (String)Optional.ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_DATA_CENTER)).orElse(""));
+                (String) Optional.ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_DATA_CENTER)).orElse(""));
             v1RegistryConfig.setConsulServiceTag(
-                (String)Optional.ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_SERVICE_TAG)).orElse(""));
+                (String) Optional.ofNullable(properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_SERVICE_TAG)).orElse(""));
             v1RegistryConfig
-                .setConsulRefreshInterval((Integer)properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_REFRESH_INTERVAL));
+                .setConsulRefreshInterval((Integer) properties.get(V1McpBridge.REGISTRY_TYPE_CONSUL_REFRESH_INTERVAL));
         }
 
         if (V1McpBridge.MCP_SUPPORTED_REGISTRY_TYPES.contains(v1RegistryConfig.getType())) {
             v1RegistryConfig.setEnableMcpServer(
-                (Boolean)Optional.ofNullable(properties.get(V1McpBridge.ENABLE_MCP_SERVER)).orElse(Boolean.FALSE));
+                (Boolean) Optional.ofNullable(properties.get(V1McpBridge.ENABLE_MCP_SERVER)).orElse(Boolean.FALSE));
             v1RegistryConfig.setMcpServerBaseUrl(
-                (String)Optional.ofNullable(properties.get(V1McpBridge.MCP_SERVER_BASE_URL)).orElse(""));
-            v1RegistryConfig.setMcpServerExportDomains((List<String>)Optional
+                (String) Optional.ofNullable(properties.get(V1McpBridge.MCP_SERVER_BASE_URL)).orElse(""));
+            v1RegistryConfig.setMcpServerExportDomains((List<String>) Optional
                 .ofNullable(properties.get(V1McpBridge.MCP_SERVER_EXPORT_DOMAINS)).orElse(new ArrayList<>()));
         }
     }
@@ -1752,7 +1768,7 @@ public class KubernetesModelConverter {
     private static X509Certificate parseCertificateData(String certData) {
         try {
             CertificateFactory cf = CertificateFactory.getInstance("X509");
-            return (X509Certificate)cf.generateCertificate(new ByteArrayInputStream(certData.getBytes()));
+            return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certData.getBytes()));
         } catch (Exception ex) {
             log.error("Failed to parse certificate data:\n" + certData, ex);
             return null;
@@ -1789,7 +1805,7 @@ public class KubernetesModelConverter {
                 }
                 Object name = nameEntry.get(1);
                 if (name instanceof String) {
-                    domains.add((String)name);
+                    domains.add((String) name);
                 }
             }
         }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -116,9 +116,9 @@ public class KubernetesModelConverter {
     private static final V1IngressBackend DEFAULT_MCP_BRIDGE_BACKEND = new V1IngressBackend();
     private static final Set<String> SUPPORTED_ANNOTATIONS;
     private static final Integer DEFAULT_WEIGHT = 100;
+    private static final String SERVICE_FQDN_TEMPLATE = "%s.%s.svc.%s";
 
     private static final Gson GSON = new Gson();
-    public static final String K8S_SVC_FQDN_SUFFIX = ".svc.cluster.local";
 
     private final KubernetesClientService kubernetesClientService;
 
@@ -1605,8 +1605,8 @@ public class KubernetesModelConverter {
 
     public Service v1Service2Service(V1Service v1Service) {
         Service result = new Service();
-        String fqdn = StringUtils.join(v1Service.getMetadata().getName(), Separators.DOT,
-            v1Service.getMetadata().getNamespace(), K8S_SVC_FQDN_SUFFIX);
+        String fqdn = String.format(SERVICE_FQDN_TEMPLATE, v1Service.getMetadata().getName(),
+            v1Service.getMetadata().getNamespace(), kubernetesClientService.getClusterDomainSuffix());
         result.setName(fqdn);
         result.setNamespace(v1Service.getMetadata().getNamespace());
         V1ServiceSpec spec = v1Service.getSpec();

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: {{ .Values.controller.serviceName }}
             - name: HIGRESS_CONSOLE_CONTROLLER_JWT_POLICY
               value: {{ include "higress-console.controller.jwtPolicy" . }}
+            - name: CLUSTER_DOMAIN_SUFFIX
+              value: {{ .Values.global.proxy.clusterDomain }}
             {{- if $o11y.enabled }}
             - name: HIGRESS_CONSOLE_DASHBOARD_BASE_URL
               value: http://{{ include "higress-console-grafana.name" . }}.{{ .Release.Namespace }}:{{ $o11y.grafana.port }}{{ include "higress-console-grafana.path" . }}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
在 higressConfig 中增加一个参数：dependControllerApi，用于支持调整对于 组件 higress controller的依赖。默认行为保持原来的依赖关系，允许在不使用注册中心时，将其依赖关系解耦。使得它只依赖 k8s apiserver

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #505 

