### PR TITLE
适配mcpbridge新增vport属性，以修复服务后端端口不一致导致的兼容性问题

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ServiceSource.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ServiceSource.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.VPort;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,10 @@ public class ServiceSource implements VersionedDto {
 
     @Schema(description = "Service source name")
     private String name;
+
+    @Schema(description = "Register vport configuration with default and service-specific values. Optional.",
+            example = "{\"default\": 8080, \"services\": [{\"name\": \"svc1\", \"value\": 9090}]}")
+    private VPort vport;
 
     @Schema(description = "Service source version. Required when updating.")
     private String version;
@@ -107,6 +112,20 @@ public class ServiceSource implements VersionedDto {
         ServiceSourceValidator validator = VALIDATORS.get(this.getType());
         if (validator != null && !validator.validate(this)) {
             return false;
+        }
+
+        if (this.vport != null) {
+            if (this.vport.getDefaultValue() != null && !ValidateUtil.checkPort(this.vport.getDefaultValue())) {
+                return false;
+            }
+
+            if (this.vport.getVportServices() != null) {
+                for (VPort.vportService vportService : this.vport.getVportServices()) {
+                    if (!ValidateUtil.checkPort(vportService.getValue())) {
+                        return false;
+                    }
+                }
+            }
         }
 
         return true;

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -1761,6 +1761,7 @@ public class KubernetesModelConverter {
         v1RegistryConfig.setName(serviceSource.getName());
         v1RegistryConfig.setProtocol(StringUtils.firstNonBlank(serviceSource.getProtocol()));
         v1RegistryConfig.setSni(serviceSource.getSni());
+        v1RegistryConfig.setVport(serviceSource.getVport());
         Map<String, Object> properties =
             Optional.ofNullable(serviceSource.getProperties()).orElse(Collections.emptyMap());
         if (V1McpBridge.REGISTRY_TYPE_NACOS.equals(v1RegistryConfig.getType())

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/mcp/V1RegistryConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/mcp/V1RegistryConfig.java
@@ -104,4 +104,8 @@ public class V1RegistryConfig {
     public static final String SERIALIZED_NAME_METADATA_NAME = "metadata";
     @SerializedName(SERIALIZED_NAME_METADATA_NAME)
     private Map<String, V1RegistryConfigMetadata> metadata;
+
+    public static final String SERIALIZED_NAME_VPORT = "vport";
+    @SerializedName(SERIALIZED_NAME_VPORT)
+    private VPort vport;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/mcp/VPort.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/crd/mcp/VPort.java
@@ -1,0 +1,26 @@
+package com.alibaba.higress.sdk.service.kubernetes.crd.mcp;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class VPort {
+    public static final String SERIALIZED_NAME_DEFAULT_VALUE_NAME = "default";
+    @SerializedName(SERIALIZED_NAME_DEFAULT_VALUE_NAME)
+    private Integer defaultValue;
+
+    public static final String SERIALIZED_NAME_SERVICES = "services";
+    @SerializedName(SERIALIZED_NAME_SERVICES)
+    private List<vportService> vportServices;
+    @Data
+    public static class vportService {
+        public static final String SERIALIZED_NAME_VPORTSERVICE_NAME = "name";
+        @SerializedName(SERIALIZED_NAME_VPORTSERVICE_NAME)
+        private String name;
+        public static final String SERIALIZED_NAME_VPORTSERVICE_VALUE = "value";
+        @SerializedName(SERIALIZED_NAME_VPORTSERVICE_VALUE)
+        private int value;
+    }
+}

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverterTest.java
@@ -1504,7 +1504,7 @@ public class KubernetesModelConverterTest {
         spec.setRegistries(registries);
 
         ServiceSource serviceSource =
-            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
+            new ServiceSource("testService",null, "1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
 
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
 
@@ -1529,7 +1529,7 @@ public class KubernetesModelConverterTest {
         spec.setRegistries(registries);
 
         ServiceSource serviceSource =
-            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
+            new ServiceSource("testService", null,"1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
 
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
 
@@ -1538,6 +1538,7 @@ public class KubernetesModelConverterTest {
         Assertions.assertEquals(serviceSource.getDomain(), result.getDomain());
         Assertions.assertEquals(serviceSource.getType(), result.getType());
         Assertions.assertEquals(serviceSource.getPort(), result.getPort());
+        Assertions.assertEquals(serviceSource.getVport().getDefaultValue(),result.getVport().getDefaultValue());
         Assertions.assertTrue(registries.contains(result));
     }
 
@@ -1560,7 +1561,7 @@ public class KubernetesModelConverterTest {
         V1McpBridge v1McpBridge = new V1McpBridge();
 
         ServiceSource serviceSource =
-            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
+            new ServiceSource("testService", null,"1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
 
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
 
@@ -1577,7 +1578,7 @@ public class KubernetesModelConverterTest {
         v1McpBridge.setSpec(spec);
 
         ServiceSource serviceSource =
-            new ServiceSource("testService", "1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
+            new ServiceSource("testService",null, "1.0", "http", "test.domain.com", 8080, null, null, new HashMap<>(), null);
 
         V1RegistryConfig result = converter.addV1McpBridgeRegistry(v1McpBridge, serviceSource);
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
当在eureka或者nacos等注册的服务实例端口不一致的时候，当后端实例端口变化，会导致原来的路由配置失效，新增vport属性，当配置注册中心的时候，可以选择性配置好vport默认端口或指定服务虚拟端口

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #518 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
