### PR TITLE
feat: Plugin server supports k8s deployment and configures the default download URL of the plugin

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
               value: "{{ .Values.swagger.enabled }}"
             - name: SPRINGDOC_SWAGGER_UI_ENABLED
               value: "{{ .Values.swagger.enabled }}"
+            {{- if .Values.global.enablePluginServer }}
+            - name: HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN
+              value: "{{ .Values.pluginServer.UrlPattern }}"
+            {{- end }}
             {{- if .Values.podEnvs }}
             {{- range $key, $val := .Values.podEnvs }}
             - name: {{ $key }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               value: "{{ .Values.swagger.enabled }}"
             - name: SPRINGDOC_SWAGGER_UI_ENABLED
               value: "{{ .Values.swagger.enabled }}"
-            {{- if .Values.global.enablePluginServer }}
+            {{- if and .Values.global.enablePluginServer (not (hasKey .Values.podEnvs "HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN"))}}
             - name: HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN
               value: "{{ .Values.pluginServer.UrlPattern }}"
             {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -127,3 +127,6 @@ o11y:
 
 pvc:
   __placeholder__: true
+
+pluginServer:
+  UrlPattern: "http://higress-plugin-server.higress-system.svc/plugins/${name}/${version}/plugin.wasm"


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
Plugin server supports k8s one-click deployment and configures the default download URL of the plugin

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes [#2232](https://github.com/alibaba/higress/issues/2232), [#2280](https://github.com/alibaba/higress/issues/2280),[#2312](https://github.com/alibaba/higress/issues/2312)

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
