### PR TITLE
refactor(mcp): 优化 API 网关默认值和数据库配置

### DIFF
--- a/frontend/src/pages/mcp/components/DatabaseConfig.tsx
+++ b/frontend/src/pages/mcp/components/DatabaseConfig.tsx
@@ -95,7 +95,6 @@ const DatabaseConfig: React.FC<DatabaseConfigProps> = ({ dsn, dbType, dbUrl, dbP
               <Input
                 key={item.id}
                 style={{ width: 180 }}
-                disabled={item.type === 'db_server_host' || item.type === 'db_server_port'}
                 type={item.type === 'db_password' ? 'password' : 'text'}
               />
             )}

--- a/frontend/src/pages/mcp/detail.tsx
+++ b/frontend/src/pages/mcp/detail.tsx
@@ -36,7 +36,7 @@ const MCPDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('config');
   const [mcpData, setMcpData] = useState<any>(null);
-  const [apiGatewayUrl, setApiGatewayUrl] = useState('https://<higress-gateway-ip>');
+  const [apiGatewayUrl, setApiGatewayUrl] = useState('http://<higress-gateway-ip>');
   const [authEnabled, setAuthEnabled] = useState(false);
   const [tools, setTools] = useState<any[]>([]);
   const [editToolVisible, setEditToolVisible] = useState(false);
@@ -73,7 +73,7 @@ const MCPDetailPage: React.FC = () => {
           const domainProtocol = domain?.enableHttps === 'off' ? 'http' : 'https';
           setApiGatewayUrl(`${domainProtocol}://${domain?.name}`);
         } else {
-          setApiGatewayUrl('https://<higress-gateway-ip>');
+          setApiGatewayUrl('http://<higress-gateway-ip>');
         }
       }
     } catch (error) {
@@ -265,10 +265,10 @@ const MCPDetailPage: React.FC = () => {
                 <Card title={t('mcp.detail.endpointInfo')} bordered style={{ marginTop: 16 }}>
                   <Descriptions column={2}>
                     <Descriptions.Item label={t('mcp.detail.sseEndpoint')}>
-                      {`${apiGatewayUrl || 'https://<higress-gateway-ip>'}/mcp-servers/${name}/sse`}
+                      {`${apiGatewayUrl || 'http://<higress-gateway-ip>'}/mcp-servers/${name}/sse`}
                     </Descriptions.Item>
                     <Descriptions.Item label={t('mcp.detail.httpEndpoint')}>
-                      {`${apiGatewayUrl || 'https://<higress-gateway-ip>'}/mcp-servers/${name}`}
+                      {`${apiGatewayUrl || 'http://<higress-gateway-ip>'}/mcp-servers/${name}`}
                     </Descriptions.Item>
                   </Descriptions>
                 </Card>
@@ -413,7 +413,7 @@ const MCPDetailPage: React.FC = () => {
                     />
                   </div>
 
-                  {apiGatewayUrl !== 'https://<higress-gateway-ip>' && (
+                  {apiGatewayUrl !== 'http://<higress-gateway-ip>' && (
                     <div>
                       <div style={{ fontWeight: 'bold', marginBottom: 8 }}>{t('mcp.detail.step2')}</div>
                       <div style={{ background: '#f7f9fa', padding: 16, borderRadius: 4 }}>


### PR DESCRIPTION
- 移除数据库配置中的主机和端口字段的禁用状态
- 将 API 网关默认 URL 从 https 改为 http
- 更新 MCP 详细页面中的 API 网关 URL 显示逻辑

### Ⅰ. Describe what this PR did
This pull request makes three key modifications:
1. Removes the disabled state of the host and port fields in the database configuration, allowing users to edit these fields.
2. Changes the default URL of the API gateway from https to http.
3. Updates the display logic of the API gateway URL on the MCP detail page to align with the modified default protocol and ensure accurate URL presentation.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
(If applicable, add "fixes #xxx" here; otherwise, leave blank or state "No specific issue fixed, this is a functional adjustment.")


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
The changes primarily involve UI configuration adjustments and URL protocol modifications, which are straightforward and can be verified through manual testing. Given the low risk of logical errors and the need for quick iteration, no additional test cases are added in this PR. However, manual verification steps are provided in section Ⅳ to ensure functionality.


### Ⅳ. Describe how to verify it
1. **Database configuration verification**:
   - Navigate to the database configuration page.
   - Check that the host and port input fields are no longer disabled (i.e., editable).
   - Attempt to modify the host and port values, save the configuration, and confirm that the changes are successfully applied.

2. **API gateway default URL verification**:
   - Access the settings or configuration section where the API gateway URL is displayed by default.
   - Confirm that the default URL starts with "http://" instead of "https://".
   - Test creating a new MCP instance (if applicable) and check that the automatically generated API gateway URL uses the http protocol by default.

3. **MCP detail page URL display verification**:
   - Open the MCP detail page for an existing instance.
   - Verify that the displayed API gateway URL correctly reflects the actual protocol (http) and any user-configured host/port (if applicable).
   - If the MCP instance was created before this PR, check that the URL display logic correctly handles both existing (potentially https) and newly updated (http) URLs without formatting issues.


### Ⅴ. Special notes for reviews
- The modification to the API gateway's default protocol from https to http may affect integrations that rely on the previous default. Reviewers should confirm that this change aligns with the overall system architecture and external integration requirements.
- Ensure that the updated display logic on the MCP detail page properly handles edge cases, such as custom URLs with non-standard ports or mixed protocols (though the default is now http).
- After merging, it is recommended to inform users of the change in the API gateway's default protocol to avoid confusion during manual configuration.