### PR TITLE
fix: update openapi mcp server NPE, and postgres enum value(#580)

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerConfigMap.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerConfigMap.java
@@ -12,6 +12,7 @@
  */
 package com.alibaba.higress.sdk.model.mcp;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class McpServerConfigMap {
     @JsonProperty("match_list")
     private List<MatchList> matchList;
 
-    private List<Server> servers;
+    private List<Server> servers = Collections.emptyList();
 
     @Data
     public static class RedisConfig {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerDBTypeEnum.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerDBTypeEnum.java
@@ -37,7 +37,7 @@ public enum McpServerDBTypeEnum {
     /**
      * PostgreSQL
      */
-    POSTGRESQL("postgresql"),
+    POSTGRESQL("postgres"),
 
     /**
      * SQLite


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
1. 修复更新 openapi mcp server 时 NPE 异常
2. postgres 枚举值与 higress 中对应常量值对齐

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes: #580 


