### PR TITLE
fix: correct AI route name validation to support dots

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -86,7 +86,7 @@
         "serviceWeightRequired": "Please input the weight value",
         "fallbackUpstreamRequired": "Please select the fallback service",
         "fallbackResponseCodesRequired": "Please select the response codes that need fallback",
-        "nameRequired": "Shall only contain upper-and lower-case letters, digits, dashes (-) and dots (.). And cannot end with a dash (-) or dot (.).",
+        "nameRequired": "Shall only contain lower-case letters, digits, dashes (-) and dots (.), and must begin and end with a letter or digit.",
         "targetServiceRequired": "Please select a target service",
         "badWeightSum": "The sum of all service weights must be 100.",
         "noUpstreams": "At least one target service is required."

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -86,7 +86,7 @@
         "serviceWeightRequired": "请输入请求比例",
         "fallbackUpstreamRequired": "请选择降级服务",
         "fallbackResponseCodesRequired": "请选择需要降级的响应码",
-        "nameRequired": "包含小写字母、数字和以及特殊字符(- .)，且不能以特殊字符开头和结尾",
+        "nameRequired": "包含小写字母、数字以及特殊字符(- .)，且不能以特殊字符开头和结尾",
         "targetServiceRequired": "请选择目标服务",
         "badWeightSum": "所有服务的权重总和必须为100",
         "noUpstreams": "至少要配置一个目标AI服务"

--- a/frontend/src/pages/ai/components/RouteForm/index.tsx
+++ b/frontend/src/pages/ai/components/RouteForm/index.tsx
@@ -239,7 +239,7 @@ const AiRouteForm: React.FC = forwardRef((props: { value: any }, ref) => {
         rules={[
           {
             required: true,
-            pattern: /^(?!-)[A-Za-z0-9-]{0,63}[A-Za-z0-9]$/,
+            pattern: /^[a-z0-9](?:[a-z0-9.-]{0,61}[a-z0-9])?$/,
             message: t('aiRoute.routeForm.rule.nameRequired'),
           },
         ]}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

修正了 AI 路由名称的验证规则，解决了界面提示与实际验证逻辑不一致的问题：

1. 原验证规则不支持点号，但界面提示文字说明支持特殊字符(- .)，现已修正正则表达式使其支持点号
2.原验证规则允许大小写字母(A-Za-z)，但界面提示说明只支持小写字母，现已修正为只允许小写字母
3. 更新了中英文的错误提示信息，使其准确描述新的验证规则


### Ⅱ. Does this pull request fix one issue?

fixes alibaba/higress#2937


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
此改动属于前端表单验证规则的修正，主要涉及正则表达式模式的调整和国际化文本的更新
验证逻辑由 Ant Design的 form组件处理，可以通过手动测试验证功能正确性

### Ⅳ. Describe how to verify it

测试以下场景：
应该通过验证的名称：
   - `test123` （小写字母+数字）
   - `my-route` （包含短横线）
   - `my.route` （包含点号）
   - `api-v1.2` （混合使用短横线和点号）
   - `a` （单个字符）
  
应该拒绝的名称：
   - `Test123` （包含大写字母）
   - `-test` （以短横线开头）
   - `test-` （以短横线结尾）
   - `.test` （以点号开头）
   - `test.` （以点号结尾）
   - `test_route` （包含下划线）
