### PR TITLE
feat: Switch the jdk base image to eclipse-temurin:21-jdk

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

openjdk image repository is now deprecated. Switch to eclipse-temurin as out base image.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/18a3a673-5f07-4a98-9c87-b67c52d571dc" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
