### PR TITLE
feat: Support configuring multiple endpoints for custom OpenAI LLM providers

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProviderEndpoint.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProviderEndpoint.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.model.ai;
+
+import java.net.URI;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
+import com.alibaba.higress.sdk.util.ValidateUtil;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LlmProviderEndpoint {
+
+    private String protocol;
+    private String address;
+    private Integer port;
+    private String contextPath;
+
+    public void validate() {
+        if (protocol == null || protocol.isEmpty()) {
+            throw new IllegalArgumentException("Protocol cannot be null or empty.");
+        }
+        if (address == null || address.isEmpty()) {
+            throw new IllegalArgumentException("Address cannot be null or empty.");
+        }
+        if (!ValidateUtil.checkPort(port)) {
+            throw new IllegalArgumentException("Port must be a positive integer.");
+        }
+    }
+
+    public static LlmProviderEndpoint fromUri(URI uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("URI cannot be null.");
+        }
+        if (!uri.isAbsolute()) {
+            throw new IllegalArgumentException("URI must be absolute: " + uri);
+        }
+        return LlmProviderEndpoint.builder().protocol(getServiceProtocol(uri)).address(getServiceDomain(uri))
+            .port(getServicePort(uri)).contextPath(getServiceContextPath(uri)).build();
+    }
+
+    private static String getServiceDomain(URI uri) {
+        return uri.getHost();
+    }
+
+    private static int getServicePort(URI uri) {
+        if (uri.getPort() != -1) {
+            return uri.getPort();
+        }
+        String protocol = getServiceProtocol(uri);
+        switch (protocol) {
+            case V1McpBridge.PROTOCOL_HTTP:
+                return 80;
+            case V1McpBridge.PROTOCOL_HTTPS:
+                return 443;
+            default:
+                return 80;
+        }
+    }
+
+    private static String getServiceProtocol(URI uri) {
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            return V1McpBridge.PROTOCOL_HTTP;
+        }
+        switch (scheme.toLowerCase(Locale.ROOT)) {
+            case V1McpBridge.PROTOCOL_HTTP:
+            case V1McpBridge.PROTOCOL_HTTPS:
+                return scheme;
+            default:
+                return V1McpBridge.PROTOCOL_HTTP;
+        }
+    }
+
+    private static String getServiceContextPath(URI uri) {
+        String path = uri.getPath();
+        return StringUtils.firstNonEmpty(path, "/");
+    }
+}

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
@@ -42,10 +42,12 @@ import com.alibaba.higress.sdk.constant.Separators;
 import com.alibaba.higress.sdk.exception.ValidationException;
 import com.alibaba.higress.sdk.model.ServiceSource;
 import com.alibaba.higress.sdk.model.ai.LlmProvider;
+import com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint;
 import com.alibaba.higress.sdk.model.ai.LlmProviderProtocol;
 import com.alibaba.higress.sdk.model.ai.TokenFailoverConfig;
 import com.alibaba.higress.sdk.model.route.UpstreamService;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
+import com.alibaba.higress.sdk.util.ValidateUtil;
 
 abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
 
@@ -131,43 +133,68 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
     public ServiceSource buildServiceSource(String providerName, Map<String, Object> providerConfig) {
         ServiceSource serviceSource = new ServiceSource();
         serviceSource.setName(generateServiceProviderName(providerName));
-        serviceSource.setType(getServiceRegistryType(providerConfig));
-        serviceSource.setProtocol(getServiceProtocol(providerConfig));
-
-        String domain = getServiceDomain(providerConfig);
-        int port = getServicePort(providerConfig);
-        if (V1McpBridge.REGISTRY_TYPE_STATIC.equals(serviceSource.getType())) {
-            serviceSource.setDomain(domain + Separators.COLON + port);
-            serviceSource.setPort(V1McpBridge.STATIC_PORT);
-        } else {
-            serviceSource.setDomain(domain);
-            serviceSource.setPort(port);
+        List<LlmProviderEndpoint> endpoints = getProviderEndpoints(providerConfig);
+        if (CollectionUtils.isEmpty(endpoints)) {
+            throw new ValidationException("No endpoints found for provider: " + providerName);
         }
+        String type = null, protocol = null, contextPath = null;
+        List<String> domains = new ArrayList<>(endpoints.size());
+        Integer port = null;
+        for (LlmProviderEndpoint endpoint : endpoints) {
+            if (endpoint == null) {
+                continue;
+            }
+            endpoint.validate();
 
+            if (protocol != null && !protocol.equals(endpoint.getProtocol())) {
+                throw new ValidationException("Multiple protocols found in the endpoints of provider: " + providerName);
+            }
+            protocol = endpoint.getProtocol();
+
+            if (contextPath != null && !contextPath.equals(endpoint.getContextPath())) {
+                throw new ValidationException(
+                    "Multiple context paths found in the endpoints of provider: " + providerName);
+            }
+            contextPath = endpoint.getContextPath();
+
+            String endpointSourceType;
+            if (ValidateUtil.checkIpAddress(endpoint.getAddress())) {
+                endpointSourceType = V1McpBridge.REGISTRY_TYPE_STATIC;
+                domains.add(endpoint.getAddress() + Separators.COLON + endpoint.getPort());
+                port = V1McpBridge.STATIC_PORT;
+            } else {
+                if (endpoints.size() > 1) {
+                    throw new ValidationException(
+                        "Multiple endpoints only work with static IP addresses, provider: " + providerName);
+                }
+                port = endpoint.getPort();
+                endpointSourceType = V1McpBridge.REGISTRY_TYPE_DNS;
+                domains.add(endpoint.getAddress());
+            }
+            if (type != null && !type.equals(endpointSourceType)) {
+                throw new ValidationException("Multiple types of endpoints found for provider: " + providerName);
+            }
+            type = endpointSourceType;
+        }
+        serviceSource.setType(type);
+        serviceSource.setProtocol(protocol);
+        serviceSource.setDomain(String.join(Separators.COMMA, domains));
+        serviceSource.setPort(port);
         return serviceSource;
     }
 
     @Override
     public UpstreamService buildUpstreamService(String providerName, Map<String, Object> providerConfig) {
+        ServiceSource serviceSource = buildServiceSource(providerName, providerConfig);
+
         UpstreamService service = new UpstreamService();
-        String registryType = getServiceRegistryType(providerConfig);
-        service.setName(generateServiceProviderName(providerName) + Separators.DOT + registryType);
-        if (V1McpBridge.REGISTRY_TYPE_STATIC.equals(registryType)) {
-            service.setPort(V1McpBridge.STATIC_PORT);
-        } else {
-            service.setPort(getServicePort(providerConfig));
-        }
+        service.setName(serviceSource.getName() + Separators.DOT + serviceSource.getType());
+        service.setPort(serviceSource.getPort());
         service.setWeight(100);
         return service;
     }
 
-    protected abstract String getServiceRegistryType(Map<String, Object> providerConfig);
-
-    protected abstract String getServiceDomain(Map<String, Object> providerConfig);
-
-    protected abstract int getServicePort(Map<String, Object> providerConfig);
-
-    protected abstract String getServiceProtocol(Map<String, Object> providerConfig);
+    protected abstract List<LlmProviderEndpoint> getProviderEndpoints(Map<String, Object> providerConfig);
 
     protected static int getIntConfig(Map<String, Object> providerConfig, String key) {
         Object serverPortObj = providerConfig.get(key);

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AzureLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AzureLlmProviderHandler.java
@@ -14,6 +14,8 @@ package com.alibaba.higress.sdk.service.ai;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -21,6 +23,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint;
 import com.alibaba.higress.sdk.model.ai.LlmProviderType;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
 
@@ -50,49 +53,9 @@ public class AzureLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    protected String getServiceRegistryType(Map<String, Object> providerConfig) {
-        return V1McpBridge.REGISTRY_TYPE_DNS;
-    }
-
-    @Override
-    protected String getServiceDomain(Map<String, Object> providerConfig) {
+    protected List<LlmProviderEndpoint> getProviderEndpoints(Map<String, Object> providerConfig) {
         URI uri = getServiceUri(providerConfig);
-        return uri.getHost();
-    }
-
-    @Override
-    protected int getServicePort(Map<String, Object> providerConfig) {
-        URI uri = getServiceUri(providerConfig);
-        String scheme = uri.getScheme();
-        if (scheme == null) {
-            return 80;
-        }
-        scheme = scheme.toLowerCase(Locale.ROOT);
-        switch (scheme) {
-            case V1McpBridge.PROTOCOL_HTTP:
-                return 80;
-            case V1McpBridge.PROTOCOL_HTTPS:
-                return 443;
-            default:
-                return 80;
-        }
-    }
-
-    @Override
-    protected String getServiceProtocol(Map<String, Object> providerConfig) {
-        URI uri = getServiceUri(providerConfig);
-        String scheme = uri.getScheme();
-        if (scheme == null) {
-            return V1McpBridge.PROTOCOL_HTTP;
-        }
-        scheme = scheme.toLowerCase(Locale.ROOT);
-        switch (scheme) {
-            case V1McpBridge.PROTOCOL_HTTP:
-            case V1McpBridge.PROTOCOL_HTTPS:
-                return scheme;
-            default:
-                return V1McpBridge.PROTOCOL_HTTP;
-        }
+        return Collections.singletonList(LlmProviderEndpoint.fromUri(uri));
     }
 
     private static URI getServiceUri(Map<String, Object> providerConfig) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/BedrockLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/BedrockLlmProviderHandler.java
@@ -12,12 +12,15 @@
  */
 package com.alibaba.higress.sdk.service.ai;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint;
 import com.alibaba.higress.sdk.model.ai.LlmProviderType;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
 
@@ -57,26 +60,12 @@ public class BedrockLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    protected String getServiceRegistryType(Map<String, Object> providerConfig) {
-        return V1McpBridge.REGISTRY_TYPE_DNS;
-    }
-
-    @Override
-    protected String getServiceDomain(Map<String, Object> providerConfig) {
+    protected List<LlmProviderEndpoint> getProviderEndpoints(Map<String, Object> providerConfig) {
         String region = MapUtils.getString(providerConfig, AWS_REGION_KEY);
         if (StringUtils.isEmpty(region)) {
             throw new ValidationException(AWS_REGION_KEY + " cannot be empty.");
         }
-        return String.format(DOMAIN_FORMAT, region);
-    }
-
-    @Override
-    protected int getServicePort(Map<String, Object> providerConfig) {
-        return 443;
-    }
-
-    @Override
-    protected String getServiceProtocol(Map<String, Object> providerConfig) {
-        return V1McpBridge.PROTOCOL_HTTPS;
+        String domain = String.format(DOMAIN_FORMAT, region);
+        return Collections.singletonList(new LlmProviderEndpoint(V1McpBridge.PROTOCOL_HTTPS, domain, 443, "/"));
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/DefaultLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/DefaultLlmProviderHandler.java
@@ -12,9 +12,11 @@
  */
 package com.alibaba.higress.sdk.service.ai;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
-import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
+import com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint;
 
 class DefaultLlmProviderHandler extends AbstractLlmProviderHandler {
 
@@ -22,12 +24,18 @@ class DefaultLlmProviderHandler extends AbstractLlmProviderHandler {
     private final String domain;
     private final int port;
     private final String protocol;
+    private final String contextPath;
 
     DefaultLlmProviderHandler(String type, String domain, int port, String protocol) {
+        this(type, domain, port, protocol, "/");
+    }
+
+    DefaultLlmProviderHandler(String type, String domain, int port, String protocol, String contextPath) {
         this.type = type;
         this.domain = domain;
         this.port = port;
         this.protocol = protocol;
+        this.contextPath = contextPath;
     }
 
     @Override
@@ -36,22 +44,7 @@ class DefaultLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    protected String getServiceRegistryType(Map<String, Object> providerConfig) {
-        return V1McpBridge.REGISTRY_TYPE_DNS;
-    }
-
-    @Override
-    protected String getServiceDomain(Map<String, Object> providerConfig) {
-        return domain;
-    }
-
-    @Override
-    protected int getServicePort(Map<String, Object> providerConfig) {
-        return port;
-    }
-
-    @Override
-    protected String getServiceProtocol(Map<String, Object> providerConfig) {
-        return protocol;
+    protected List<LlmProviderEndpoint> getProviderEndpoints(Map<String, Object> providerConfig) {
+        return Collections.singletonList(new LlmProviderEndpoint(protocol, domain, port, contextPath));
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
@@ -147,10 +147,8 @@ public class LlmProviderServiceImpl implements LlmProviderService {
         if (!found) {
             providers.add(providerConfig);
         }
-        wasmPluginInstanceService.addOrUpdate(instance);
 
         ServiceSource serviceSource = handler.buildServiceSource(provider.getName(), providerConfig);
-        serviceSourceService.addOrUpdate(serviceSource);
 
         UpstreamService upstreamService = handler.buildUpstreamService(provider.getName(), providerConfig);
         WasmPluginInstance serviceInstance = new WasmPluginInstance();
@@ -160,6 +158,10 @@ public class LlmProviderServiceImpl implements LlmProviderService {
         serviceInstance.setEnabled(true);
         serviceInstance.setInternal(true);
         serviceInstance.setConfigurations(MapUtil.of(ACTIVE_PROVIDER_ID, provider.getName()));
+
+        // Perform all the updates here just to avoid possible errors in resource building.
+        wasmPluginInstanceService.addOrUpdate(instance);
+        serviceSourceService.addOrUpdate(serviceSource);
         wasmPluginInstanceService.addOrUpdate(serviceInstance);
 
         return query(provider.getName());

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OllamaLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OllamaLlmProviderHandler.java
@@ -12,12 +12,15 @@
  */
 package com.alibaba.higress.sdk.service.ai;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint;
 import com.alibaba.higress.sdk.model.ai.LlmProviderType;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
 import com.alibaba.higress.sdk.util.ValidateUtil;
@@ -55,27 +58,19 @@ public class OllamaLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
-    protected String getServiceRegistryType(Map<String, Object> providerConfig) {
-        String serviceDomain = getServiceDomain(providerConfig);
-        if (StringUtils.isEmpty(serviceDomain)) {
-            return V1McpBridge.REGISTRY_TYPE_DNS;
-        }
-        if (ValidateUtil.checkIpAddress(serviceDomain)) {
-            return V1McpBridge.REGISTRY_TYPE_STATIC;
-        }
-        return V1McpBridge.REGISTRY_TYPE_DNS;
+    protected List<LlmProviderEndpoint> getProviderEndpoints(Map<String, Object> providerConfig) {
+        return Collections.singletonList(new LlmProviderEndpoint(getServiceProtocol(providerConfig),
+            getServiceDomain(providerConfig), getServicePort(providerConfig), "/"));
     }
 
-    @Override
-    protected String getServiceDomain(Map<String, Object> providerConfig) {
+    private String getServiceDomain(Map<String, Object> providerConfig) {
         if (MapUtils.isEmpty(providerConfig)) {
             return "";
         }
         return (String)providerConfig.getOrDefault(SERVER_HOST_KEY, "");
     }
 
-    @Override
-    protected int getServicePort(Map<String, Object> providerConfig) {
+    private int getServicePort(Map<String, Object> providerConfig) {
         if (MapUtils.isEmpty(providerConfig)) {
             return DEFAULT_PORT;
         }
@@ -87,8 +82,7 @@ public class OllamaLlmProviderHandler extends AbstractLlmProviderHandler {
         }
     }
 
-    @Override
-    protected String getServiceProtocol(Map<String, Object> providerConfig) {
+    private String getServiceProtocol(Map<String, Object> providerConfig) {
         return V1McpBridge.PROTOCOL_HTTP;
     }
 }

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -259,6 +259,10 @@
         "ollamaServerHostRequired": "Please input Ollama service host",
         "ollamaServerPortRequired": "Please input Ollama service port",
         "openaiCustomUrlRequired": "Please input a valid custom OpenAI service base URL",
+        "invalidOpenaiCustomUrl": "Bad URL format: ",
+        "openaiCustomUrlMultipleValuesWithIpOnly": "Only URLs with IP and port are supported when specifying multiple custom OpenAI service base URLs",
+        "openaiCustomUrlInconsistentProtocols": "Inconsistent protocols found in custom OpenAI service base URLs",
+        "openaiCustomUrlInconsistentContextPaths": "Inconsistent paths found in custom OpenAI service base URLs",
         "awsRegionRequired": "Please input AWS Region",
         "awsAccessKeyRequired": "Please input AWS Access Key ID",
         "awsSecretKeyRequired": "Please input AWS Secret Access Key"

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -259,6 +259,10 @@
         "ollamaServerHostRequired": "请输入 Ollama 服务主机名",
         "ollamaServerPortRequired": "请输入 Ollama 服务端口",
         "openaiCustomUrlRequired": "请输入合法的自定义 OpenAI 服务 BaseURL",
+        "invalidOpenaiCustomUrl": "URL 格式不正确：",
+        "openaiCustomUrlMultipleValuesWithIpOnly": "仅支持指定多个使用 IP 和端口的自定义 OpenAI 服务 BaseURL",
+        "openaiCustomUrlInconsistentProtocols": "各个自定义 OpenAI 服务 BaseURL 所使用的协议不一致",
+        "openaiCustomUrlInconsistentContextPaths": "各个自定义 OpenAI 服务 BaseURL 所使用的路径不一致",
         "awsRegionRequired": "请输入 AWS Region",
         "awsAccessKeyRequired": "请输入 AWS Access Key ID",
         "awsSecretKeyRequired": "请输入 AWS Secret Access Key"

--- a/frontend/src/pages/ai/configs.tsx
+++ b/frontend/src/pages/ai/configs.tsx
@@ -35,8 +35,18 @@ export const aiModelProviders = [
       return !record.rawConfigs || !record.rawConfigs.openaiCustomUrl;
     },
     getProviderEndpoints: (record) => {
-      const customUrl = record.rawConfigs && record.rawConfigs.openaiCustomUrl;
-      return customUrl && [customUrl] || null;
+      if (!record.rawConfigs) {
+        return null;
+      }
+      const customUrl = record.rawConfigs.openaiCustomUrl;
+      if (!customUrl) {
+        return null;
+      }
+      const customUrls = [customUrl];
+      if (Array.isArray(record.rawConfigs.openaiExtraCustomUrls)) {
+        customUrls.push(...record.rawConfigs.openaiExtraCustomUrls)
+      }
+      return customUrls;
     },
   },
   {

--- a/frontend/src/pages/ai/provider.tsx
+++ b/frontend/src/pages/ai/provider.tsx
@@ -86,7 +86,8 @@ const LlmProviderList: React.FC = () => {
           }
           value = [providerConfig.serviceAddress];
         }
-        return value.map((token) => <span>{token}</span>).reduce((prev, curr) => [prev, <br />, curr]);
+        return value.map((endpoint) => <span key={endpoint}>{endpoint}</span>)
+          .reduce((prev, curr) => [prev, <br key={`${prev.key}_br_${curr.key}`} />, curr]);
       },
     },
     {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

1. Support configuring multiple endpoints for custom OpenAI LLM providers.
    1. Only URLs with IP+Port are supported when configuring multiple endpoints.
    2. All the URLs must have the same protocol and path.
3. Refactor LlmProvider endpoint management logic.

![image](https://github.com/user-attachments/assets/b3ca3a9a-055c-436e-bdd3-017fe641dec1)

![image](https://github.com/user-attachments/assets/03ae757e-fb42-4129-a510-89d856c5899a)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
