### PR TITLE
fix(llm-provider): Use blacklist for rawConfigs merge to prevent stale config bleeding

### DIFF
--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -8,7 +8,7 @@ import { AutoComplete, Button, Empty, Form, Input, InputNumber, Modal, Select, S
 import { useRequest } from 'ice';
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { aiModelProviders } from '../../configs';
+import { aiModelProviders, builtInProviderConfigKeys } from '../../configs';
 
 const { TextArea } = Input;
 const { Text, Link } = Typography;
@@ -216,6 +216,16 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
         providerConfig.normalizeRawConfigs(values.rawConfigs);
       }
 
+      // Only keep keys from the original that the current provider doesn't supports.
+      const supportedKeys = new Set(builtInProviderConfigKeys);
+      (providerConfig?.customRawConfigsKeys || []).forEach(key => supportedKeys.add(key));
+      const filteredOriginal: Record<string, any> = {};
+      for (const key of Object.keys(originalRawConfigsRef.current)) {
+        if (!supportedKeys.has(key)) {
+          filteredOriginal[key] = originalRawConfigsRef.current[key];
+        }
+      }
+
       const result = {
         type: values.type,
         name: values.name,
@@ -233,7 +243,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
         proxyName: values.proxyName,
         // Merge unknown extra fields (set via API, not exposed in the form) back into
         // rawConfigs so they are not silently dropped when the user saves via the UI.
-        rawConfigs: { ...originalRawConfigsRef.current, ...(values.rawConfigs || {}) },
+        rawConfigs: { ...filteredOriginal, ...(values.rawConfigs || {}) },
       };
 
       return result;

--- a/frontend/src/pages/ai/configs.tsx
+++ b/frontend/src/pages/ai/configs.tsx
@@ -1,4 +1,12 @@
-import { serviceToString } from "@/interfaces/service";
+export const builtInProviderConfigKeys = [
+  'id',
+  'type',
+  'protocol',
+  'apiTokens',
+  'failover',
+  'retryOnFailure',
+  'proxyName',
+];
 
 export const aiModelProviders = [
   {
@@ -6,6 +14,19 @@ export const aiModelProviders = [
     value: 'openai',
     serviceAddress: 'https://api.openai.com/v1',
     modelNamePattern: 'gpt-*',
+    customRawConfigsKeys: [
+      'openaiServerType',
+      'openaiCustomServerType',
+      'openaiCustomUrls',
+      'openaiCustomService',
+      'openaiCustomServiceHost',
+      'openaiCustomServicePath',
+      'openaiCustomServiceObj',
+      'openaiCustomServiceName',
+      'openaiCustomServicePort',
+      'openaiCustomUrl',
+      'openaiExtraCustomUrls',
+    ],
     targetModelList: [
       {
         label: 'gpt-3',
@@ -92,6 +113,13 @@ export const aiModelProviders = [
     value: 'qwen',
     serviceAddress: 'https://dashscope.aliyuncs.com/api/v1/services/aigc',
     modelNamePattern: 'qwen-*',
+    customRawConfigsKeys: [
+      'qwenServerType',
+      'qwenDomain',
+      'qwenEnableSearch',
+      'qwenEnableCompatible',
+      'qwenFileIds',
+    ],
     targetModelList: [
       {
         label: 'qwen-max',
@@ -146,6 +174,9 @@ export const aiModelProviders = [
     value: 'azure',
     serviceAddress: '',
     modelNamePattern: 'gpt-*',
+    customRawConfigsKeys: [
+      'azureServiceUrl',
+    ],
     targetModelList: [
       {
         label: 'gpt-3',
@@ -283,6 +314,10 @@ export const aiModelProviders = [
     value: 'zhipuai',
     serviceAddress: 'https://open.bigmodel.cn',
     modelNamePattern: 'GLM-*',
+    customRawConfigsKeys: [
+      'zhipuDomain',
+      'zhipuCodePlanMode',
+    ],
     targetModelList: [
       {
         label: 'GLM-4-Plus',
@@ -558,6 +593,10 @@ export const aiModelProviders = [
     label: 'Ollama',
     value: 'ollama',
     tokenRequired: false,
+    customRawConfigsKeys: [
+      'ollamaServerHost',
+      'ollamaServerPort',
+    ],
     targetModelList: [],
     getProviderEndpoints: (record) => {
       if (!record.rawConfigs) {
@@ -598,6 +637,11 @@ export const aiModelProviders = [
   {
     label: 'AWS Bedrock',
     value: 'bedrock',
+    customRawConfigsKeys: [
+      'awsRegion',
+      'awsAccessKey',
+      'awsSecretKey',
+    ],
     availableRegions: [
       'af-south-1',
       'ap-east-1',
@@ -650,6 +694,14 @@ export const aiModelProviders = [
   {
     label: 'Google Vertex',
     value: 'vertex',
+    customRawConfigsKeys: [
+      'vertexRegion',
+      'vertexProjectId',
+      'vertexAuthKey',
+      'vertexTokenRefreshAhead',
+      'parsed',
+      'geminiSafetySettings',
+    ],
     availableRegions: [
       'global',
       'africa-south1',
@@ -861,6 +913,11 @@ export const aiModelProviders = [
   {
     label: 'vLLM',
     value: 'vllm',
+    customRawConfigsKeys: [
+      'vllmCustomUrls',
+      'vllmCustomUrl',
+      'vllmExtraCustomUrls',
+    ],
     targetModelList: [],
     tokenRequired: false,
     getProviderEndpoints: (record) => {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Use blacklist for rawConfigs merge to prevent stale config bleeding, in order to fix the bug that it's unable to change an OpenAI LLM provider from using a custom service to the official service.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
