### PR TITLE
fix: Disable the default config of ai-proxy when no provider is in it

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
@@ -270,6 +270,10 @@ public class LlmProviderServiceImpl implements LlmProviderService {
             return;
         }
 
+        if (providers.isEmpty()) {
+            globalInstance.setEnabled(false);
+        }
+
         // Delete other resources related to the deleted provider.
         Object type = deletedProvider.get(PROVIDER_TYPE);
         if (type != null) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Disable the default config of ai-proxy when no provider is in it, so gateway doesn't need to load the wasm plugin any more.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
