### PR TITLE
fix: Update the empty service list handling logic related to ServiceWeightTable

### DIFF
--- a/frontend/src/components/ServiceWeightTable/index.tsx
+++ b/frontend/src/components/ServiceWeightTable/index.tsx
@@ -54,6 +54,11 @@ function ServiceWeightTable({
       return () => { aborted = true; };
     }
 
+    if (value.length === 0) {
+      setIsAutoMode(true);
+      return () => { aborted = true; };
+    }
+
     const currentNames = value.map(s => s.name);
     const prevNames = prevServiceNamesRef.current;
 
@@ -165,7 +170,7 @@ function ServiceWeightTable({
             max={100}
             value={record.weight}
             onChange={(val) => handleWeightChange(record.id, val || 0)}
-            disabled={disabled || value.length === 1}
+            disabled={disabled}
             style={{ width: 80 }}
           />
           <Text type="secondary">%</Text>
@@ -182,7 +187,7 @@ function ServiceWeightTable({
       key: 'action',
       width: 80,
       render: (_: unknown, record: WeightedService) => (
-        value.length > 1 ? (
+        value.length > 0 && (
           <Tooltip title={t('route.weightTable.delete')}>
             <Button
               type="text"
@@ -193,10 +198,15 @@ function ServiceWeightTable({
               aria-label={String(t('route.weightTable.delete'))}
             />
           </Tooltip>
-        ) : null
+        )
       ),
     },
   ], [t, disabled, value.length, handleWeightChange, handleDelete]);
+
+  // Return nothing when service list is empty
+  if (value.length === 0) {
+    return null;
+  }
 
   return (
     <div>

--- a/frontend/src/pages/route/components/RouteForm/index.tsx
+++ b/frontend/src/pages/route/components/RouteForm/index.tsx
@@ -445,21 +445,14 @@ const RouteForm: React.FC = forwardRef((props, ref) => {
             />
           </div>
         </Form.Item>
-        {
-          weightedServices.length > 0 && (
-            <Form.Item
-              label={t('route.routeForm.weightConfig')}
-              required
-            >
-              <ServiceWeightTable
-                value={weightedServices}
-                onChange={setWeightedServices}
-                disabled={false}
-                autoMode={!editMode}
-              />
-            </Form.Item>
-          )
-        }
+        <Form.Item>
+          <ServiceWeightTable
+            value={weightedServices}
+            onChange={setWeightedServices}
+            disabled={false}
+            autoMode={!editMode}
+          />
+        </Form.Item>
       </Form.Item>
     </Form>
   );


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix the bug that when editing a route, clear the upstream service selection and select a new service, the new service has a non-editable zero weight.

Before:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/58d9283e-f27c-49ce-aac3-d9a4131f8869" />

After:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/236bd6b1-bf75-4620-8629-ffb20b916b8b" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
