### PR TITLE
feat(mcp): 支持 PostgreSQL 和 ClickHouse 数据库连接

### DIFF
--- a/frontend/src/pages/mcp/components/DatabaseConfig.tsx
+++ b/frontend/src/pages/mcp/components/DatabaseConfig.tsx
@@ -60,12 +60,12 @@ export const computeDSN = (values: any) => {
   const { db_type, db_user_name, db_password, db_server_host, db_database, db_server_port } = values;
   if (!db_type || !db_user_name || !db_password || !db_server_host || !db_server_port) return '';
   // PostgreSQL: postgres://username:password@host:port/dbname
-  if (db_type === 'PostgreSQL') {
+  if (db_type === 'POSTGRESQL') {
     if (!db_database) return '';
     return `postgres://${db_user_name}:${db_password}@${db_server_host}:${db_server_port}/${db_database}`;
   }
   // ClickHouse: tcp://host:port?database=xxx&username=xxx&password=xxx
-  if (db_type === 'Clickhouse') {
+  if (db_type === 'CLICKHOUSE') {
     const query = new URLSearchParams({
       database: db_database || '',
       username: db_user_name,

--- a/frontend/src/pages/mcp/components/DatabaseConfig.tsx
+++ b/frontend/src/pages/mcp/components/DatabaseConfig.tsx
@@ -58,8 +58,23 @@ export const DB_FIXED_FIELDS = [
 
 export const computeDSN = (values: any) => {
   const { db_type, db_user_name, db_password, db_server_host, db_database, db_server_port } = values;
-  if (!db_type || !db_user_name || !db_password || !db_server_host || !db_database) return '';
-  // eslint-disable-next-line max-len
+  if (!db_type || !db_user_name || !db_password || !db_server_host || !db_server_port) return '';
+  // PostgreSQL: postgres://username:password@host:port/dbname
+  if (db_type === 'PostgreSQL') {
+    if (!db_database) return '';
+    return `postgres://${db_user_name}:${db_password}@${db_server_host}:${db_server_port}/${db_database}`;
+  }
+  // ClickHouse: tcp://host:port?database=xxx&username=xxx&password=xxx
+  if (db_type === 'Clickhouse') {
+    const query = new URLSearchParams({
+      database: db_database || '',
+      username: db_user_name,
+      password: db_password,
+    }).toString();
+    return `tcp://${db_server_host}:${db_server_port}?${query}`;
+  }
+  // MySQL (默认): username:password@tcp(host:port)/dbname?...
+  if (!db_database) return '';
   return `${db_user_name}:${db_password}@tcp(${db_server_host}:${db_server_port})/${db_database}?charset=utf8mb4&parseTime=True&loc=Local`;
 };
 

--- a/frontend/src/pages/mcp/components/McpFormDrawer.tsx
+++ b/frontend/src/pages/mcp/components/McpFormDrawer.tsx
@@ -76,8 +76,8 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
                 db_database: m[5],
               });
             }
-          } else if (type === 'PostgreSQL') {
-            m = record.dsn.match(REG_DSN_STRING.PostgreSQL);
+          } else if (type === 'POSTGRESQL') {
+            m = record.dsn.match(REG_DSN_STRING.POSTGRESQL);
             if (m) {
               form.setFieldsValue({
                 db_user_name: m[1],
@@ -85,14 +85,13 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
                 db_database: m[5],
               });
             }
-          } else if (type === 'Clickhouse') {
-            m = record.dsn.match(REG_DSN_STRING.Clickhouse);
+          } else if (type === 'CLICKHOUSE') {
+            m = record.dsn.match(REG_DSN_STRING.CLICKHOUSE);
             if (m) {
-              const search = new URLSearchParams(m[3] || '');
               form.setFieldsValue({
-                db_user_name: search.get('username') || '',
-                db_password: search.get('password') || '',
-                db_database: search.get('database') || '',
+                db_user_name: m[4],
+                db_password: m[5],
+                db_database: m[3],
               });
             }
           }
@@ -362,10 +361,10 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
                   let valid = false;
                   if (type === 'MYSQL') {
                     valid = REG_DSN_STRING.MYSQL.test(value);
-                  } else if (type === 'PostgreSQL') {
-                    valid = REG_DSN_STRING.PostgreSQL.test(value);
-                  } else if (type === 'Clickhouse') {
-                    valid = REG_DSN_STRING.Clickhouse.test(value);
+                  } else if (type === 'POSTGRESQL') {
+                    valid = REG_DSN_STRING.POSTGRESQL.test(value);
+                  } else if (type === 'CLICKHOUSE') {
+                    valid = REG_DSN_STRING.CLICKHOUSE.test(value);
                   }
                   if (!valid) {
                     return Promise.reject(new Error(t('mcp.form.databaseConfigInvalid')!));

--- a/frontend/src/pages/mcp/components/McpFormDrawer.tsx
+++ b/frontend/src/pages/mcp/components/McpFormDrawer.tsx
@@ -65,13 +65,36 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
         form.resetFields();
       } else {
         if (record && record.dsn) {
-          const match = record.dsn.match(REG_DSN_STRING.DEFAULT);
-          if (match) {
-            form.setFieldsValue({
-              db_user_name: match[1],
-              db_password: match[2],
-              db_database: match[5],
-            });
+          const type = record?.dbType;
+          let m: RegExpMatchArray | null = null;
+          if (type === 'MYSQL') {
+            m = record.dsn.match(REG_DSN_STRING.MYSQL);
+            if (m) {
+              form.setFieldsValue({
+                db_user_name: m[1],
+                db_password: m[2],
+                db_database: m[5],
+              });
+            }
+          } else if (type === 'PostgreSQL') {
+            m = record.dsn.match(REG_DSN_STRING.PostgreSQL);
+            if (m) {
+              form.setFieldsValue({
+                db_user_name: m[1],
+                db_password: m[2],
+                db_database: m[5],
+              });
+            }
+          } else if (type === 'Clickhouse') {
+            m = record.dsn.match(REG_DSN_STRING.Clickhouse);
+            if (m) {
+              const search = new URLSearchParams(m[3] || '');
+              form.setFieldsValue({
+                db_user_name: search.get('username') || '',
+                db_password: search.get('password') || '',
+                db_database: search.get('database') || '',
+              });
+            }
           }
         }
         form.setFieldsValue({
@@ -331,7 +354,20 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
               {
                 required: true,
                 validator: (_, value) => {
-                  if (!value || !value.match(REG_DSN_STRING.DEFAULT)) {
+                  const values = form.getFieldsValue();
+                  const type = values?.db_type;
+                  if (!value) {
+                    return Promise.reject(new Error(t('mcp.form.databaseConfigInvalid')!));
+                  }
+                  let valid = false;
+                  if (type === 'MYSQL') {
+                    valid = REG_DSN_STRING.MYSQL.test(value);
+                  } else if (type === 'PostgreSQL') {
+                    valid = REG_DSN_STRING.PostgreSQL.test(value);
+                  } else if (type === 'Clickhouse') {
+                    valid = REG_DSN_STRING.Clickhouse.test(value);
+                  }
+                  if (!valid) {
                     return Promise.reject(new Error(t('mcp.form.databaseConfigInvalid')!));
                   }
                   return Promise.resolve();

--- a/frontend/src/pages/mcp/constant.ts
+++ b/frontend/src/pages/mcp/constant.ts
@@ -13,11 +13,10 @@ export function getServiceTypeMap(directRouteText: string) {
     [SERVICE_TYPE.DIRECT_ROUTE]: directRouteText,
   };
 }
-// MYSQL/PostgreSQL/Sqlite/Clickhouse
+// MYSQL/PostgreSQL/Clickhouse
 export const DB_TYPE_OPTIONS = [
   { label: 'MySQL', value: 'MYSQL' },
   { label: 'PostgreSQL', value: 'PostgreSQL' },
-  { label: 'SQLite', value: 'Sqlite' },
   { label: 'ClickHouse', value: 'Clickhouse' },
 ];
 
@@ -28,11 +27,12 @@ export const DOMAIN_PROTOCOL_MAP = {
 
 // 数据库连接字符串正则 eg: mysql:user:pass@tcp(host:port)/database?charset=utf8mb4&parseTime=True&loc=Local
 export const REG_DSN_STRING = {
-  MYSQL: /^(\w+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)\?(.+)$/,
-  POSTGRESQL: /^(\w+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)\?(.+)$/,
-  SQLITE: /^(\w+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)\?(.+)$/,
-  CLICKHOUSE: /^(\w+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)\?(.+)$/,
-  DEFAULT: /^(\w+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)\?(.+)$/,
+  // username:password@tcp(host:port)/dbname?param1=value1&param2=value2
+  MYSQL: /^([^:]+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)(?:\?(.+))?$/i,
+  // postgres://username:password@host:port/dbname
+  PostgreSQL: /^postgres:\/\/([^:]+):([^@]+)@([^:/]+):(\d+)\/([^?/#]+)(?:\?(.+))?$/i,
+  // tcp://localhost:9000?database=default&username=default&password=
+  Clickhouse: /^tcp:\/\/([^:/]+):(\d+)(?:\?(.+))?$/i,
 };
 
 

--- a/frontend/src/pages/mcp/constant.ts
+++ b/frontend/src/pages/mcp/constant.ts
@@ -16,8 +16,8 @@ export function getServiceTypeMap(directRouteText: string) {
 // MYSQL/PostgreSQL/Clickhouse
 export const DB_TYPE_OPTIONS = [
   { label: 'MySQL', value: 'MYSQL' },
-  { label: 'PostgreSQL', value: 'PostgreSQL' },
-  { label: 'ClickHouse', value: 'Clickhouse' },
+  { label: 'PostgreSQL', value: 'POSTGRESQL' },
+  { label: 'ClickHouse', value: 'CLICKHOUSE' },
 ];
 
 export const DOMAIN_PROTOCOL_MAP = {
@@ -28,11 +28,11 @@ export const DOMAIN_PROTOCOL_MAP = {
 // 数据库连接字符串正则 eg: mysql:user:pass@tcp(host:port)/database?charset=utf8mb4&parseTime=True&loc=Local
 export const REG_DSN_STRING = {
   // username:password@tcp(host:port)/dbname?param1=value1&param2=value2
-  MYSQL: /^([^:]+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)(?:\?(.+))?$/i,
+  MYSQL: /^(\w+):([^@]+)@tcp\(([^:]+):(\d+)\)\/([^?]+)\?(.+)$/,
   // postgres://username:password@host:port/dbname
-  PostgreSQL: /^postgres:\/\/([^:]+):([^@]+)@([^:/]+):(\d+)\/([^?/#]+)(?:\?(.+))?$/i,
+  POSTGRESQL: /^postgres:\/\/([^:]+):([^@]+)@([^:]+):(\d+)\/([^?]+)$/,
   // tcp://localhost:9000?database=default&username=default&password=
-  Clickhouse: /^tcp:\/\/([^:/]+):(\d+)(?:\?(.+))?$/i,
+  CLICKHOUSE: /^tcp:\/\/([^:]+):(\d+)\?database=([^&]+)&username=([^&]*)&password=([^&]*)/,
 };
 
 


### PR DESCRIPTION
## 功能描述

本次更新为MCP服务器管理功能添加了对PostgreSQL和ClickHouse数据库的支持，同时修复了数据库连接字符串解析问题。

## 主要变更

### 新增功能
- 支持PostgreSQL数据库连接（postgres://username:password@host:port/dbname）
- 支持ClickHouse数据库连接（tcp://host:port?database=xxx&username=xxx&password=xxx）
- 优化MySQL数据库连接字符串格式

### 修复问题
- 修复数据库连接字符串解析问题
- 统一数据库类型选项（移除SQLite，标准化命名）
- 改进DSN验证逻辑，支持多种数据库类型

### 技术细节
- 更新`computeDSN`函数支持多种数据库格式
- 重构`McpFormDrawer`组件中的DSN解析逻辑
- 更新正则表达式常量以支持不同数据库类型
- 优化表单验证规则

## 测试
- [x] MySQL连接字符串生成和解析
- [x] PostgreSQL连接字符串生成和解析  
- [x] ClickHouse连接字符串生成和解析
- [x] 表单验证和错误处理

## 相关Issue
Closes #561