### PR TITLE
feat: add pluginImageRegistry and pluginImageNamespace config for built-in plugins

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/wasmplugin/WasmPluginServiceConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/wasmplugin/WasmPluginServiceConfig.java
@@ -23,6 +23,10 @@ import lombok.Data;
 public class WasmPluginServiceConfig {
     private static final String CUSTOM_IMAGE_URL_PATTERN_ENV = "HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN";
     private static final String CUSTOM_IMAGE_URL_PATTERN_PROPERTY = "higress-admin.wasmplugin.custom-image-url-pattern";
+    private static final String PLUGIN_IMAGE_REGISTRY_ENV = "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY";
+    private static final String PLUGIN_IMAGE_REGISTRY_PROPERTY = "higress-admin.wasmplugin.plugin-image-registry";
+    private static final String PLUGIN_IMAGE_NAMESPACE_ENV = "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE";
+    private static final String PLUGIN_IMAGE_NAMESPACE_PROPERTY = "higress-admin.wasmplugin.plugin-image-namespace";
     private static final String CUSTOM_IMAGE_PULL_SECRET_ENV = "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_PULL_SECRET";
     private static final String CUSTOM_IMAGE_PULL_POLICY_ENV = "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_PULL_POLICY";
     private static final String CUSTOM_IMAGE_PULL_SECRET_PROPERTY = "higress-admin.wasmplugin.custom-image-pull-secret";
@@ -32,6 +36,10 @@ public class WasmPluginServiceConfig {
         WasmPluginServiceConfig result = new WasmPluginServiceConfig();
         result.customImageUrlPattern =
             EnvReadUtil.loadCustomConfFromEnv(CUSTOM_IMAGE_URL_PATTERN_PROPERTY, CUSTOM_IMAGE_URL_PATTERN_ENV);
+        result.pluginImageRegistry =
+            EnvReadUtil.loadCustomConfFromEnv(PLUGIN_IMAGE_REGISTRY_PROPERTY, PLUGIN_IMAGE_REGISTRY_ENV);
+        result.pluginImageNamespace =
+            EnvReadUtil.loadCustomConfFromEnv(PLUGIN_IMAGE_NAMESPACE_PROPERTY, PLUGIN_IMAGE_NAMESPACE_ENV);
         result.imagePullSecret =
             EnvReadUtil.loadCustomConfFromEnv(CUSTOM_IMAGE_PULL_SECRET_PROPERTY, CUSTOM_IMAGE_PULL_SECRET_ENV);
         result.imagePullPolicy =
@@ -40,6 +48,8 @@ public class WasmPluginServiceConfig {
     }
 
     private String customImageUrlPattern;
+    private String pluginImageRegistry;
+    private String pluginImageNamespace;
     private String imagePullSecret;
     private String imagePullPolicy;
 }

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,4 +1,6 @@
 {{- $o11y := merge (dict) .Values.o11y .Values.global.o11y }}
+{{- $pluginImageRegistry := .Values.pluginServer.imageRegistry | default .Values.global.hub }}
+{{- $pluginImageNamespace := .Values.pluginServer.imageNamespace | default .Values.global.pluginNamespace }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,6 +75,20 @@ spec:
             {{- if and .Values.global.enablePluginServer (not (hasKey .Values.podEnvs "HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN"))}}
             - name: HIGRESS_ADMIN_WASM_PLUGIN_CUSTOM_IMAGE_URL_PATTERN
               value: "{{ .Values.pluginServer.urlPattern }}"
+            {{- end }}
+            {{- if and .Values.pluginServer.imageRegistry (not (hasKey .Values.podEnvs "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY")) }}
+            - name: HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY
+              value: "{{ .Values.pluginServer.imageRegistry }}"
+            {{- else if and $pluginImageRegistry (not (hasKey .Values.podEnvs "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY")) }}
+            - name: HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY
+              value: "{{ $pluginImageRegistry }}"
+            {{- end }}
+            {{- if and .Values.pluginServer.imageNamespace (not (hasKey .Values.podEnvs "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE")) }}
+            - name: HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE
+              value: "{{ .Values.pluginServer.imageNamespace }}"
+            {{- else if and $pluginImageNamespace (not (hasKey .Values.podEnvs "HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE")) }}
+            - name: HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE
+              value: "{{ $pluginImageNamespace }}"
             {{- end }}
             {{- if .Values.podEnvs }}
             {{- range $key, $val := .Values.podEnvs }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,6 +9,13 @@ global:
     # cluster domain. Default value is "cluster.local".
     clusterDomain: "cluster.local"
 
+  # -- Default hub (registry) for Higress images, passed from parent chart.
+  # Used for plugin image registry when pluginServer.imageRegistry is not set.
+  hub: ""
+  # -- Plugin image namespace for built-in plugins, passed from parent chart.
+  # Used when pluginServer.imageNamespace is not set. Default is "plugins".
+  pluginNamespace: ""
+
   # Observability (o11y) configurations
   o11y:
     enabled: false
@@ -130,3 +137,9 @@ pvc:
 
 pluginServer:
   urlPattern: "http://higress-plugin-server.higress-system.svc/plugins/${name}/${version}/plugin.wasm"
+  # -- Plugin image registry for built-in plugins. If set, will override the default registry in plugins.properties.
+  # Example: "my-registry.example.com"
+  imageRegistry: ""
+  # -- Plugin image namespace for built-in plugins. If set, will override the default namespace in plugins.properties.
+  # Default namespace is "plugins". Example: "my-plugins"
+  imageNamespace: ""


### PR DESCRIPTION
## What this PR does

This PR adds support for customizing the plugin image registry and namespace for built-in plugins without modifying the `plugins.properties` file.

### Changes

1. **WasmPluginServiceConfig.java**: 
   - Added `pluginImageRegistry` and `pluginImageNamespace` fields
   - Added support for environment variables `HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY` and `HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE`

2. **WasmPluginServiceImpl.java**:
   - Added `buildPluginImageUrl()` method to construct plugin image URL with custom registry/namespace
   - Priority: customPattern > registry/namespace > defaultUrl

3. **helm/values.yaml**:
   - Added `pluginServer.imageRegistry` and `pluginServer.imageNamespace` options
   - Added `global.hub` and `global.pluginNamespace` for parent chart integration

4. **helm/templates/deployment.yaml**:
   - Added environment variable injection for the new config options
   - Support fallback: `pluginServer.imageRegistry` → `global.hub`

### Priority Chain

For plugin image registry:
1. `pluginServer.imageRegistry` (direct config)
2. `global.hub` (parent chart, shared with deployments)

For plugin image namespace:
1. `pluginServer.imageNamespace` (direct config)
2. `global.pluginNamespace` (parent chart)

### Usage

Users can customize the plugin image registry via:

1. **Helm values** (from parent higress chart):
```yaml
global:
  hub: my-registry.example.com  # Shared with deployments
  pluginNamespace: my-plugins   # Optional, default is "plugins"
```

2. **Helm values** (standalone or override):
```yaml
pluginServer:
  imageRegistry: "my-registry.example.com"
  imageNamespace: "my-plugins"
```

3. **Environment variables**:
```bash
HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY=my-registry.example.com
HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_NAMESPACE=my-plugins
```

### Image URL Transformation

Default URL:
```
oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:2.0.0
```

With `global.hub=my-registry.example.com`:
```
oci://my-registry.example.com/plugins/ai-proxy:2.0.0
```

### Related

This PR works together with [higress PR #3521](https://github.com/alibaba/higress/pull/3521) to provide a complete solution for customizing plugin image locations using a shared `global.hub` parameter.