### PR TITLE
feat: use lightweight mode for ai-statistics plugin configuration

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiStatisticsConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiStatisticsConfig.java
@@ -18,6 +18,8 @@ import java.util.Map;
 public class AiStatisticsConfig {
 
     public static final String ATTRIBUTES = "attributes";
+    public static final String USE_DEFAULT_ATTRIBUTES = "use_default_attributes";
+    public static final String USE_DEFAULT_RESPONSE_ATTRIBUTES = "use_default_response_attributes";
 
     public static final String KEY = "key";
     public static final String VALUE_SOURCE = "value_source";

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
@@ -396,16 +396,7 @@ public class AiRouteServiceImpl implements AiRouteService {
         instance.setEnabled(true);
         instance.setInternal(false);
 
-        Map<String, Object> questionAttribute = AiStatisticsConfig.buildAttribute("question",
-            AiStatisticsConfig.ValueSource.REQUEST_BODY, "messages.@reverse.0.content", null, true, null);
-        Map<String, Object> streamingAnswerAttribute =
-            AiStatisticsConfig.buildAttribute("answer", AiStatisticsConfig.ValueSource.RESPONSE_STREAMING_BODY,
-                "choices.0.delta.content", AiStatisticsConfig.Rule.APPEND, true, null);
-        Map<String, Object> nonStreamingAnswerAttribute = AiStatisticsConfig.buildAttribute("answer",
-            AiStatisticsConfig.ValueSource.RESPONSE_BODY, "choices.0.message.content", null, true, null);
-        List<Map<String, Object>> attributes =
-            Lists.newArrayList(questionAttribute, streamingAnswerAttribute, nonStreamingAnswerAttribute);
-        instance.setConfigurations(MapUtil.of(AiStatisticsConfig.ATTRIBUTES, attributes));
+        instance.setConfigurations(MapUtil.of(AiStatisticsConfig.USE_DEFAULT_RESPONSE_ATTRIBUTES, true));
 
         wasmPluginInstanceService.addOrUpdate(instance);
     }


### PR DESCRIPTION
## What this PR does

Configures the ai-statistics plugin to use lightweight mode (`use_default_response_attributes: true`) for AI routes, which is recommended for production environments.

## Changes

1. **AiStatisticsConfig.java**: Add `USE_DEFAULT_RESPONSE_ATTRIBUTES` constant
2. **AiRouteServiceImpl.java**: Use `use_default_response_attributes: true` in `writeAiStatisticsResources`

## Why Lightweight Mode?

The lightweight mode is **recommended for production** because it avoids buffering large request/response bodies:
- **Excludes**: `messages` (complete conversation history), `answer` (streaming response), `reasoning`, `tool_calls`
- **Includes**: `question`, `system`, token statistics (`reasoning_tokens`, `cached_tokens`, `input_token_details`, `output_token_details`)

This prevents memory issues in high-concurrency scenarios with large conversations.

## Related

- https://github.com/alibaba/higress/pull/3512 (adds lightweight mode to ai-statistics plugin)
- https://github.com/alibaba/higress/pull/3511 (adds system field support)