### PR TITLE
fix: update mcp-server image path after migration

### DIFF
--- a/backend/sdk/src/main/resources/plugins/plugins.properties
+++ b/backend/sdk/src/main/resources/plugins/plugins.properties
@@ -31,7 +31,7 @@ ai-json-resp=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-json-
 ai-load-balancer=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-load-balancer:2.0.0
 model-router=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/model-router:2.0.0
 model-mapper=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/model-mapper:2.0.0
-mcp-server=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/mcp-server/all-in-one:2.0.0
+mcp-server=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/mcp-server:2.0.0
 
 # Auth
 basic-auth=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/basic-auth:2.0.0


### PR DESCRIPTION
## Summary

Update mcp-server OCI image path from `mcp-server/all-in-one` to `plugins/mcp-server` to match the new plugin structure.

## Related

- Higress PR: https://github.com/alibaba/higress/pull/3516

The mcp-server plugin has been moved from `mcp-servers/all-in-one` to `extensions/mcp-server`, so the OCI image path needs to be updated accordingly.