### PR TITLE
fix: sync proxyName between LlmProvider and ServiceSource for custom upstream

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderHandler.java
@@ -40,6 +40,18 @@ interface LlmProviderHandler {
 
     String getServiceSourceName(String providerName);
 
+    /**
+     * Get the effective service source name for a provider, considering custom upstream configurations.
+     * By default, this returns the same as {@link #getServiceSourceName(String)}.
+     *
+     * @param providerName the provider name
+     * @param providerConfig the provider configuration which may contain custom upstream settings
+     * @return the effective service source name
+     */
+    default String getEffectiveServiceSourceName(String providerName, Map<String, Object> providerConfig) {
+        return getServiceSourceName(providerName);
+    }
+
     ServiceSource buildServiceSource(String providerName, Map<String, Object> providerConfig);
 
     default List<ServiceSource> getExtraServiceSources(String providerName, Map<String, Object> providerConfig,

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
@@ -204,6 +204,17 @@ public class LlmProviderServiceImpl implements LlmProviderService {
                 serviceSource.setProxyName(provider.getProxyName());
                 serviceSourceService.addOrUpdate(serviceSource);
             }
+        } else if (provider.getProxyName() != null) {
+            // When using a custom upstream service (e.g., OpenAI with custom URL),
+            // buildServiceSource returns null, but we still need to sync proxyName
+            // to the existing service source.
+            String effectiveSourceName =
+                handler.getEffectiveServiceSourceName(provider.getName(), providerConfig);
+            ServiceSource existingSource = serviceSourceService.query(effectiveSourceName);
+            if (existingSource != null) {
+                existingSource.setProxyName(provider.getProxyName());
+                serviceSourceService.addOrUpdate(existingSource);
+            }
         }
         wasmPluginInstanceService.addOrUpdate(instance);
         wasmPluginInstanceService.addOrUpdate(serviceInstance);
@@ -416,6 +427,12 @@ public class LlmProviderServiceImpl implements LlmProviderService {
             }
             String serviceSourceName = handler.getServiceSourceName(provider.getName());
             ServiceSource serviceSource = serviceSourceMap.get(serviceSourceName);
+            if (serviceSource == null) {
+                // Try using the effective service source name (handles custom upstream cases)
+                String effectiveSourceName = handler.getEffectiveServiceSourceName(
+                    provider.getName(), provider.getRawConfigs());
+                serviceSource = serviceSourceMap.get(effectiveSourceName);
+            }
             if (serviceSource != null) {
                 provider.setProxyName(serviceSource.getProxyName());
             }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OpenaiLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/OpenaiLlmProviderHandler.java
@@ -77,6 +77,21 @@ public class OpenaiLlmProviderHandler extends AbstractLlmProviderHandler {
     }
 
     @Override
+    public String getEffectiveServiceSourceName(String providerName, Map<String, Object> providerConfig) {
+        UpstreamService customUpstream = getCustomUpstreamService(providerConfig);
+        if (customUpstream != null) {
+            // Custom upstream service name format: "serviceName.type" (e.g., "openai-compat.dns")
+            String name = customUpstream.getName();
+            int dotIndex = name.lastIndexOf('.');
+            if (dotIndex > 0) {
+                return name.substring(0, dotIndex);
+            }
+            return name;
+        }
+        return getServiceSourceName(providerName);
+    }
+
+    @Override
     public ServiceSource buildServiceSource(String providerName, Map<String, Object> providerConfig) {
         UpstreamService upstreamService = getCustomUpstreamService(providerConfig);
         if (upstreamService != null) {


### PR DESCRIPTION
## Summary

- When an OpenAI-type provider uses a custom upstream service (via `openaiCustomServiceName`/`openaiCustomServicePort`), `buildServiceSource()` returns `null`, causing the `proxyName` field to never be synced to the underlying `ServiceSource`
- The read path (`fillProxyInfo`) also fails because `getServiceSourceName()` returns `llm-{name}.internal` which doesn't match the actual service source name (e.g., `openai-compat`)
- Added `getEffectiveServiceSourceName()` to `LlmProviderHandler` interface and overrode it in `OpenaiLlmProviderHandler` to resolve the correct service source name from custom upstream config
- Fixed both write path (`addOrUpdate`) and read path (`fillProxyInfo`) to use the effective name as fallback

## Reproduction

1. Create a service source `openai-compat` of type `dns`
2. Create an AI provider of type `openai` with `openaiCustomServiceName: "openai-compat.dns"` and `proxyName: "mihomo"`
3. Query the provider — `proxyName` is always `null`
4. The proxy configuration is not synced to the service source

## Root Cause

In `OpenaiLlmProviderHandler.buildServiceSource()`, when a custom upstream service is detected, it returns `null` (line 85). This causes `LlmProviderServiceImpl.addOrUpdate()` to skip the `proxyName` sync loop entirely (lines 202-206).

For the read path, `getServiceSourceName()` generates `llm-openai-compat.internal` but the actual service source is named `openai-compat`, so the lookup in `fillProxyInfo()` always fails.

## Test plan

- [ ] Verify setting `proxyName` via `PUT /v1/ai/providers/{name}` persists to the service source when using custom upstream
- [ ] Verify `GET /v1/ai/providers/{name}` returns the correct `proxyName` from the service source
- [ ] Verify standard (non-custom) provider types still work correctly (no regression)
- [ ] Verify clearing `proxyName` (setting to `null` or empty) also syncs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)