### PR TITLE
feat: Enhance the validation logic of keyed route predicates

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Route.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Route.java
@@ -118,10 +118,10 @@ public class Route implements VersionedDto {
             path.validate();
         }
         if (CollectionUtils.isNotEmpty(headers)) {
-            headers.forEach(KeyedRoutePredicate::validate);
+            headers.forEach(h -> h.validate("header"));
         }
         if (CollectionUtils.isNotEmpty(urlParams)) {
-            urlParams.forEach(KeyedRoutePredicate::validate);
+            urlParams.forEach(q -> q.validate("query"));
         }
         services.forEach(UpstreamService::validate);
         if (authConfig != null) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/route/KeyedRoutePredicate.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/route/KeyedRoutePredicate.java
@@ -12,6 +12,10 @@
  */
 package com.alibaba.higress.sdk.model.route;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.alibaba.higress.sdk.exception.ValidationException;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,4 +30,33 @@ import lombok.NoArgsConstructor;
 public class KeyedRoutePredicate extends RoutePredicate {
 
     private String key;
+
+    @Override
+    public void validate() {
+        validate(null);
+    }
+
+    public void validate(String location) {
+        super.validate();
+
+        String keyValue = this.key;
+        String matchValue = this.getMatchValue();
+
+        if (keyValue != null && !StringUtils.isAsciiPrintable(keyValue)) {
+            throw new ValidationException(buildNonAsciiErrorMessage(location));
+        }
+
+        if (matchValue != null && !StringUtils.isAsciiPrintable(matchValue)) {
+            throw new ValidationException(buildNonAsciiErrorMessage(location));
+        }
+    }
+
+    private String buildNonAsciiErrorMessage(String location) {
+        if (location != null) {
+            return String.format("Route %s predicate contains non-ASCII characters: key=%s, matchValue=%s",
+                location, getKey(), getMatchValue());
+        }
+        return String.format("Route predicate contains non-ASCII characters: key=%s, matchValue=%s", getKey(),
+            getMatchValue());
+    }
 }

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/model/RouteTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/model/RouteTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.model;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.model.route.KeyedRoutePredicate;
+import com.alibaba.higress.sdk.model.route.UpstreamService;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RouteTest {
+
+    @Test
+    @DisplayName("validate with non-ASCII header key throws with header context")
+    void validate_withNonAsciiHeaderKey_throwsWithHeaderContext() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setServices(Arrays.asList(
+            UpstreamService.builder().name("svc").weight(100).build()
+        ));
+
+        KeyedRoutePredicate header = new KeyedRoutePredicate();
+        header.setKey("x-custom=中文");
+        header.setMatchType("EQUAL");
+        header.setMatchValue("test");
+        route.setHeaders(Arrays.asList(header));
+
+        ValidationException ex = assertThrows(ValidationException.class,
+            () -> route.validate());
+        String msg = ex.getMessage();
+        assertTrue(msg.contains("header"), "Message should contain 'header': " + msg);
+        assertTrue(msg.contains("key"), "Message should contain 'key': " + msg);
+        assertTrue(msg.contains("non-ASCII"), "Message should contain 'non-ASCII': " + msg);
+    }
+
+    @Test
+    @DisplayName("validate with non-ASCII query matchValue throws with query context")
+    void validate_withNonAsciiQueryMatchValue_throwsWithQueryContext() {
+        Route route = new Route();
+        route.setName("test-route");
+        route.setServices(Arrays.asList(
+            UpstreamService.builder().name("svc").weight(100).build()
+        ));
+
+        KeyedRoutePredicate query = new KeyedRoutePredicate();
+        query.setKey("name");
+        query.setMatchType("EQUAL");
+        query.setMatchValue("李四");
+        route.setUrlParams(Arrays.asList(query));
+
+        ValidationException ex = assertThrows(ValidationException.class,
+            () -> route.validate());
+        String msg = ex.getMessage();
+        assertTrue(msg.contains("query"), "Message should contain 'query': " + msg);
+        assertTrue(msg.contains("matchValue"), "Message should contain 'matchValue': " + msg);
+        assertTrue(msg.contains("non-ASCII"), "Message should contain 'non-ASCII': " + msg);
+    }
+}

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/model/route/KeyedRoutePredicateTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/model/route/KeyedRoutePredicateTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.model.route;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.higress.sdk.exception.ValidationException;
+
+class KeyedRoutePredicateTest {
+
+    @Test
+    @DisplayName("validate with ASCII key and value succeeds")
+    void validate_withAsciiKeyAndValue_succeeds() {
+        KeyedRoutePredicate predicate = new KeyedRoutePredicate();
+        predicate.setMatchType("EQUAL");
+        predicate.setMatchValue("test");
+        predicate.setKey("name");
+
+        assertDoesNotThrow(() -> predicate.validate());
+    }
+
+    @Test
+    @DisplayName("validate with non-ASCII key throws exception with both fields in message")
+    void validate_withNonAsciiKey_throwsException() {
+        KeyedRoutePredicate predicate = new KeyedRoutePredicate();
+        predicate.setMatchType("EQUAL");
+        predicate.setMatchValue("John Doe");
+        predicate.setKey("姓名");
+
+        ValidationException exception = assertThrows(ValidationException.class, () -> predicate.validate());
+        String msg = exception.getMessage();
+        assertTrue(msg.contains("non-ASCII"));
+        assertTrue(msg.contains("key=姓名"));
+        assertTrue(msg.contains("matchValue=John Doe"));
+    }
+
+    @Test
+    @DisplayName("validate with non-ASCII matchValue throws exception with both fields in message")
+    void validate_withNonAsciiMatchValue_throwsException() {
+        KeyedRoutePredicate predicate = new KeyedRoutePredicate();
+        predicate.setMatchType("EQUAL");
+        predicate.setMatchValue("李四");
+        predicate.setKey("name");
+
+        ValidationException exception = assertThrows(ValidationException.class, () -> predicate.validate());
+        String msg = exception.getMessage();
+        assertTrue(msg.contains("non-ASCII"));
+        assertTrue(msg.contains("key=name"));
+        assertTrue(msg.contains("matchValue=李四"));
+    }
+
+    @Test
+    @DisplayName("validate with null location error message contains both field values")
+    void validate_withNullLocation_errorMessageContainsFieldValues() {
+        KeyedRoutePredicate predicate = new KeyedRoutePredicate();
+        predicate.setMatchType("EQUAL");
+        predicate.setMatchValue("test");
+        predicate.setKey("中文key");
+
+        ValidationException exception = assertThrows(ValidationException.class, () -> predicate.validate());
+        String msg = exception.getMessage();
+        assertTrue(msg.contains("non-ASCII"));
+        assertTrue(msg.contains("key=中文key"));
+        assertTrue(msg.contains("matchValue=test"));
+    }
+
+    @Test
+    @DisplayName("validate with header location error message contains header context")
+    void validate_withHeaderLocation_errorMessageContainsHeaderContext() {
+        KeyedRoutePredicate predicate = new KeyedRoutePredicate();
+        predicate.setMatchType("EQUAL");
+        predicate.setMatchValue("李四");
+        predicate.setKey("name");
+
+        ValidationException exception = assertThrows(ValidationException.class, () -> predicate.validate("header"));
+        String msg = exception.getMessage();
+        assertTrue(msg.contains("header"));
+        assertTrue(msg.contains("non-ASCII"));
+        assertTrue(msg.contains("key=name"));
+        assertTrue(msg.contains("matchValue=李四"));
+    }
+}

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -680,7 +680,10 @@
         "matchType": "Please select match type.",
         "matchValue": "Please input match value."
       },
-      "parameter": "Parameter"
+      "parameter": "Parameter",
+      "decoded": "Decode Result",
+      "encode": "Encode",
+      "nonAsciiError": "Non-ASCII characters not allowed. Please click button to encode"
     },
     "keyValueGroup": {
       "columns": {

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -680,7 +680,10 @@
         "matchType": "请选择条件",
         "matchValue": "请输入值"
       },
-      "parameter": "参数"
+      "parameter": "参数",
+      "decoded": "解码结果",
+      "encode": "编码",
+      "nonAsciiError": "不支持非ASCII字符，请点击按钮进行编码"
     },
     "keyValueGroup": {
       "columns": {

--- a/frontend/src/pages/route/components/FactorGroup/index.module.css
+++ b/frontend/src/pages/route/components/FactorGroup/index.module.css
@@ -3,3 +3,16 @@
     margin: 0;
   }
 }
+
+.nonAsciiError {
+  font-size: 12px;
+  color: #ff4d4f;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.decodedLabel {
+  color: #52c41a;
+}

--- a/frontend/src/pages/route/components/FactorGroup/index.tsx
+++ b/frontend/src/pages/route/components/FactorGroup/index.tsx
@@ -1,3 +1,4 @@
+import { containsNonAscii, looksUrlEncoded, urlDecodeValue, urlEncodeValue } from '@/utils';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { Button, Form, Input, Select, Table } from 'antd';
 import type { FormInstance } from 'antd/es/form';
@@ -5,6 +6,42 @@ import { uniqueId } from 'lodash';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './index.module.css';
+
+interface UrlEncodingHelperProps {
+  value: string;
+  onEncode: (encoded: string) => void;
+}
+
+const UrlEncodingHelper: React.FC<UrlEncodingHelperProps> = ({ value, onEncode }) => {
+  const { t } = useTranslation();
+
+  if (!value) return null;
+
+  // Input has non-ASCII characters - show encoding preview
+  if (containsNonAscii(value)) {
+    const encoded = urlEncodeValue(value);
+    return (
+      <div>
+        <span className={styles.nonAsciiError}>{t('route.factorGroup.nonAsciiError')}</span>
+        <Button type="link" size="small" onClick={() => onEncode(encoded)}>
+          {t('route.factorGroup.encode')}
+        </Button>
+      </div>
+    );
+  }
+
+  // Input looks URL-encoded - show decoded preview
+  if (looksUrlEncoded(value)) {
+    const decoded = urlDecodeValue(value);
+    return (
+      <div className={styles.decodedLabel}>
+        {t('route.factorGroup.decoded')}: {decoded}
+      </div>
+    );
+  }
+
+  return null;
+};
 
 const EditableContext = React.createContext<FormInstance<any> | null>(null);
 
@@ -63,12 +100,16 @@ const EditableCell: React.FC<EditableCellProps> = ({
   const save = async () => {
     try {
       const values = await form.validateFields();
-
       handleSave({ ...record, ...values });
     } catch (errInfo) {
       // eslint-disable-next-line no-console
       console.log('Save failed:', errInfo);
     }
+  };
+
+  const handleEncode = (encoded: string) => {
+    form.setFieldsValue({ [dataIndex as string]: encoded });
+    handleSave({ ...record, [dataIndex as string]: encoded });
   };
 
   let childNode = children;
@@ -77,7 +118,11 @@ const EditableCell: React.FC<EditableCellProps> = ({
     nodeType === 'select' ? (
       <Select ref={inputRef} options={matchOptions} />
     ) : (
-      <Input ref={inputRef} onPressEnter={save} onBlur={save} />
+      <Input
+        ref={inputRef}
+        onBlur={save}
+        onPressEnter={save}
+      />
     );
 
   if (editable) {
@@ -88,13 +133,26 @@ const EditableCell: React.FC<EditableCellProps> = ({
         rules={[
           {
             required: true,
-            message: t(`route.factorGroup.required.${dataIndex}`),
+            message: t(`route.factorGroup.required.${dataIndex}`) || '',
           },
         ]}
       >
         {node}
       </Form.Item>
     );
+
+    // For input fields (key and matchValue), wrap with EncodingPreview
+    if (nodeType === 'input') {
+      childNode = (
+        <>
+          {childNode}
+          <UrlEncodingHelper
+            value={form.getFieldValue(dataIndex as string) || record[dataIndex as string]}
+            onEncode={handleEncode}
+          />
+        </>
+      );
+    }
   }
 
   return <td {...restProps}>{childNode}</td>;
@@ -143,12 +201,13 @@ const FactorGroup: React.FC = ({ value, onChange }) => {
       title: t('route.factorGroup.columns.operation'),
       dataIndex: 'operation',
       width: 60,
-      render: (_, record: { uid: number }) =>
-        (dataSource.length >= 1 ? (
+      render: (_, record: { uid: number }) => (
+        dataSource.length >= 1 ? (
           <div onClick={() => handleDelete(record.uid)}>
             <DeleteOutlined />
           </div>
-        ) : null),
+        ) : null
+      ),
     },
   ];
 

--- a/frontend/src/pages/route/components/RouteForm/index.tsx
+++ b/frontend/src/pages/route/components/RouteForm/index.tsx
@@ -6,7 +6,7 @@ import { stringToUpstreamService, upstreamServiceToString } from '@/interfaces/r
 import { HistoryButton } from '@/pages/ai/components/RouteForm/Components';
 import { getGatewayDomains, getGatewayServices } from '@/services';
 import { getConsumers } from '@/services/consumer';
-import { getOfficialSiteLink } from '@/utils';
+import { containsNonAscii, getOfficialSiteLink } from '@/utils';
 import { QuestionCircleOutlined, RedoOutlined } from '@ant-design/icons';
 import { useRequest } from 'ahooks';
 import { Button, Checkbox, Form, Input, Select, Switch, Tooltip } from 'antd';
@@ -41,6 +41,22 @@ const RouteForm: React.FC = forwardRef((props, ref) => {
   const servicesRef = useRef(new Map());
   const { data: _services = [], refresh: refreshServices } = useRequest(getGatewayServices);
   const { data: _domains = [], refresh: refreshDomains } = useRequest(getGatewayDomains);
+
+  // Validator for FactorGroup items (headers, urlParams)
+  const validateFactorGroupItems = (_: unknown, values: Array<{ key?: string; matchType?: string; matchValue?: string }>) => {
+    if (!Array.isArray(values)) {
+      return Promise.resolve();
+    }
+    for (const item of values) {
+      if (!item.key || !item.matchType || !item.matchValue) {
+        return Promise.reject();
+      }
+      if (containsNonAscii(item.key) || containsNonAscii(item.matchValue)) {
+        return Promise.reject();
+      }
+    }
+    return Promise.resolve();
+  };
 
   const [consumerList, setConsumerList] = useState<Consumer[]>([]);
   const [weightedServices, setWeightedServices] = useState<WeightedService[]>([]);
@@ -316,6 +332,7 @@ const RouteForm: React.FC = forwardRef((props, ref) => {
           label={t('route.routeForm.header')}
           name="headers"
           tooltip={t('route.routeForm.headerTooltip')}
+          rules={[{ validator: validateFactorGroupItems }]}
         >
           <FactorGroup />
         </Form.Item>
@@ -323,6 +340,7 @@ const RouteForm: React.FC = forwardRef((props, ref) => {
           label={t('route.routeForm.query')}
           name="urlParams"
           tooltip={t('route.routeForm.queryTooltip')}
+          rules={[{ validator: validateFactorGroupItems }]}
         >
           <FactorGroup />
         </Form.Item>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -46,3 +46,21 @@ export const getOfficialSiteLink = (path: string) => {
   const basePath = path.startsWith('/') ? path : `/${path}`;
   return `https://higress.io${langPrefix}${basePath}`;
 };
+
+// Detect non-ASCII characters
+export const containsNonAscii = (str: string): boolean => /[^\x00-\x7F]/.test(str);
+
+// Detect URL-encoded pattern
+export const looksUrlEncoded = (str: string): boolean => /%[0-9A-F]{2}/i.test(str);
+
+// Encode non-ASCII characters
+export const urlEncodeValue = (str: string): string => encodeURIComponent(str);
+
+// Decode URL-encoded string
+export const urlDecodeValue = (str: string): string => {
+  try {
+    return decodeURIComponent(str);
+  } catch {
+    return str;
+  }
+};


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Enhance the validation logic of keyed route predicates by detecting non-ASCII characters and letting user know to encode it before submit.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/222795ba-8257-4361-b71f-2c0d8a175aa6" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6c9d1e0b-8d96-41ba-86ef-8bcfb1253b24" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/higress-group/higress/issues/1773

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
