### PR TITLE
fix: sort upstreams by weight before writing model-mapper config

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
@@ -15,7 +15,9 @@ package com.alibaba.higress.sdk.service.ai;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -348,13 +350,33 @@ public class AiRouteServiceImpl implements AiRouteService {
         }
 
         final String pluginName = BuiltInPluginName.MODEL_MAPPER;
-        for (AiUpstream upstream : upstreams) {
+
+        // Multiple upstreams of the same provider resolve to the same service and share
+        // one model-mapper instance. Group by service, merge their modelMappings, and
+        // write once per service. Higher-weight upstreams take precedence on conflicts.
+        Map<String, String> serviceByProvider = new LinkedHashMap<>();
+        Map<String, Map<String, String>> mergedMappings = new LinkedHashMap<>();
+
+        List<AiUpstream> sorted = new ArrayList<>(upstreams);
+        sorted.sort(Comparator.comparingInt(u -> Optional.ofNullable(u.getWeight()).orElse(0)));
+
+        for (AiUpstream upstream : sorted) {
             UpstreamService upstreamService = llmProviderService.buildUpstreamService(upstream.getProvider());
+            String serviceName = upstreamService.getName();
+            serviceByProvider.putIfAbsent(serviceName, upstream.getProvider());
 
+            if (MapUtils.isNotEmpty(upstream.getModelMapping())) {
+                mergedMappings.computeIfAbsent(serviceName, k -> new HashMap<>())
+                    .putAll(upstream.getModelMapping());
+            }
+        }
+
+        for (String serviceName : serviceByProvider.keySet()) {
             Map<WasmPluginInstanceScope, String> targets = MapUtil.of(WasmPluginInstanceScope.ROUTE, routeName,
-                WasmPluginInstanceScope.SERVICE, upstreamService.getName());
+                WasmPluginInstanceScope.SERVICE, serviceName);
 
-            if (MapUtils.isEmpty(upstream.getModelMapping())) {
+            Map<String, String> merged = mergedMappings.get(serviceName);
+            if (MapUtils.isEmpty(merged)) {
                 wasmPluginInstanceService.delete(targets, pluginName, true);
                 continue;
             }
@@ -369,12 +391,11 @@ public class AiRouteServiceImpl implements AiRouteService {
 
             Map<String, Object> configurations = instance.getConfigurations();
             if (MapUtils.isEmpty(configurations)) {
-                // Just in case it is a readonly empty map.
                 configurations = new HashMap<>();
                 instance.setConfigurations(configurations);
             }
 
-            configurations.put(ModelMapperConfig.MODEL_MAPPING, new HashMap<>(upstream.getModelMapping()));
+            configurations.put(ModelMapperConfig.MODEL_MAPPING, new HashMap<>(merged));
 
             wasmPluginInstanceService.addOrUpdate(instance);
         }


### PR DESCRIPTION
## Summary

Fix model-mapper plugin config corruption when multiple upstreams share the same provider.

## Problem

`writeModelMappingResources()` iterates over upstreams individually and writes one model-mapper instance per iteration. Since upstreams of the same provider resolve to the same service (and thus the same plugin instance scope), the last upstream processed overwrites the entire `modelMapping` — causing three bugs:

1. **Weight ignored**: A weight-0 upstream's mapping silently overrides a weight-100 upstream's mapping depending on array order.
2. **Non-conflicting keys lost**: Different upstreams with non-conflicting mapping keys (e.g., `{gpt-4: gpt-4-turbo}` and `{gpt-3.5: gpt-3.5-turbo}`) lose earlier entries because `new HashMap<>(upstream.getModelMapping())` replaces the entire map.
3. **Empty mapping deletes siblings**: An upstream with null/empty `modelMapping` triggers `delete(targets)`, removing mappings written by sibling upstreams of the same provider.

## Fix

Group upstreams by resolved service name, sort by weight ascending, and **merge** all their `modelMapping` entries into one map per service. Higher-weight entries take precedence on key conflicts. Write once per service instead of once per upstream.

```java
// Before: per-upstream loop, last-write-wins, entire map replaced
for (AiUpstream upstream : upstreams) {
    configurations.put(MODEL_MAPPING, new HashMap<>(upstream.getModelMapping()));
    wasmPluginInstanceService.addOrUpdate(instance);
}

// After: group by service, merge mappings, write once
Map<String, Map<String, String>> mergedMappings = new LinkedHashMap<>();
sorted.sort(byWeightAsc);  // highest weight last → wins on conflicts
for (AiUpstream upstream : sorted) {
    mergedMappings.computeIfAbsent(serviceName, k -> new HashMap<>())
        .putAll(upstream.getModelMapping());
}
// write merged mapping once per service
```

## Edge cases handled

| Scenario | Before | After |
|----------|--------|-------|
| Same provider, `*→kimi` (w=100) + `*→glm` (w=0) | `glm` wins (wrong) | `kimi` wins ✓ |
| Same provider, `{gpt-4→turbo}` (w=50) + `{gpt-3.5→turbo}` (w=50) | Only last survives | Both merged ✓ |
| Same provider, has mapping (w=50) + empty mapping (w=50) | Instance deleted | Mapping preserved ✓ |
| Different providers with modelMapping | Works (separate instances) | No change ✓ |

## Test plan

- [ ] Same provider, conflicting key, different weights → highest weight wins
- [ ] Same provider, non-conflicting keys → all keys merged
- [ ] Same provider, one has mapping + one empty → mapping preserved
- [ ] Different providers → separate instances, no regression
- [ ] Single upstream → no behavior change

Fixes #695