### PR TITLE
change rwxSupported's default value to false

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,7 +50,7 @@ global:
       securityContext: {}
 
   pvc:
-    rwxSupported: true
+    rwxSupported: false
 
 replicaCount: 1
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Changing the default PVC access mode to `ReadWriteOnce`, which is more commonly used and sufficient for default setups. Prometheus and Grafana run with a single replica by default, so `ReadWriteMany` is unnecessary in most cases. Users who need multiple replicas can switch to `ReadWriteMany` if required.

fixes: https://github.com/alibaba/higress/issues/204
Related PR: https://github.com/higress-group/higress-group.github.io/pull/437

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
