### PR TITLE
fix: Remove version info from the data json when converting AiRoute to ConfigMap

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/kubernetes/KubernetesModelConverter.java
@@ -327,7 +327,13 @@ public class KubernetesModelConverter {
         metadata.setLabels(MapUtil.of(KubernetesConstants.Label.CONFIG_MAP_TYPE_KEY,
             KubernetesConstants.Label.CONFIG_MAP_TYPE_VALUE_AI_ROUTE));
 
-        domainConfigMap.data(MapUtil.of(KubernetesConstants.DATA_FIELD, GSON.toJson(route)));
+        String versionBackup = route.getVersion();
+        route.setVersion(null);
+        try {
+            domainConfigMap.data(MapUtil.of(KubernetesConstants.DATA_FIELD, GSON.toJson(route)));
+        } finally {
+            route.setVersion(versionBackup);
+        }
 
         return domainConfigMap;
     }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Remove version info from the data json when converting AiRoute to ConfigMap, because it is already saved in the ConfigMap metadata.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
