### PR TITLE
feat: add name validation for LlmProvider and Consumer

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -134,7 +134,8 @@
       "tokenSourceRequired": "Please choose a token source",
       "authTokenRequired": "Please input auth token",
       "headerNameRequired": "Please input header name",
-      "paramNameRequired": "Please input parameter key"
+      "paramNameRequired": "Please input parameter key",
+      "invalidNamePattern": "Only letters (a-z, A-Z), numbers (0-9), hyphens (-), and dots (.) are allowed. Cannot start or end with special characters. Maximum length is 63 characters."
     },
     "selectBEARER": "Authorization: Bearer ${value}",
     "selectHEADER": "Custom HTTP Header",
@@ -336,7 +337,8 @@
         "invalidVllmCustomUrl": "Bad URL format: ",
         "vllmCustomUrlMultipleValuesWithIpOnly": "Only URLs with IP and port are supported when specifying multiple custom vLLM service base URLs",
         "vllmCustomUrlInconsistentProtocols": "Inconsistent protocols found in custom vLLM service base URLs",
-        "vllmCustomUrlInconsistentContextPaths": "Inconsistent paths found in custom vLLM service base URLs"
+        "vllmCustomUrlInconsistentContextPaths": "Inconsistent paths found in custom vLLM service base URLs",
+        "invalidNamePattern": "Only letters (a-z, A-Z), numbers (0-9), hyphens (-), and dots (.) are allowed. Cannot start or end with special characters. Maximum length is 63 characters."
       },
       "tooltips": {
         "qwenFileIdsTooltip": "The file IDs uploaded to Dashscope via the file API. The file contents will be used as contextual input for AI conversations.",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -134,7 +134,8 @@
       "tokenSourceRequired": "请选择令牌来源",
       "authTokenRequired": "请输入认证令牌",
       "headerNameRequired": "请输入Header名称",
-      "paramNameRequired": "请输入参数名称"
+      "paramNameRequired": "请输入参数名称",
+      "invalidNamePattern": "仅允许字母、数字、连字符(-)和点(.)，不能以特殊字符开头或结尾，最大长度63个字符"
     },
     "selectBEARER": "Authorization: Bearer ${value}",
     "selectHEADER": "自定义 HTTP Header",
@@ -336,7 +337,8 @@
         "invalidVllmCustomUrl": "URL 格式不正确：",
         "vllmCustomUrlMultipleValuesWithIpOnly": "仅支持指定多个使用 IP 和端口的自定义 vLLM 服务 BaseURL",
         "vllmCustomUrlInconsistentProtocols": "各个自定义 vLLM 服务 BaseURL 所使用的协议不一致",
-        "vllmCustomUrlInconsistentContextPaths": "各个自定义 vLLM 服务 BaseURL 所使用的路径不一致"
+        "vllmCustomUrlInconsistentContextPaths": "各个自定义 vLLM 服务 BaseURL 所使用的路径不一致",
+        "invalidNamePattern": "仅允许字母、数字、连字符(-)和点(.)，不能以特殊字符开头或结尾，最大长度63个字符"
       },
       "tooltips": {
         "qwenFileIdsTooltip": "通过文件接口上传至 Dashscope 的文件 ID，其内容将被用做 AI 对话的上下文。",

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -362,8 +362,15 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
           },
           {
             validator: (_, value) => {
+              // Skip pattern validation when editing to maintain compatibility with existing non-ASCII names
+              if (!props.value) {
+                const pattern = /^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,61}[a-zA-Z0-9])?$/;
+                if (value && !pattern.test(value)) {
+                  return Promise.reject(t('llmProvider.providerForm.rules.invalidNamePattern'));
+                }
+              }
               if (value && value.includes('/')) {
-                return Promise.reject('name is invalid: slashes (/) are not allowed.');
+                return Promise.reject(t('llmProvider.providerForm.rules.serviceNameNoSlash'));
               }
               return Promise.resolve();
             },

--- a/frontend/src/pages/consumer/components/ConsumerForm/index.tsx
+++ b/frontend/src/pages/consumer/components/ConsumerForm/index.tsx
@@ -84,6 +84,21 @@ const ConsumerForm: React.FC = forwardRef((props, ref) => {
             required: true,
             message: t('consumer.consumerForm.nameRequired') || '',
           },
+          {
+            validator: (_, name) => {
+              if (!value) {
+                return Promise.resolve();
+              }
+              // Skip pattern validation when editing to maintain compatibility with existing non-ASCII names
+              if (!props.value) {
+                const pattern = /^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,61}[a-zA-Z0-9])?$/;
+                if (!pattern.test(name)) {
+                  return Promise.reject(t('consumer.consumerForm.invalidNamePattern') || '');
+                }
+              }
+              return Promise.resolve();
+            },
+          },
         ]}
       >
         <Input


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Some users use Chinese characters in the name of LlmProviders and Consumers. Because these names will be used in cluster names, HTTP headers, etc. Using non-ASCII characters may cause unexpected behaviors, even errors during request processing.

So this PR add name field validation logic to only allow alphanumeric characters, hyphens, and dots (matching AI Route pattern). Validation only applies during creation to maintain compatibility with existing non-ASCII resources.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
