### PR TITLE
feat: Support configuring multiple model mapping rules for an AI roue upstream

### DIFF
--- a/frontend/src/interfaces/ai-route.ts
+++ b/frontend/src/interfaces/ai-route.ts
@@ -23,4 +23,5 @@ export interface AiRouteFallbackConfig {
 export interface AiUpstream {
   provider: string;
   weight?: number;
+  modelMapping?: Record<string, string>;
 }

--- a/frontend/src/interfaces/route.ts
+++ b/frontend/src/interfaces/route.ts
@@ -157,3 +157,9 @@ export const fetchPluginsByRoute = async (record: Route): Promise<WasmPluginData
   data[record.name] = data[record.name] ? data[record.name].concat(builtInPlugins) : builtInPlugins;
   return data[record.name] || [];
 };
+
+export enum MatchType {
+  EQUAL = "EQUAL", // 精确匹配
+  PRE = "PRE", // 前缀匹配
+  REGULAR = "REGULAR", // 正则匹配
+}

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -89,6 +89,15 @@
         "badWeightSum": "The sum of all service weights must be 100.",
         "noUpstreams": "At least one target service is required."
       },
+      "modelMapping": {
+        "key": "Model Name Match Key",
+        "target": "Mapped Model Name",
+        "mappingTargetPlaceholder_full": "If left empty, the model name in the request will be used.",
+        "mappingTargetPlaceholder_simple": "Empty means unchanged.",
+        "add": "Add New Mapping",
+        "default": "Default Model Name",
+        "advanced": "Model Name Mapping"
+      },
       "modelMatchType": "Model Match Type",
       "modelMatchValue": "Match Value",
       "byModelName": "By model name",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -89,6 +89,15 @@
         "badWeightSum": "所有服务的权重总和必须为100",
         "noUpstreams": "至少要配置一个目标AI服务"
       },
+      "modelMapping": {
+        "key": "模型名称匹配条件",
+        "target": "映射后的模型名称",
+        "mappingTargetPlaceholder_full": "留空表示使用请求中的模型名称",
+        "mappingTargetPlaceholder_simple": "留空表示不变",
+        "add": "添加模型名称映射规则",
+        "default": "默认模型名称",
+        "advanced": "模型名称映射规则"
+      },
       "modelMatchType": "匹配方式",
       "modelMatchValue": "匹配条件",
       "byModelName": "按模型名称",

--- a/frontend/src/pages/ai/components/RouteForm/Components.tsx
+++ b/frontend/src/pages/ai/components/RouteForm/Components.tsx
@@ -1,5 +1,9 @@
-import { RedoOutlined } from '@ant-design/icons';
-import { Button, Form } from 'antd';
+import { MatchType } from '@/interfaces/route';
+import { FormOutlined, MinusCircleOutlined, PlusOutlined, RedoOutlined } from '@ant-design/icons';
+import { AutoComplete, Button, Empty, Form, Input, Popover, Select } from 'antd';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { modelMapping2String, string2ModelMapping } from './util';
 
 // 刷新按钮
 const RedoOutlinedBtn = (props) => {
@@ -28,6 +32,227 @@ const HistoryButton = (props) => {
   )
 };
 
+// 模型映射编辑器
+const ModelMappingEditor = (props) => {
+  const { t } = useTranslation();
+  const { value, style, options, onChange } = props;
+  const [form] = Form.useForm();
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  interface ModelMapping {
+    key: string;
+    matchType: MatchType;
+    target: string;
+  }
+
+  const handleChange = (e) => {
+    onChange && onChange(e);
+  };
+
+  const onConfirm = () => {
+    downloadFromPopoverForm();
+    closePopover();
+  };
+
+  const onCancel = () => {
+    closePopover();
+  };
+
+  const closePopover = () => {
+    setPopoverOpen(false);
+  };
+
+  const onPopoverOpenChange = (open) => {
+    setPopoverOpen(open);
+    open && uploadToPopoverForm();
+  };
+
+  const uploadToPopoverForm = () => {
+    const modelMappingObj = string2ModelMapping(value);
+    const formValues = {
+      defaultMapping: '',
+      modelMappings: new Array<ModelMapping>(),
+    }
+    for (const [key, target] of Object.entries(modelMappingObj)) {
+      if (!key) {
+        continue;
+      }
+      if (key === '*') {
+        formValues.defaultMapping = target;
+      } else if (key.endsWith('*')) {
+        const prefix = key.replace(/\*+$/, '');
+        formValues.modelMappings.push({
+          key: prefix,
+          matchType: MatchType.PRE,
+          target,
+        });
+      } else {
+        formValues.modelMappings.push({
+          key,
+          matchType: MatchType.EQUAL,
+          target,
+        });
+      }
+    }
+    form.setFieldsValue(formValues);
+  };
+
+  const downloadFromPopoverForm = () => {
+    form.validateFields().then((values) => {
+      const modelMappingObj: Record<string, string> = {};
+      const modelMappings = values.modelMappings || [];
+      for (const modelMapping of modelMappings) {
+        if (!modelMapping.key || !modelMapping.matchType) {
+          continue;
+        }
+        switch (modelMapping.matchType) {
+          case MatchType.EQUAL:
+            modelMappingObj[modelMapping.key] = modelMapping.target || '';
+            break;
+          case MatchType.PRE:
+            modelMappingObj[modelMapping.key + '*'] = modelMapping.target || '';
+            break;
+        }
+        if (values.defaultMapping) {
+          modelMappingObj['*'] = values.defaultMapping;
+        }
+        handleChange(modelMapping2String(modelMappingObj));
+      }
+    });
+  };
+
+  const popoverContent = (
+    <Form form={form} layout="vertical">
+      <Form.Item
+        label={t('aiRoute.routeForm.modelMapping.default')}
+        name="defaultMapping"
+      >
+        <Input
+          allowClear
+          maxLength={63}
+          placeholder={t('aiRoute.routeForm.modelMapping.mappingTargetPlaceholder_full') || ''}
+        />
+      </Form.Item>
+      <Form.Item label={t('aiRoute.routeForm.modelMapping.advanced')}>
+        <Form.List name="modelMappings" initialValue={[{}]} >
+          {(fields, { add, remove }) => (
+            <>
+              <div className="ant-table ant-table-small">
+                <div className="ant-table-content">
+                  <table style={{ tableLayout: "auto" }}>
+                    <thead className="ant-table-thead">
+                      <tr>
+                        <th className="ant-table-cell" style={{ width: "150px" }} >{t("aiRoute.routeForm.modelMapping.key")}</th>
+                        <th className="ant-table-cell" style={{ width: "150px" }} >{t("aiRoute.routeForm.modelMatchType")}</th>
+                        <th className="ant-table-cell" style={{ width: "150px" }} >{t("aiRoute.routeForm.modelMapping.target")}</th>
+                        <th className="ant-table-cell" style={{ width: "60px" }} >{t("misc.action")}</th>
+                      </tr>
+                    </thead>
+                    <tbody className="ant-table-tbody">
+                      {
+                        fields.length && fields.map(({ key, name, ...restField }, index) => (
+                          <tr className="ant-table-row ant-table-row-level-0" key={key}>
+                            <td className="ant-table-cell">
+                              <Form.Item
+                                {...restField}
+                                name={[name, 'key']}
+                                noStyle
+                              >
+                                <Input allowClear />
+                              </Form.Item>
+                            </td>
+                            <td className="ant-table-cell">
+                              <Form.Item
+                                name={[name, 'matchType']}
+                                noStyle
+                              >
+                                <Select>
+                                  {
+                                    [
+                                      { name: MatchType.EQUAL, label: t("route.matchTypes.EQUAL") }, // 精确匹配
+                                      { name: MatchType.PRE, label: t("route.matchTypes.PRE") }, // 前缀匹配
+                                    ].map((item) => (<Select.Option key={item.name} value={item.name}>{item.label} </Select.Option>))
+                                  }
+                                </Select>
+                              </Form.Item>
+                            </td>
+                            <td className="ant-table-cell">
+                              <Form.Item
+                                {...restField}
+                                name={[name, 'target']}
+                                noStyle
+                              >
+                                <Input allowClear placeholder={t('aiRoute.routeForm.modelMapping.mappingTargetPlaceholder_simple') || ''} />
+                              </Form.Item>
+                            </td>
+                            <td className="ant-table-cell">
+                              <MinusCircleOutlined onClick={() => remove(name)} />
+                            </td>
+                          </tr>
+                        )) || (
+                          <tr className="ant-table-row ant-table-row-level-0">
+                            <td className="ant-table-cell" colSpan={4}>
+                              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} style={{ margin: 0 }} />
+                            </td>
+                          </tr>
+                        )
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+              <div>
+                <Button type="dashed" block icon={<PlusOutlined />} onClick={() => add()}>{t("aiRoute.routeForm.modelMapping.add")}</Button>
+              </div>
+            </>
+          )}
+        </Form.List>
+      </Form.Item>
+      <Form.Item
+        style={{
+          marginBottom: 0,
+          textAlign: 'right',
+        }}
+        wrapperCol={{ span: 24 }}
+      >
+        <Button type="primary" style={{ marginRight: '0.5rem' }} onClick={onConfirm}>
+          {t('misc.confirm')}
+        </Button>
+        <Button onClick={onCancel}>
+          {t('misc.cancel')}
+        </Button>
+      </Form.Item>
+    </Form>
+  )
+
+  return (
+    <div style={style}>
+      <AutoComplete
+        className="model-mapping-editor"
+        options={options}
+        style={{ width: 'calc(100% - 32px)' }}
+        value={value}
+        onChange={handleChange}
+        filterOption={(inputValue, option: any) => {
+          return option.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
+        }}
+      >
+        <Input />
+      </AutoComplete>
+      <Popover
+        trigger="click"
+        content={popoverContent}
+        open={popoverOpen}
+        onOpenChange={onPopoverOpenChange}
+      >
+        <Button icon={<FormOutlined />} />
+      </Popover>
+    </div>
+  );
+}
+
 export {
-  HistoryButton, RedoOutlinedBtn,
+  HistoryButton,
+  ModelMappingEditor,
+  RedoOutlinedBtn,
 };

--- a/frontend/src/pages/ai/components/RouteForm/index.tsx
+++ b/frontend/src/pages/ai/components/RouteForm/index.tsx
@@ -7,12 +7,13 @@ import { getConsumers } from '@/services/consumer';
 import { getLlmProviders } from '@/services/llm-provider';
 import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import { useRequest } from 'ahooks';
-import { AutoComplete, Button, Checkbox, Empty, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
+import { Button, Checkbox, Empty, Form, Input, InputNumber, Select, Space, Switch } from 'antd';
 import { uniqueId } from "lodash";
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { aiModelProviders } from '../../configs';
-import { HistoryButton, RedoOutlinedBtn } from './Components';
+import { HistoryButton, ModelMappingEditor, RedoOutlinedBtn } from './Components';
+import { modelMapping2String, string2ModelMapping } from './util';
 
 const { Option } = Select;
 
@@ -88,7 +89,7 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
       }
       fallbackInitValues['fallbackConfig_upstreams'] = value?.fallbackConfig?.upstreams?.[0]?.provider;
       try {
-        fallbackInitValues['fallbackConfig_modelNames'] = value?.fallbackConfig?.upstreams?.[0]?.modelMapping['*'];
+        fallbackInitValues['fallbackConfig_modelNames'] = modelMapping2String(value?.fallbackConfig?.upstreams?.[0]?.modelMapping);
       } catch (err) {
         fallbackInitValues['fallbackConfig_modelNames'] = '';
       }
@@ -123,7 +124,7 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
         weight: item.weight,
       };
       if (item.modelMapping) {
-        obj["modelMapping"] = item.modelMapping["*"] || null;
+        obj["modelMapping"] = modelMapping2String(item.modelMapping);
       }
       return obj;
     });
@@ -183,9 +184,7 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
       }
       payload["upstreams"] = upstreams.map(({ provider, weight, modelMapping }) => {
         const obj = { provider, weight, modelMapping: {} };
-        if (modelMapping) {
-          obj["modelMapping"]["*"] = modelMapping;
-        }
+        obj["modelMapping"] = string2ModelMapping(modelMapping);
         return obj;
       });
       payload["modelPredicates"] = modelPredicates ? modelPredicates.map(({ matchType, matchValue }) => ({ matchType, matchValue })) : null;
@@ -194,7 +193,7 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
           provider: fallbackConfig_upstreams,
           modelMapping: {},
         };
-        _upstreams["modelMapping"]["*"] = fallbackConfig_modelNames;
+        _upstreams["modelMapping"] = string2ModelMapping(fallbackConfig_modelNames);
         payload['fallbackConfig']['upstreams'] = [_upstreams];
         payload['fallbackConfig']['strategy'] = "SEQ";
         payload['fallbackConfig']['responseCodes'] = fallbackConfig_responseCodes;
@@ -462,14 +461,10 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
                       />
                     </Form.Item>
 
-                    <Form.Item {...restField} name={[name, 'modelMapping']} noStyle>{/* 模型名称 */}
-                      <AutoComplete
+                    <Form.Item {...restField} name={[name, 'modelMapping']} noStyle>
+                      <ModelMappingEditor
                         style={{ ...baseStyle }}
                         options={getOptions(index)}
-                        filterOption={(inputValue, option: any) => {
-                          return option.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1
-                        }}
-                        allowClear
                       />
                     </Form.Item>
                     {
@@ -545,10 +540,8 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
                 label={t("aiRoute.routeForm.label.targetModel")}
                 rules={[{ required: true, message: t('aiRoute.routeForm.rule.modelNameRequired') }]}
               >{/* 模型名称 */}
-                <AutoComplete
+                <ModelMappingEditor
                   options={getOptionsForAi(form.getFieldValue("fallbackConfig_upstreams"))}
-                  filterOption={(inputValue, option: any) => option.value.toUpperCase().indexOf(inputValue.toUpperCase()) !== -1}
-                  allowClear
                 />
               </Form.Item>
             </div>

--- a/frontend/src/pages/ai/components/RouteForm/util.tsx
+++ b/frontend/src/pages/ai/components/RouteForm/util.tsx
@@ -1,0 +1,54 @@
+const modelMapping2String = (modelMapping?: { [key: string]: string }): string => {
+  if (!modelMapping) {
+    return '';
+  }
+  if (typeof modelMapping === 'string') {
+    // If modelMapping is a string, return it directly.
+    return modelMapping;
+  }
+  const entries = Object.entries(modelMapping);
+  if (entries.length === 0) {
+    return '';
+  }
+  if (entries.length === 1 && entries[0][0] === '*') {
+    // Only one entry with key '*', return the value directly.
+    return entries[0][1];
+  }
+  let result = '';
+  for (const [key, value] of Object.entries(modelMapping)) {
+    if (!key) {
+      continue;
+    }
+    if (result) {
+      result += ';';
+    }
+    result += `${key}=${value}`;
+  }
+  return result;
+};
+
+const string2ModelMapping = (str?: string): { [key: string]: string } => {
+  if (!str) {
+    return {};
+  }
+  const modelMapping = {};
+  if (str.indexOf(';') === -1 && str.indexOf('=') === -1) {
+    // If the string does not contain ';' or '=', treat it as a single value for '*'.
+    modelMapping['*'] = str.trim();
+  } else {
+    const pairs = str.split(';');
+    for (const pair of pairs) {
+      const [key, value] = pair.split('=', 2);
+      if (!key) {
+        continue; // Skip invalid pairs
+      }
+      modelMapping[key.trim()] = value.trim();
+    }
+  }
+  return modelMapping;
+};
+
+export {
+  modelMapping2String,
+  string2ModelMapping,
+}

--- a/frontend/src/pages/ai/route.tsx
+++ b/frontend/src/pages/ai/route.tsx
@@ -54,7 +54,7 @@ const AiRouteList: React.FC = () => {
             {
               value && value.length ? value.map((v, i) => {
                 return (
-                  <>{!!i && <br />}{`${t(`route.matchTypes.${v.matchType}`)} ｜ ${v.matchValue}`}</>
+                  <span key={i}>{!!i && <br />}{`${t(`route.matchTypes.${v.matchType}`)} ｜ ${v.matchValue}`}</span>
                 )
               }) : '-'
             }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support configuring multiple model mapping rules for an AI roue upstream, direct upstream or fallback upstream, by adding a popover dialog to perform advanced config editing.

![image](https://github.com/user-attachments/assets/aef6506a-a9ba-4596-b262-29410456a58e)

![0](https://github.com/user-attachments/assets/5349ba62-07f7-4a85-9d7b-c8d2b5b5bdac)

1. User can just put a model name in the text box and it will be consider as the default model mapping.
    ![5](https://github.com/user-attachments/assets/9204b3e6-5871-48b1-8dc5-d6753bdb649c)
2. Multiple mapping rules are shown in the textbox as semicolon-separated key-value pairs.
    `qwen-turbo=gpt-for-qwen;*=gpt-35-turbo;moonshot-*=gpt-for-ms;deepseek-*=`
    ![2](https://github.com/user-attachments/assets/737a430b-bb22-4b97-99ce-ab063841f803)
    ![image](https://github.com/user-attachments/assets/feb448cc-643b-4254-a044-c62ff0961982)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/1901 https://github.com/alibaba/higress/issues/1902

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
