### PR TITLE
feat：路由管理新增筛选功能

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -615,6 +615,13 @@
     }
   },
   "route": {
+    "search": {
+      "name": "Please select the Route Name",
+      "domain": "Please select the Domain",
+      "routePredicates": "Please select the Route Predicates",
+      "services": "Please select the Service",
+      "auth": "Please select the Request Auth"
+    },
     "columns": {
       "name": "Route Name",
       "domains": "Domain",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -615,6 +615,13 @@
     }
   },
   "route": {
+    "search": {
+      "name": "请选择路由名称",
+      "domain": "请选择域名",
+      "routePredicates": "请选择路由条件",
+      "services": "请选择目标服务",
+      "auth": "请选择已授权的服务"
+    },
     "columns": {
       "name": "路由名称",
       "domains": "域名",


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
1、删除路由管理页的输入框搜索
2、新增路由名称、域名、路由条件、目标服务、请求授权的多选下拉筛选
3、新增的筛选框的内容进行中英文的适配

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
feat ： [https://github.com/alibaba/higress/issues/3245](url)
### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it
1、筛选功能：可以任意选择，单个下拉框是or的关系；多个下拉框之间是and的关系。
2、中英文适配：点击右上角的切换语言即可。
## 中文：
#before：
<img width="1897" height="933" alt="image" src="https://github.com/user-attachments/assets/e73bcace-608f-4124-b545-6d7ffbbcc38b" />
# After：
<img width="1883" height="935" alt="image" src="https://github.com/user-attachments/assets/d11337ce-57db-49ea-ad05-1ccd40643469" />


## 英文：

# Before：
<img width="1882" height="931" alt="image" src="https://github.com/user-attachments/assets/29fad37a-a2fb-41d4-92b9-7bf8a5256a3d" />
# After：
<img width="1883" height="921" alt="image" src="https://github.com/user-attachments/assets/b256f97e-4c80-4df0-a995-4eb1075b81f3" />

### Ⅴ. Special notes for reviews
