### PR TITLE
fix: Fix the compatibility issue in URL.parse function

### DIFF
--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -323,8 +323,10 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
                           if (!item) {
                             continue;
                           }
-                          const url = URL.parse(item);
-                          if (!url) {
+                          let url;
+                          try {
+                            url = new URL(item);
+                          } catch (e) {
                             return Promise.reject(t('llmProvider.providerForm.rules.invalidOpenaiCustomUrl') + item)
                           }
                           if (value.length > 1


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

`URL.parse` function are only supported in some recent browser versions. Use `new URL()` instead to fix the compatibility issue.

![image](https://github.com/user-attachments/assets/2da0bd3e-4dd8-4620-93f7-64bf7d02b37d)

![image](https://github.com/user-attachments/assets/8a8f5712-15de-451d-a7cc-24d88db905e4)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
