### PR TITLE
fix: Sync the domain regex pattern between backend and frontend

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/util/ValidateUtil.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/util/ValidateUtil.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 public class ValidateUtil {
 
     private static final Pattern SERVICE_NAME_PATTERN = Pattern.compile("^(?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9]$");
-    private static final Pattern DOMAIN_PATTERN = Pattern.compile("^(?:(?!-)[a-z0-9-]{0,62}[a-z0-9]\\.)+[a-z]{2,6}$");
+    private static final Pattern DOMAIN_PATTERN = Pattern.compile("^(?:(?!-)[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,63}$");
     private static final Pattern DOMAIN_WITH_WILDCARD_PATTERN =
         Pattern.compile("^(\\*\\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,6}$");
     private static final Pattern IPV4_ADDRESS_PATTERN = Pattern

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/util/ValidateUtilTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/util/ValidateUtilTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ValidateUtilTest {
+
+    @Test
+    void testCheckServiceName() {
+        assertTrue(ValidateUtil.checkServiceName("service-1"));
+        assertTrue(ValidateUtil.checkServiceName("abc123"));
+        assertFalse(ValidateUtil.checkServiceName("-invalid"));
+        assertFalse(ValidateUtil.checkServiceName("invalid-"));
+        assertFalse(ValidateUtil.checkServiceName(""));
+    }
+
+    @Test
+    void testCheckPort() {
+        assertTrue(ValidateUtil.checkPort(80));
+        assertTrue(ValidateUtil.checkPort(65534));
+        assertFalse(ValidateUtil.checkPort(0));
+        assertFalse(ValidateUtil.checkPort(65535));
+        assertFalse(ValidateUtil.checkPort(null));
+        assertFalse(ValidateUtil.checkPort(1));
+    }
+
+    @Test
+    void testCheckDomain() {
+        assertTrue(ValidateUtil.checkDomain("example.com"));
+        assertTrue(ValidateUtil.checkDomain("example.internal"));
+        assertTrue(ValidateUtil.checkDomain("abc.def.com"));
+        assertFalse(ValidateUtil.checkDomain("-abc.com"));
+        assertFalse(ValidateUtil.checkDomain("abc-.com"));
+        assertFalse(ValidateUtil.checkDomain("abc"));
+        assertFalse(ValidateUtil.checkDomain(""));
+    }
+
+    @Test
+    void testCheckDomainWithWildcard() {
+        assertTrue(ValidateUtil.checkDomainWithWildcard("*.example.com"));
+        assertTrue(ValidateUtil.checkDomainWithWildcard("example.com"));
+        assertFalse(ValidateUtil.checkDomainWithWildcard("*example.com"));
+        assertFalse(ValidateUtil.checkDomainWithWildcard("-abc.com"));
+        assertFalse(ValidateUtil.checkDomainWithWildcard(""));
+    }
+
+    @Test
+    void testCheckIpAddress() {
+        assertTrue(ValidateUtil.checkIpAddress("192.168.1.1"));
+        assertTrue(ValidateUtil.checkIpAddress("255.255.255.255"));
+        assertFalse(ValidateUtil.checkIpAddress("256.0.0.1"));
+        assertFalse(ValidateUtil.checkIpAddress("abc.def.ghi.jkl"));
+        assertFalse(ValidateUtil.checkIpAddress(""));
+    }
+
+    @Test
+    void testCheckUrlPath() {
+        assertTrue(ValidateUtil.checkUrlPath("/api/test"));
+        assertFalse(ValidateUtil.checkUrlPath("api/test"));
+        assertFalse(ValidateUtil.checkUrlPath("/api/test?param=1"));
+        assertFalse(ValidateUtil.checkUrlPath(""));
+    }
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Use the same regex pattern to validate domain names so domains with a long top-level name, like `test.internal` can be accepted.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
