### PR TITLE
fix: Fix missing requestBody parameters in swagger to mcp config conv…

### DIFF
--- a/backend/sdk/pom.xml
+++ b/backend/sdk/pom.xml
@@ -58,5 +58,9 @@
 			<artifactId>velocity-engine-core</artifactId>
 			<version>2.3</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServerHelper.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServerHelper.java
@@ -17,6 +17,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -38,6 +40,9 @@ import com.alibaba.higress.sdk.model.mcp.ConsumerAuthInfo;
 import com.alibaba.higress.sdk.model.mcp.McpServer;
 import com.alibaba.higress.sdk.model.mcp.McpServerConstants;
 import com.alibaba.higress.sdk.model.mcp.McpServerTypeEnum;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,6 +51,10 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class McpServerHelper {
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory()
+        .enable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE).disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     @PostConstruct
     public void init() {
@@ -99,6 +108,13 @@ public class McpServerHelper {
             Path mcpConfigFilePath = Paths.get(McpConstants.getMcpTempDir(), mcpConfigFileName);
 
             String mcpConfigContent = new String(Files.readAllBytes(mcpConfigFilePath), StandardCharsets.UTF_8);
+
+            // Fix missing requestBody parameters in the converted config
+            try {
+                mcpConfigContent = fixRequestBodyInMcpConfig(mcpConfigContent, swaggerContent);
+            } catch (Exception e) {
+                log.warn("Failed to fix requestBody in mcp config, using original config: {}", e.getMessage());
+            }
 
             // delete temp file
             Files.deleteIfExists(openapiFilePath);
@@ -214,5 +230,232 @@ public class McpServerHelper {
         }
 
         return result;
+    }
+
+    /**
+     * Fix missing requestBody parameters in MCP config by extracting them from OpenAPI spec
+     *
+     * @param mcpConfigContent MCP config YAML content
+     * @param swaggerContent OpenAPI/Swagger JSON content
+     * @return Fixed MCP config YAML content
+     */
+    @SuppressWarnings("unchecked")
+    private String fixRequestBodyInMcpConfig(String mcpConfigContent, String swaggerContent) throws Exception {
+        if (StringUtils.isBlank(mcpConfigContent) || StringUtils.isBlank(swaggerContent)) {
+            return mcpConfigContent;
+        }
+
+        // Parse MCP config YAML
+        Map<String, Object> mcpConfig = YAML_MAPPER.readValue(mcpConfigContent, Map.class);
+        
+        // Parse OpenAPI spec JSON
+        Map<String, Object> openApiSpec = JSON_MAPPER.readValue(swaggerContent, Map.class);
+        
+        // Extract paths from OpenAPI spec
+        Map<String, Object> paths = (Map<String, Object>) openApiSpec.get("paths");
+        if (paths == null) {
+            return mcpConfigContent;
+        }
+
+        // Get tools from MCP config
+        List<Map<String, Object>> tools = (List<Map<String, Object>>) mcpConfig.get("tools");
+        if (tools == null) {
+            return mcpConfigContent;
+        }
+
+        // Build operationId to path mapping from OpenAPI
+        Map<String, Map<String, Object>> operationMap = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> pathEntry : paths.entrySet()) {
+            String path = pathEntry.getKey();
+            Map<String, Object> pathMethods = (Map<String, Object>) pathEntry.getValue();
+            
+            for (Map.Entry<String, Object> methodEntry : pathMethods.entrySet()) {
+                String method = methodEntry.getKey().toLowerCase();
+                Map<String, Object> operation = (Map<String, Object>) methodEntry.getValue();
+                String operationId = (String) operation.get("operationId");
+                
+                if (StringUtils.isNotBlank(operationId)) {
+                    operationMap.put(operationId, operation);
+                }
+            }
+        }
+
+        // Fix each tool
+        boolean hasChanges = false;
+        for (Map<String, Object> tool : tools) {
+            String toolName = (String) tool.get("name");
+            if (StringUtils.isBlank(toolName)) {
+                continue;
+            }
+
+            // Try to find matching operation in OpenAPI spec
+            Map<String, Object> operation = operationMap.get(toolName);
+            if (operation == null) {
+                // Try to find by matching description or summary
+                for (Map.Entry<String, Map<String, Object>> entry : operationMap.entrySet()) {
+                    Map<String, Object> op = entry.getValue();
+                    String summary = (String) op.get("summary");
+                    String description = (String) op.get("description");
+                    String toolDescription = (String) tool.get("description");
+                    
+                    if ((StringUtils.isNotBlank(summary) && summary.equals(toolDescription)) ||
+                        (StringUtils.isNotBlank(description) && description.equals(toolDescription))) {
+                        operation = op;
+                        break;
+                    }
+                }
+            }
+
+            if (operation == null) {
+                continue;
+            }
+
+            // Check if operation has requestBody
+            Map<String, Object> requestBody = (Map<String, Object>) operation.get("requestBody");
+            if (requestBody == null) {
+                continue;
+            }
+
+            // Get existing args
+            List<Map<String, Object>> args = (List<Map<String, Object>>) tool.get("args");
+            if (args == null) {
+                args = new ArrayList<>();
+                tool.put("args", args);
+                hasChanges = true;
+            }
+
+            // Extract requestBody schema
+            Map<String, Object> content = (Map<String, Object>) requestBody.get("content");
+            if (content == null) {
+                continue;
+            }
+
+            // Find the first content type (prefer application/json, then application/x-www-form-urlencoded)
+            String contentType = null;
+            Map<String, Object> schemaMap = null;
+            
+            if (content.containsKey("application/json")) {
+                contentType = "application/json";
+                Map<String, Object> jsonContent = (Map<String, Object>) content.get("application/json");
+                schemaMap = (Map<String, Object>) jsonContent.get("schema");
+            } else if (content.containsKey("application/x-www-form-urlencoded")) {
+                contentType = "application/x-www-form-urlencoded";
+                Map<String, Object> formContent = (Map<String, Object>) content.get("application/x-www-form-urlencoded");
+                schemaMap = (Map<String, Object>) formContent.get("schema");
+            } else {
+                // Get the first available content type
+                for (Map.Entry<String, Object> contentEntry : content.entrySet()) {
+                    contentType = contentEntry.getKey();
+                    Map<String, Object> contentValue = (Map<String, Object>) contentEntry.getValue();
+                    schemaMap = (Map<String, Object>) contentValue.get("schema");
+                    break;
+                }
+            }
+
+            if (schemaMap == null) {
+                continue;
+            }
+
+            // Extract properties from schema
+            Map<String, Object> properties = (Map<String, Object>) schemaMap.get("properties");
+            if (properties == null || properties.isEmpty()) {
+                continue;
+            }
+
+            // Get required fields
+            List<String> required = (List<String>) schemaMap.get("required");
+            if (required == null) {
+                required = new ArrayList<>();
+            }
+
+            // Check if args already contain requestBody parameters
+            Map<String, Boolean> existingArgs = new LinkedHashMap<>();
+            for (Map<String, Object> arg : args) {
+                String argName = (String) arg.get("name");
+                if (argName != null) {
+                    existingArgs.put(argName, true);
+                }
+            }
+
+            // Add missing parameters from requestBody
+            for (Map.Entry<String, Object> propEntry : properties.entrySet()) {
+                String propName = propEntry.getKey();
+                Map<String, Object> propSchema = (Map<String, Object>) propEntry.getValue();
+                
+                // Skip if already exists
+                if (existingArgs.containsKey(propName)) {
+                    continue;
+                }
+
+                Map<String, Object> newArg = new LinkedHashMap<>();
+                newArg.put("name", propName);
+                
+                // Set description
+                String propDescription = (String) propSchema.get("description");
+                if (StringUtils.isNotBlank(propDescription)) {
+                    newArg.put("description", propDescription);
+                }
+                
+                // Set type
+                String propType = (String) propSchema.get("type");
+                if (StringUtils.isNotBlank(propType)) {
+                    newArg.put("type", propType);
+                }
+                
+                // Set required
+                newArg.put("required", required.contains(propName));
+                
+                // Set position to body for POST/PUT/PATCH requests
+                newArg.put("position", "body");
+                
+                args.add(newArg);
+                hasChanges = true;
+            }
+
+            // Update requestTemplate to include body for POST/PUT/PATCH requests
+            if (hasChanges && (contentType != null && (contentType.equals("application/json") || 
+                contentType.equals("application/x-www-form-urlencoded")))) {
+                Map<String, Object> requestTemplate = (Map<String, Object>) tool.get("requestTemplate");
+                if (requestTemplate == null) {
+                    requestTemplate = new LinkedHashMap<>();
+                    tool.put("requestTemplate", requestTemplate);
+                }
+
+                String method = (String) requestTemplate.get("method");
+                if (method == null || method.equalsIgnoreCase("GET")) {
+                    // Set default method to POST if not specified and has requestBody
+                    requestTemplate.put("method", "POST");
+                }
+
+                // Ensure Content-Type header is set
+                List<Map<String, String>> headers = (List<Map<String, String>>) requestTemplate.get("headers");
+                if (headers == null) {
+                    headers = new ArrayList<>();
+                    requestTemplate.put("headers", headers);
+                }
+
+                // Check if Content-Type header already exists
+                boolean hasContentType = false;
+                for (Map<String, String> header : headers) {
+                    if ("Content-Type".equalsIgnoreCase(header.get("key"))) {
+                        hasContentType = true;
+                        break;
+                    }
+                }
+
+                if (!hasContentType) {
+                    Map<String, String> contentTypeHeader = new LinkedHashMap<>();
+                    contentTypeHeader.put("key", "Content-Type");
+                    contentTypeHeader.put("value", contentType);
+                    headers.add(contentTypeHeader);
+                }
+            }
+        }
+
+        if (hasChanges) {
+            return YAML_MAPPER.writeValueAsString(mcpConfig);
+        }
+
+        return mcpConfigContent;
     }
 }


### PR DESCRIPTION
…ersion

### Ⅰ. Describe what this PR did
修复了使用 all-in-one 方式部署服务时，Swagger/OpenAPI 的 requestBody 参数在转换为 MCP 配置后不显示的问题。

**问题描述：**
在使用 Swagger/OpenAPI 文档转换为 MCP 工具配置时，如果 API 定义了 `requestBody`，转换后的 MCP 配置中的 `args` 数组不包含这些 requestBody 参数，导致工具参数缺失。

**修复方案：**
在 `McpServerHelper.swaggerToMcpConfig()` 方法中，添加了 `fixRequestBodyInMcpConfig()` 后处理逻辑：
1. 解析转换后的 MCP 配置 YAML 和原始 OpenAPI JSON
2. 从 OpenAPI 的 `requestBody` 中提取参数（支持 `application/json` 和 `application/x-www-form-urlencoded`）
3. 将缺失的参数添加到工具的 `args` 数组中，并设置正确的属性（name、description、type、required、position: body）
4. 自动设置 `requestTemplate.headers` 中的 `Content-Type` 头

**修改文件：**
- `backend/sdk/pom.xml`: 添加 `jackson-dataformat-yaml` 依赖
- `backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServerHelper.java`: 添加修复逻辑

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
修复了 Swagger/OpenAPI 转 MCP 配置时 requestBody 参数丢失的问题。（Higress仓库中#3207）

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
已在本地通过实际场景验证：
1. 使用包含 requestBody 的 OpenAPI 文档进行转换测试
2. 验证转换后的配置包含所有 requestBody 参数
3. 验证参数属性正确（position: body、required 等）
4. 通过前端界面验证参数正确显示

建议后续可以添加单元测试覆盖以下场景：
- 不同 content-type 的 requestBody（application/json、application/x-www-form-urlencoded）
- 必需和可选参数的区分
- 工具名称与 operationId 的匹配逻辑
- Content-Type 头的自动设置

### Ⅳ. Describe how to verify it
**验证步骤：**

1. **启动后端服务：**
   ```bash
   cd backend
   mvn spring-boot:run -pl console
   ```

2. **准备测试数据：**
   使用包含 requestBody 的 OpenAPI 文档，例如 `test-swagger-requestbody.json` 文件中的内容。

3. **通过前端界面验证：**
   - 访问 Higress Console 前端
   - 进入 MCP 管理页面
   - 创建或编辑 MCP 服务（服务类型选择 OpenAPI）
   - 在工具配置中使用 Swagger 模式，粘贴 OpenAPI 文档
   - 点击"解析Swagger并合并"
   - 在工具列表的"参数"列中，应该能看到所有 requestBody 中定义的参数

4. **通过 API 验证：**
   ```bash
   curl -X POST http://localhost:8080/v1/mcpServer/swaggerToMcpConfig \
     -H "Content-Type: application/json" \
     -d '{"content": "..."}'
   ```
   检查返回的 YAML 配置中的 `tools[].args[]` 是否包含 requestBody 参数。

**验证点：**
- ✅ requestBody 中的所有参数都出现在 `args` 数组中
- ✅ 每个参数都有 `position: body` 属性
- ✅ `required` 属性与 OpenAPI 定义一致
- ✅ `requestTemplate.headers` 包含正确的 `Content-Type` 头
- ✅ 参数的类型和描述正确

**测试文件：**
项目中提供了 `test-swagger-requestbody.json` 作为测试用例，包含：
- `createUser` 工具：application/json 格式的 requestBody，包含 username、email、age、isActive
- `submitForm` 工具：application/x-www-form-urlencoded 格式的 requestBody，包含 name、phone、message

### Ⅴ. Special notes for reviews
1. **向后兼容性：**
   - 修复逻辑通过 try-catch 包裹，如果修复失败会回退到原始配置，不影响现有功能
   - 只处理缺失的参数，不会删除或修改已存在的参数

2. **性能考虑：**
   - 仅在检测到有 requestBody 的情况下才进行修复处理
   - 使用 LinkedHashMap 保持参数顺序

3. **匹配逻辑：**
   - 优先通过 `operationId` 匹配工具名称
   - 如果匹配失败，尝试通过 `summary` 或 `description` 匹配
   - 如果都匹配不到，跳过该工具的修复（不影响其他工具）

4. **Content-Type 处理：**
   - 优先处理 `application/json` 和 `application/x-www-form-urlencoded`
   - 如果都没有，使用第一个可用的 content-type
   - 自动设置 `Content-Type` header，避免重复设置

5. **依赖说明：**
   - 添加了 `jackson-dataformat-yaml` 依赖用于 YAML 解析和生成
   - 该依赖在项目中已有使用（测试代码中），不会引入新的依赖风险