### PR TITLE
optimize consumer list

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -112,6 +112,7 @@
     "deleteConfirmation": "Are you sure you want to delete <1>{{currentRouteName}}</1>?",
     "authNotEnabled": "Not enabled",
     "authEnabledWithoutConsumer": "Nobody authorized",
+    "viewConsumers": "View",
     "usage": "Usage",
     "aiRouteUsage": "AI Route Usage",
     "aiRouteUsageContent": "You can send a test request using the command below:",

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -112,7 +112,7 @@
     "deleteConfirmation": "Are you sure you want to delete <1>{{currentRouteName}}</1>?",
     "authNotEnabled": "Not enabled",
     "authEnabledWithoutConsumer": "Nobody authorized",
-    "viewConsumers": "View",
+    "viewConsumers": "View Consumers",
     "usage": "Usage",
     "aiRouteUsage": "AI Route Usage",
     "aiRouteUsageContent": "You can send a test request using the command below:",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -112,7 +112,7 @@
     "deleteConfirmation": "确定删除 <1>{{currentRouteName}}</1> 吗？",
     "authNotEnabled": "未开启认证",
     "authEnabledWithoutConsumer": "未授权任何人访问",
-    "viewConsumers": "查看",
+    "viewConsumers": "查看消费者",
     "usage": "使用方法",
     "aiRouteUsage": "AI路由使用方法",
     "aiRouteUsageContent": "可使用以下命令发送请求：",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -112,6 +112,7 @@
     "deleteConfirmation": "确定删除 <1>{{currentRouteName}}</1> 吗？",
     "authNotEnabled": "未开启认证",
     "authEnabledWithoutConsumer": "未授权任何人访问",
+    "viewConsumers": "查看",
     "usage": "使用方法",
     "aiRouteUsage": "AI路由使用方法",
     "aiRouteUsageContent": "可使用以下命令发送请求：",

--- a/frontend/src/pages/ai/route.tsx
+++ b/frontend/src/pages/ai/route.tsx
@@ -120,14 +120,11 @@ const AiRouteList: React.FC = () => {
         if (!Array.isArray(value) || !value.length) {
           return t('aiRoute.authEnabledWithoutConsumer');
         }
-        const result: React.ReactNode[] = [];
-        value.forEach((consumer, index) => {
-          if (index > 0) {
-            result.push(<br key={`br-${index}`} />);
-          }
-          result.push(<span key={`span-${index}`}>{consumer}</span>);
-        });
-        return result;
+        return (
+          <a onClick={() => { setConsumerModalList(value); setConsumerModalVisible(true); }}>
+            {t('aiRoute.viewConsumers')}
+          </a>
+        );
       },
     },
     {
@@ -162,6 +159,8 @@ const AiRouteList: React.FC = () => {
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [pluginData, setPluginsData] = useState<Record<string, WasmPluginData[]>>({});
   const [pluginInfoList, setPluginInfoList] = useState<WasmPluginData[]>([]);
+  const [consumerModalVisible, setConsumerModalVisible] = useState(false);
+  const [consumerModalList, setConsumerModalList] = useState<string[]>([]);
 
   const { loading: wasmLoading, run: loadWasmPlugins } = useRequest(() => {
     return getWasmPlugins(i18n.language)
@@ -485,6 +484,16 @@ const AiRouteList: React.FC = () => {
             确定删除 <span style={{ color: '#0070cc' }}>{{ currentRouteName: (currentAiRoute && currentAiRoute.name) || '' }}</span> 吗？
           </Trans>
         </p>
+      </Modal>
+      <Modal
+        title={t('aiRoute.viewConsumers')}
+        open={consumerModalVisible}
+        onCancel={() => setConsumerModalVisible(false)}
+        footer={null}
+      >
+        {consumerModalList.map((consumer: string) => (
+          <div key={consumer} style={{ padding: '4px 0' }}>{consumer}</div>
+        ))}
       </Modal>
     </PageContainer>
   );

--- a/frontend/src/pages/ai/route.tsx
+++ b/frontend/src/pages/ai/route.tsx
@@ -8,7 +8,7 @@ import { getWasmPlugins } from '@/services';
 import { ArrowRightOutlined, ExclamationCircleOutlined, RedoOutlined, SearchOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import { useRequest } from 'ahooks';
-import { Button, Col, Drawer, Form, FormProps, Input, message, Modal, Row, Space, Table } from 'antd';
+import { Button, Col, Drawer, Form, FormProps, Input, message, Modal, Popover, Row, Space, Table, Tag } from 'antd';
 import { history } from 'ice';
 import React, { useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -112,6 +112,7 @@ const AiRouteList: React.FC = () => {
       title: t('aiRoute.columns.auth'),
       dataIndex: ['authConfig', 'allowedConsumers'],
       key: 'authConfig.allowedConsumers',
+      width: 300,
       render: (value, record) => {
         const { authConfig } = record;
         if (!authConfig || !authConfig.enabled) {
@@ -120,10 +121,23 @@ const AiRouteList: React.FC = () => {
         if (!Array.isArray(value) || !value.length) {
           return t('aiRoute.authEnabledWithoutConsumer');
         }
+        const maxDisplay = 3;
+        const displayed = value.slice(0, maxDisplay);
+        const remaining = value.length - maxDisplay;
+        const popoverContent = (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, maxHeight: 300, overflow: 'auto' }}>
+            {value.map((c: string) => <div key={c}>{c}</div>)}
+          </div>
+        );
         return (
-          <a onClick={() => { setConsumerModalList(value); setConsumerModalVisible(true); }}>
-            {t('aiRoute.viewConsumers')}
-          </a>
+          <Popover content={popoverContent}>
+            <Space direction="vertical" size={4}>
+              {displayed.map((consumer: string) => (
+                <Tag key={consumer} style={{ maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{consumer}</Tag>
+              ))}
+              {remaining > 0 && <Tag>+{remaining}</Tag>}
+            </Space>
+          </Popover>
         );
       },
     },
@@ -159,8 +173,6 @@ const AiRouteList: React.FC = () => {
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [pluginData, setPluginsData] = useState<Record<string, WasmPluginData[]>>({});
   const [pluginInfoList, setPluginInfoList] = useState<WasmPluginData[]>([]);
-  const [consumerModalVisible, setConsumerModalVisible] = useState(false);
-  const [consumerModalList, setConsumerModalList] = useState<string[]>([]);
 
   const { loading: wasmLoading, run: loadWasmPlugins } = useRequest(() => {
     return getWasmPlugins(i18n.language)
@@ -484,16 +496,6 @@ const AiRouteList: React.FC = () => {
             确定删除 <span style={{ color: '#0070cc' }}>{{ currentRouteName: (currentAiRoute && currentAiRoute.name) || '' }}</span> 吗？
           </Trans>
         </p>
-      </Modal>
-      <Modal
-        title={t('aiRoute.viewConsumers')}
-        open={consumerModalVisible}
-        onCancel={() => setConsumerModalVisible(false)}
-        footer={null}
-      >
-        {consumerModalList.map((consumer: string) => (
-          <div key={consumer} style={{ padding: '4px 0' }}>{consumer}</div>
-        ))}
       </Modal>
     </PageContainer>
   );

--- a/frontend/src/pages/route/index.tsx
+++ b/frontend/src/pages/route/index.tsx
@@ -17,7 +17,7 @@ import { isInternalResource } from '@/utils';
 import { ExclamationCircleOutlined, RedoOutlined, SearchOutlined } from '@ant-design/icons';
 import { PageContainer } from '@ant-design/pro-layout';
 import { useRequest } from 'ahooks';
-import { Alert, Button, Col, Drawer, Form, Input, message, Modal, Row, Space, Table, Typography, Select } from 'antd';
+import { Alert, Button, Col, Drawer, Form, Input, message, Modal, Popover, Row, Space, Table, Tag, Typography, Select } from 'antd';
 import { history } from 'ice';
 import React, { useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -102,6 +102,7 @@ const RouteList: React.FC = () => {
       title: t('aiRoute.columns.auth'),
       dataIndex: ['authConfig', 'allowedConsumers'],
       key: 'authConfig.allowedConsumers',
+      width: 300,
       render: (value, record) => {
         const { authConfig } = record;
         if (!authConfig || !authConfig.enabled) {
@@ -110,10 +111,23 @@ const RouteList: React.FC = () => {
         if (!Array.isArray(value) || !value.length) {
           return t('aiRoute.authEnabledWithoutConsumer')
         }
+        const maxDisplay = 3;
+        const displayed = value.slice(0, maxDisplay);
+        const remaining = value.length - maxDisplay;
+        const popoverContent = (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, maxHeight: 300, overflow: 'auto' }}>
+            {value.map((c: string) => <div key={c}>{c}</div>)}
+          </div>
+        );
         return (
-          <a onClick={() => { setConsumerModalList(value); setConsumerModalVisible(true); }}>
-            {t('aiRoute.viewConsumers')}
-          </a>
+          <Popover content={popoverContent}>
+            <Space direction="vertical" size={4}>
+              {displayed.map((consumer: string) => (
+                <Tag key={consumer} style={{ maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{consumer}</Tag>
+              ))}
+              {remaining > 0 && <Tag>+{remaining}</Tag>}
+            </Space>
+          </Popover>
         );
       },
     },
@@ -154,8 +168,6 @@ const RouteList: React.FC = () => {
   const [selectedPathMatchTypes, setSelectedPathMatchTypes] = useState<string[]>([]);
   const [selectedServices, setSelectedServices] = useState<string[]>([]);
   const [selectedAllowedConsumers, setSelectedAllowedConsumers] = useState<string[]>([]);
-  const [consumerModalVisible, setConsumerModalVisible] = useState(false);
-  const [consumerModalList, setConsumerModalList] = useState<string[]>([]);
 
   // 使用useRef保持最新状态以便在事件处理器外访问
   const selectedNamesRef = useRef(selectedNames);
@@ -635,16 +647,6 @@ const RouteList: React.FC = () => {
             吗？
           </Trans>
         </p>
-      </Modal>
-      <Modal
-        title={t('aiRoute.viewConsumers')}
-        open={consumerModalVisible}
-        onCancel={() => setConsumerModalVisible(false)}
-        footer={null}
-      >
-        {consumerModalList.map((consumer: string) => (
-          <div key={consumer} style={{ padding: '4px 0' }}>{consumer}</div>
-        ))}
       </Modal>
       <Drawer
         title={t(currentRoute ? 'route.editRoute' : 'route.createRoute')}

--- a/frontend/src/pages/route/index.tsx
+++ b/frontend/src/pages/route/index.tsx
@@ -110,14 +110,11 @@ const RouteList: React.FC = () => {
         if (!Array.isArray(value) || !value.length) {
           return t('aiRoute.authEnabledWithoutConsumer')
         }
-        return value.map((consumer: string, index: number) => {
-          return (
-            <span key={consumer}>
-              {index !== 0 && (<br />)}
-              {consumer}
-            </span>
-          );
-        });
+        return (
+          <a onClick={() => { setConsumerModalList(value); setConsumerModalVisible(true); }}>
+            {t('aiRoute.viewConsumers')}
+          </a>
+        );
       },
     },
     {
@@ -157,6 +154,8 @@ const RouteList: React.FC = () => {
   const [selectedPathMatchTypes, setSelectedPathMatchTypes] = useState<string[]>([]);
   const [selectedServices, setSelectedServices] = useState<string[]>([]);
   const [selectedAllowedConsumers, setSelectedAllowedConsumers] = useState<string[]>([]);
+  const [consumerModalVisible, setConsumerModalVisible] = useState(false);
+  const [consumerModalList, setConsumerModalList] = useState<string[]>([]);
 
   // 使用useRef保持最新状态以便在事件处理器外访问
   const selectedNamesRef = useRef(selectedNames);
@@ -636,6 +635,16 @@ const RouteList: React.FC = () => {
             吗？
           </Trans>
         </p>
+      </Modal>
+      <Modal
+        title={t('aiRoute.viewConsumers')}
+        open={consumerModalVisible}
+        onCancel={() => setConsumerModalVisible(false)}
+        footer={null}
+      >
+        {consumerModalList.map((consumer: string) => (
+          <div key={consumer} style={{ padding: '4px 0' }}>{consumer}</div>
+        ))}
       </Modal>
       <Drawer
         title={t(currentRoute ? 'route.editRoute' : 'route.createRoute')}


### PR DESCRIPTION
### Ⅰ. Describe what this PR did                                                                                                                                                                               
                                                                                                                                                                                                                 
  优化路由列表中 `allowedConsumers` 的展示方式。当路由开启了认证并配置了授权消费者时，将原来直接平铺展示所有消费者名称的方式，改为最多展示3个，超过3个popover展示。同时新增中英文国际化  
  key `aiRoute.viewConsumers`。
                                                                                                                                                                                                                 
  ### Ⅱ. Does this pull request fix one issue?                                                                                                                                                                   
   
  No.                                                                                                                                                                                                            
                  
  ### Ⅲ. Why don't you add test cases (unit test/integration test)?                                                                                                                                              
                  
  This is a pure frontend UI interaction change (table column rendering + Modal display), no complex business logic involved.                                                                                    
                  
  ### Ⅳ. Describe how to verify it                                                                                                                                                                               
                  
  1. 进入路由列表页面，找到一条开启了认证并配置了授权消费者的路由                                                                                                                                                
  2. 确认 `allowedConsumers` 列不再平铺展示所有消费者，而是显示一个"查看"链接
  3. 鼠标放上去，确认弹出 popover并正确展示该路由授权的所有消费者                                                                                                                                             
  4. 关闭 Modal 确认能正常关闭                                                                                                                                                                                   
                                                                                                                                                                                                                 
  ### Ⅴ. Special notes for reviews                                                                                                                                                                               
                                                                                                                                                                                                                 
  None. 