### PR TITLE
fix(provider-form): preserve extra rawConfigs fields set via API on UI save

### DIFF
--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -88,6 +88,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
     if (serviceOptions == null) {
       serviceResult.run();
     }
+    originalRawConfigsRef.current = {}
     if (props.value) {
       const {
         name,


### PR DESCRIPTION
## Problem

When a provider config has fields set directly via API that have no corresponding form control (e.g. `mergeConsecutiveMessages: true`), those fields are silently lost the next time the user saves the provider through the console UI.

**Root cause**: Ant Design `form.validateFields()` only returns values for registered `<Form.Item>` paths. Extra `rawConfigs` keys not bound to any form field are absent from the submitted payload, causing the backend to replace the full plugin config without them.

## Fix

Store the original `rawConfigs` in a `useRef` when the form loads. On submit, spread it under the form values so unknown extra fields are preserved while UI-managed fields are still updated normally:

```ts
// originalRawConfigsRef.current = rawConfigs from props.value (set on load)

rawConfigs: { ...originalRawConfigsRef.current, ...(values.rawConfigs || {}) },
```

This is a **frontend-only change** — the API contract is unchanged. Direct API callers still control `rawConfigs` fully (they send the complete object); only UI users get the preservation behaviour.

## Changes

- `ProviderForm/index.tsx`: add `useRef` import; add `originalRawConfigsRef`; save original rawConfigs on load; merge on submit

## Test plan

- [x] Set an extra field via API (`rawConfigs: { mergeConsecutiveMessages: true }`)
- [x] Open the provider in the console UI, change any field (e.g. token), and save
- [x] Verify the saved config still contains `mergeConsecutiveMessages: true`