### PR TITLE
fix: Fix the bug that external dashboard cannot be embedded

### DIFF
--- a/frontend/src/document.tsx
+++ b/frontend/src/document.tsx
@@ -7,8 +7,6 @@ export default function Document() {
         <meta charSet="utf-8" />
         <link rel="icon" href="/higress.jpg" type="image/x-icon" />
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-        {/* 防止点击劫持攻击 */}
-        <meta httpEquiv="x-Frame-Options" content="DENY" />
         {/* 内容安全策略 */}
         <meta
           httpEquiv="Content-Security-Policy"
@@ -16,7 +14,7 @@ export default function Document() {
             "default-src 'self'; " +
             "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
             "style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data:; " +
+            "img-src * data:; " +
             "font-src 'self' data:; " +
             "connect-src 'self'; " +
             "frame-src *; "


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

#### References:

1. The `frame-src` directive specifies valid sources for nested browsing contexts loading using elements such as `<frame>` and `<iframe>`.
    https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-src
2. The `frame-ansestor` directive is not supported in the `meta` element.
    https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors
3. Plugin icons use external CDN image URLs. So `img-src` shall be adjusted accordingly.
4. `X-Frame-Options` may only be set via an HTTP header sent along with a document. It may not be set inside `<meta>`.

#### Before

<img width="800" alt="image" src="https://github.com/user-attachments/assets/7057016f-2904-4c4b-906f-05de8ccab8be" />

#### After

<img width="800" alt="image" src="https://github.com/user-attachments/assets/e3fb1a76-310f-44a9-9c66-be5bc7cf4457" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
