### PR TITLE
fix: Fix bugs in enabling auth with no allowed consumer

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/ConsumerServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/ConsumerServiceImpl.java
@@ -139,15 +139,14 @@ public class ConsumerServiceImpl implements ConsumerService {
                         return newAllowList;
                     });
                 List<String> consumerNames = handler.getAllowedConsumers(instance);
-                if (CollectionUtils.isEmpty(consumerNames)) {
-                    continue;
-                }
                 if (!allowList.getCredentialTypes().contains(handler.getType())) {
                     allowList.getCredentialTypes().add(handler.getType());
                 }
-                for (String consumerName : consumerNames) {
-                    if (!allowList.getConsumerNames().contains(consumerName)) {
-                        allowList.getConsumerNames().add(consumerName);
+                if (CollectionUtils.isNotEmpty(consumerNames)) {
+                    for (String consumerName : consumerNames) {
+                        if (!allowList.getConsumerNames().contains(consumerName)) {
+                            allowList.getConsumerNames().add(consumerName);
+                        }
                     }
                 }
             }
@@ -260,6 +259,8 @@ public class ConsumerServiceImpl implements ConsumerService {
             if (targetInstance == null) {
                 targetInstance = wasmPluginInstanceService.createEmptyInstance(handler.getPluginName());
                 targetInstance.setInternal(true);
+                // Default to disabled.
+                targetInstance.setEnabled(false);
                 targetInstance.setTargets(targets);
             }
             if (allowList.getAuthEnabled() != null) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/KeyAuthCredentialHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/KeyAuthCredentialHandler.java
@@ -264,31 +264,32 @@ class KeyAuthCredentialHandler implements CredentialHandler {
             instance.setConfigurations(configurations);
         }
 
-        if (CollectionUtils.isEmpty(consumerNames)) {
-            configurations.put(ALLOW, Collections.emptyList());
-        } else {
-            List<String> newAllowList = getAllowedConsumers(instance);
-            switch (operation) {
-                case ADD:
-                    for (String consumerName : consumerNames) {
-                        if (!newAllowList.contains(consumerName)) {
-                            newAllowList.add(consumerName);
-                        }
+        List<String> newAllowList = getAllowedConsumers(instance);
+        switch (operation) {
+            case ADD:
+                for (String consumerName : consumerNames) {
+                    if (!newAllowList.contains(consumerName)) {
+                        newAllowList.add(consumerName);
                     }
-                    break;
-                case REMOVE:
-                    for (String consumerName : consumerNames) {
-                        newAllowList.remove(consumerName);
-                    }
-                    break;
-                case REPLACE:
-                    newAllowList = consumerNames;
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Unsupported operation: " + operation);
-            }
-            configurations.put(ALLOW, newAllowList);
+                }
+                break;
+            case REMOVE:
+                for (String consumerName : consumerNames) {
+                    newAllowList.remove(consumerName);
+                }
+                break;
+            case REPLACE:
+                newAllowList = consumerNames;
+                break;
+            case TOGGLE_ONLY:
+                if (CollectionUtils.isEmpty(newAllowList)) {
+                    newAllowList = new ArrayList<>();
+                }
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported operation: " + operation);
         }
+        configurations.put(ALLOW, newAllowList);
     }
 
     private Consumer extractConsumer(Map<String, Object> consumerMap) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -566,7 +566,7 @@ public class KubernetesModelConverter {
                 }
             }
         }
-        instances.removeIf(i -> MapUtils.isEmpty(i.getConfigurations()));
+        instances.removeIf(i -> Boolean.FALSE.equals(i.getEnabled()) && MapUtils.isEmpty(i.getConfigurations()));
         instances.forEach(i -> {
             i.setPluginName(name);
             i.setPluginVersion(version);

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/consumer/KeyAuthCredentialHandlerTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/consumer/KeyAuthCredentialHandlerTest.java
@@ -446,6 +446,10 @@ public class KeyAuthCredentialHandlerTest {
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof UnsupportedOperationException || e instanceof NullPointerException);
         }
+        // 8. TOGGLE_ONLY
+        handler.updateAllowList(AllowListOperation.ADD, instance, Lists.newArrayList("a", "b"));
+        handler.updateAllowList(AllowListOperation.TOGGLE_ONLY, instance, null);
+        Assertions.assertEquals(Lists.newArrayList("a", "b"), handler.getAllowedConsumers(instance));
     }
 
     @Test


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix bugs in enabling auth with no allowed consumer.

1. Do not clear allowed consumer list when performing toggle-only operation.
2. Fix the incorrect auth status display when auth is enabled with no allowed consumer.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
