### PR TITLE
fix: Fix the incorrect logic of filtering V1alpha1WasmPlugin by internal flag

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -78,14 +78,15 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
     public List<WasmPluginInstance> list(String pluginName, Boolean internal) {
         List<V1alpha1WasmPlugin> plugins;
         try {
-            plugins = kubernetesClientService.listWasmPlugin(pluginName, null, internal);
+            plugins = kubernetesClientService.listWasmPlugin(pluginName, null);
         } catch (ApiException e) {
             throw new BusinessException("Error occurs when listing WasmPlugin.", e);
         }
         if (CollectionUtils.isEmpty(plugins)) {
             return Collections.emptyList();
         }
-        return plugins.stream().map(kubernetesModelConverter::getWasmPluginInstancesFromCr).filter(Objects::nonNull)
+        return plugins.stream().filter(p -> internal == null || internal == KubernetesUtil.isInternalResource(p))
+            .map(kubernetesModelConverter::getWasmPluginInstancesFromCr).filter(Objects::nonNull)
             .flatMap(Collection::stream).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

The override used before was `listWasmPlugin(String name, String version, Boolean builtIn)`, which doesn't match the scenario, causing non-internal instances being returned here. This PR fixes this problem.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/2736

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
