### PR TITLE
fix: Correct logic error in Consumer update (PUT) name handling

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/ConsumersController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/ConsumersController.java
@@ -92,7 +92,7 @@ public class ConsumersController {
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<Response<Consumer>> put(@PathVariable("name") @NotBlank String name,
         @RequestBody Consumer consumer) {
-        if (StringUtils.isNotEmpty(consumer.getName())) {
+        if (StringUtils.isEmpty(consumer.getName())) {
             consumer.setName(name);
         } else if (!StringUtils.equals(name, consumer.getName())) {
             throw new ValidationException("Consumer name in the URL doesn't match the one in the body.");


### PR DESCRIPTION
This PR corrects a logic error in the consumer update (`PUT`) method. / 此 PR 修正了 Consumer 更新 (`PUT`) 方法中的一个逻辑错误。

Specifically, it changes `StringUtils.isNotEmpty` to **`StringUtils.isEmpty`**. / 具体来说，它将 `StringUtils.isNotEmpty` 更改为 **`StringUtils.isEmpty`**。

This ensures the path name is only used when the body name is missing, and correctly enforces a match when both are present. / 这确保了只有当请求体名称缺失时才使用路径名称，并在两者都存在时正确地要求名称匹配。