### PR TITLE
feat: 增加original协议可选配置传入，避免自动加上多余的请求体

### DIFF
--- a/frontend/src/interfaces/llm-provider.ts
+++ b/frontend/src/interfaces/llm-provider.ts
@@ -19,4 +19,5 @@ export interface TokeFailoverConfig {
 
 export enum LlmProviderProtocol {
   OPENAI_V1 = 'openai/v1',
+  ORIGINAL = 'original',
 }

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -15,6 +15,7 @@ const { Text, Link } = Typography;
 
 const protocolList = [
   { label: "openai/v1", value: "openai/v1" },
+  { label: "original", value: "original" },
 ];
 
 const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
增加original协议可选配置传入。选择original后，ai-proxy这个插件就不会对原始请求加上include_usage这个字段，避免对接外部大模型出错。


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
