### PR TITLE
feat: Support disabling generating model-router and ai-statistics configs when saving AI routes using env

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
@@ -59,6 +59,7 @@ import com.alibaba.higress.sdk.service.WasmPluginInstanceService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
 import com.alibaba.higress.sdk.service.kubernetes.crd.istio.V1alpha3EnvoyFilter;
+import com.alibaba.higress.sdk.util.EnvUtil;
 import com.alibaba.higress.sdk.util.MapUtil;
 import com.alibaba.higress.sdk.util.StringUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -70,6 +71,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class AiRouteServiceImpl implements AiRouteService {
+
+    private static final String AI_ROUTE_AUTO_ENABLE_AI_STATS_ENV_KEY = "AI_ROUTE_AUTO_ENABLE_AI_STATS";
+    private static final String AI_ROUTE_AUTO_ENABLE_MODEL_ROUTER_ENV_KEY = "AI_ROUTE_AUTO_ENABLE_MODEL_ROUTER";
 
     private static final String ROUTE_FALLBACK_ENVOY_FILTER_CONFIG_PATH = "/templates/envoyfilter-route-fallback.yaml";
 
@@ -239,8 +243,7 @@ public class AiRouteServiceImpl implements AiRouteService {
         String routeName = buildRouteResourceName(aiRoute.getName());
         Route route = buildRoute(routeName, aiRoute);
         setUpstreams(route, aiRoute.getUpstreams());
-        saveRoute(route);
-        writeModelRouteResources(aiRoute.getModelPredicates());
+        writeModelRouterResources(aiRoute.getModelPredicates());
         writeModelMappingResources(routeName, aiRoute.getUpstreams());
         writeAiStatisticsResources(routeName);
     }
@@ -305,8 +308,12 @@ public class AiRouteServiceImpl implements AiRouteService {
         writeAiStatisticsResources(fallbackRouteName);
     }
 
-    private void writeModelRouteResources(List<AiModelPredicate> modelPredicates) {
+    private void writeModelRouterResources(List<AiModelPredicate> modelPredicates) {
         if (CollectionUtils.isEmpty(modelPredicates)) {
+            return;
+        }
+
+        if (!EnvUtil.getBooleanEnv(AI_ROUTE_AUTO_ENABLE_MODEL_ROUTER_ENV_KEY, true)) {
             return;
         }
 
@@ -373,6 +380,10 @@ public class AiRouteServiceImpl implements AiRouteService {
     }
 
     private void writeAiStatisticsResources(String routeName) {
+        if (!EnvUtil.getBooleanEnv(AI_ROUTE_AUTO_ENABLE_AI_STATS_ENV_KEY, true)) {
+            return;
+        }
+
         WasmPluginInstance existedInstance = wasmPluginInstanceService.query(WasmPluginInstanceScope.ROUTE, routeName,
             BuiltInPluginName.AI_STATISTICS, false);
         if (existedInstance != null) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/util/EnvUtil.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/util/EnvUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.util;
+
+public class EnvUtil {
+
+    private EnvUtil() {
+    }
+
+    public static boolean getBooleanEnv(String name, boolean defaultValue) {
+        String value = System.getenv(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(value);
+    }
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Support disabling generating model-router and ai-statistics configs when saving AI routes using env.

```bash
AI_ROUTE_AUTO_ENABLE_AI_STATS=true
AI_ROUTE_AUTO_ENABLE_MODEL_ROUTER=true
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
