### PR TITLE
fix: Update envoyfilter for AI route fallback to be compatible with the new gateway filter change in 2.1.10

### DIFF
--- a/backend/sdk/src/main/resources/templates/envoyfilter-route-fallback.yaml
+++ b/backend/sdk/src/main/resources/templates/envoyfilter-route-fallback.yaml
@@ -90,3 +90,5 @@ spec:
                                       key: "${fallbackHeader}"
                                       value: "${routeName}"
                                     append: false
+                with_request_body:
+                  max_request_bytes: 1024000


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Add a new `with_request_body.max_request_bytes` field to the envoyfilter applying configs to `custom_response` filter for AI route fallback, so the request body can be buffered in gateway correctly, which requires this field based on my DingTalk conversation with @rinfx.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
