### PR TITLE
feat: Show the fixed service port 80 for static service sources

### DIFF
--- a/frontend/src/pages/service-source/components/SourceForm/index.tsx
+++ b/frontend/src/pages/service-source/components/SourceForm/index.tsx
@@ -12,6 +12,8 @@ import { useTranslation } from 'react-i18next';
 
 const { Option } = Select;
 
+const STATIC_SERVICE_PORT = 80;
+
 const SourceForm: React.FC = forwardRef((props, ref) => {
   const { t } = useTranslation();
   const { value } = props;
@@ -109,7 +111,7 @@ const SourceForm: React.FC = forwardRef((props, ref) => {
         }
 
         if (values.type === ServiceSourceTypes.static.key) {
-          values.port = 80;
+          values.port = STATIC_SERVICE_PORT;
         }
       } else {
         values.protocol = null;
@@ -459,6 +461,11 @@ const SourceForm: React.FC = forwardRef((props, ref) => {
       {
         sourceType === ServiceSourceTypes.static.key && (
           <>
+            <Form.Item
+              label={t('serviceSource.serviceSourceForm.servicePort')}
+            >
+              <span className="ant-form-text">{STATIC_SERVICE_PORT}</span>
+            </Form.Item>
             <Form.Item
               label={t('serviceSource.serviceSourceForm.serviceStaticAddresses')}
               name={['domainForEdit']}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Show the fixed service port 80 for static service sources.

<img width="660" height="426" alt="image" src="https://github.com/user-attachments/assets/4d442104-9c02-477b-a164-b2a2c6e5f1bb" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
