### PR TITLE
feat: Add failover on HTTP status codes and separate retry-on-failure config

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiProxyConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiProxyConfig.java
@@ -30,6 +30,7 @@ public class AiProxyConfig {
     public static final String FAILOVER_HEALTH_CHECK_INTERVAL = "healthCheckInterval";
     public static final String FAILOVER_HEALTH_CHECK_TIMEOUT = "healthCheckTimeout";
     public static final String FAILOVER_HEALTH_CHECK_MODEL = "healthCheckModel";
+    public static final String FAILOVER_ON_STATUS = "failoverOnStatus";
 
     public static final String RETRY_ON_FAILURE = "retryOnFailure";
     public static final String RETRY_ENABLED = "enabled";

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiProxyConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiProxyConfig.java
@@ -34,4 +34,5 @@ public class AiProxyConfig {
 
     public static final String RETRY_ON_FAILURE = "retryOnFailure";
     public static final String RETRY_ENABLED = "enabled";
+    public static final String RETRY_ON_STATUS = "retryOnStatus";
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProvider.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProvider.java
@@ -42,6 +42,8 @@ public class LlmProvider {
     private List<String> tokens;
     @Schema(description = "Token fail-over configuration")
     private TokenFailoverConfig tokenFailoverConfig;
+    @Schema(description = "Retry on failure configuration")
+    private RetryOnFailureConfig retryOnFailureConfig;
     @Schema(description = "Raw configuration key-value pairs used by ai-proxy plugin")
     private Map<String, Object> rawConfigs;
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/RetryOnFailureConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/RetryOnFailureConfig.java
@@ -12,8 +12,6 @@
  */
 package com.alibaba.higress.sdk.model.ai;
 
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,14 +22,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "Token Failover Config")
-public class TokenFailoverConfig {
+@Schema(description = "Retry on Failure Config")
+public class RetryOnFailureConfig {
 
     private Boolean enabled;
-    private Integer failureThreshold;
-    private Integer successThreshold;
-    private Integer healthCheckInterval;
-    private Integer healthCheckTimeout;
-    private String healthCheckModel;
-    private List<Integer> failoverOnStatus;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
@@ -18,6 +18,7 @@ import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILO
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_HEALTH_CHECK_INTERVAL;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_HEALTH_CHECK_MODEL;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_HEALTH_CHECK_TIMEOUT;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_ON_STATUS;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_SUCCESS_THRESHOLD;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROTOCOL;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROVIDER_API_TOKENS;
@@ -43,6 +44,7 @@ import com.alibaba.higress.sdk.model.ServiceSource;
 import com.alibaba.higress.sdk.model.ai.LlmProvider;
 import com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint;
 import com.alibaba.higress.sdk.model.ai.LlmProviderProtocol;
+import com.alibaba.higress.sdk.model.ai.RetryOnFailureConfig;
 import com.alibaba.higress.sdk.model.ai.TokenFailoverConfig;
 import com.alibaba.higress.sdk.model.route.UpstreamService;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
@@ -80,6 +82,14 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
             failoverConfig = buildTokenFailoverConfig((Map<String, Object>)failoverObj);
         }
 
+        RetryOnFailureConfig retryOnFailureConfig = null;
+        Object retryObj = configurations.get(RETRY_ON_FAILURE);
+        if (retryObj instanceof Map<?, ?>) {
+            Map<String, Object> retryMap = (Map<String, Object>)retryObj;
+            retryOnFailureConfig = new RetryOnFailureConfig();
+            retryOnFailureConfig.setEnabled(MapUtils.getBoolean(retryMap, RETRY_ENABLED));
+        }
+
         LlmProviderProtocol protocol =
             LlmProviderProtocol.fromPluginValue(MapUtils.getString(configurations, PROTOCOL));
         if (protocol == null) {
@@ -91,6 +101,7 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
         provider.setType(getType());
         provider.setTokens(tokens);
         provider.setTokenFailoverConfig(failoverConfig);
+        provider.setRetryOnFailureConfig(retryOnFailureConfig);
         provider.setRawConfigs(new HashMap<>(configurations));
         return true;
     }
@@ -121,7 +132,13 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
             Map<String, Object> failoverMap = new HashMap<>();
             saveTokenFailoverConfig(failoverConfig, failoverMap);
             configurations.put(FAILOVER, failoverMap);
-            Map<String, Object> retryOnFailureMap = MapUtil.of(RETRY_ENABLED, failoverConfig.getEnabled());
+        }
+
+        RetryOnFailureConfig retryOnFailureConfig = provider.getRetryOnFailureConfig();
+        if (retryOnFailureConfig == null) {
+            configurations.remove(RETRY_ON_FAILURE);
+        } else {
+            Map<String, Object> retryOnFailureMap = MapUtil.of(RETRY_ENABLED, retryOnFailureConfig.getEnabled());
             configurations.put(RETRY_ON_FAILURE, retryOnFailureMap);
         }
     }
@@ -232,6 +249,18 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
         failoverConfig.setHealthCheckInterval(MapUtils.getInteger(failoverMap, FAILOVER_HEALTH_CHECK_INTERVAL));
         failoverConfig.setHealthCheckTimeout(MapUtils.getInteger(failoverMap, FAILOVER_HEALTH_CHECK_TIMEOUT));
         failoverConfig.setHealthCheckModel(MapUtils.getString(failoverMap, FAILOVER_HEALTH_CHECK_MODEL));
+        Object failoverOnStatusObj = failoverMap.get(FAILOVER_ON_STATUS);
+        if (failoverOnStatusObj instanceof List<?>) {
+            List<Integer> statusList = new ArrayList<>();
+            for (Object item : (List<?>)failoverOnStatusObj) {
+                if (item instanceof Integer) {
+                    statusList.add((Integer)item);
+                } else if (item instanceof Number) {
+                    statusList.add(((Number)item).intValue());
+                }
+            }
+            failoverConfig.setFailoverOnStatus(statusList);
+        }
         return failoverConfig;
     }
 
@@ -242,5 +271,10 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
         failoverMap.put(FAILOVER_HEALTH_CHECK_INTERVAL, failoverConfig.getHealthCheckInterval());
         failoverMap.put(FAILOVER_HEALTH_CHECK_TIMEOUT, failoverConfig.getHealthCheckTimeout());
         failoverMap.put(FAILOVER_HEALTH_CHECK_MODEL, failoverConfig.getHealthCheckModel());
+        if (CollectionUtils.isNotEmpty(failoverConfig.getFailoverOnStatus())) {
+            failoverMap.put(FAILOVER_ON_STATUS, failoverConfig.getFailoverOnStatus());
+        } else {
+            failoverMap.remove(FAILOVER_ON_STATUS);
+        }
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
@@ -26,6 +26,7 @@ import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROVI
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROVIDER_TYPE;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ENABLED;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ON_FAILURE;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ON_STATUS;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,7 +49,6 @@ import com.alibaba.higress.sdk.model.ai.RetryOnFailureConfig;
 import com.alibaba.higress.sdk.model.ai.TokenFailoverConfig;
 import com.alibaba.higress.sdk.model.route.UpstreamService;
 import com.alibaba.higress.sdk.service.kubernetes.crd.mcp.V1McpBridge;
-import com.alibaba.higress.sdk.util.MapUtil;
 import com.alibaba.higress.sdk.util.ValidateUtil;
 
 abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
@@ -127,7 +127,6 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
         TokenFailoverConfig failoverConfig = provider.getTokenFailoverConfig();
         if (failoverConfig == null) {
             configurations.remove(FAILOVER);
-            configurations.remove(RETRY_ON_FAILURE);
         } else {
             Map<String, Object> failoverMap = new HashMap<>();
             saveTokenFailoverConfig(failoverConfig, failoverMap);
@@ -135,12 +134,13 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
         }
 
         RetryOnFailureConfig retryOnFailureConfig = provider.getRetryOnFailureConfig();
-        if (retryOnFailureConfig == null) {
-            configurations.remove(RETRY_ON_FAILURE);
-        } else {
-            Map<String, Object> retryOnFailureMap = MapUtil.of(RETRY_ENABLED, retryOnFailureConfig.getEnabled());
-            configurations.put(RETRY_ON_FAILURE, retryOnFailureMap);
+        Boolean retryEnabled = retryOnFailureConfig != null ? retryOnFailureConfig.getEnabled() : null;
+        Map<String, Object> retryOnFailureMap = new HashMap<>();
+        retryOnFailureMap.put(RETRY_ENABLED, retryEnabled != null ? retryEnabled : false);
+        if (failoverConfig != null && CollectionUtils.isNotEmpty(failoverConfig.getFailoverOnStatus())) {
+            retryOnFailureMap.put(RETRY_ON_STATUS, failoverConfig.getFailoverOnStatus());
         }
+        configurations.put(RETRY_ON_FAILURE, retryOnFailureMap);
     }
 
     @Override

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandlerTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandlerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.service.ai;
+
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_ENABLED;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.FAILOVER_ON_STATUS;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROVIDER_API_TOKENS;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROVIDER_ID;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROTOCOL;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ENABLED;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ON_FAILURE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.higress.sdk.model.ai.LlmProvider;
+import com.alibaba.higress.sdk.model.ai.RetryOnFailureConfig;
+import com.alibaba.higress.sdk.model.ai.TokenFailoverConfig;
+
+public class AbstractLlmProviderHandlerTest {
+
+    private final OpenaiLlmProviderHandler handler = new OpenaiLlmProviderHandler();
+
+    @Test
+    public void loadConfig_readsFailoverOnStatus() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(PROVIDER_ID, "test-provider");
+        configs.put(PROTOCOL, "openai/v1");
+        configs.put(PROVIDER_API_TOKENS, Collections.singletonList("sk-test"));
+
+        Map<String, Object> failoverMap = new HashMap<>();
+        failoverMap.put(FAILOVER_ENABLED, true);
+        failoverMap.put(FAILOVER_ON_STATUS, Arrays.asList(502, 503, 504));
+        configs.put(FAILOVER, failoverMap);
+
+        LlmProvider provider = new LlmProvider();
+        boolean result = handler.loadConfig(provider, configs);
+
+        Assertions.assertTrue(result);
+        TokenFailoverConfig failoverConfig = provider.getTokenFailoverConfig();
+        Assertions.assertNotNull(failoverConfig);
+        Assertions.assertEquals(Arrays.asList(502, 503, 504), failoverConfig.getFailoverOnStatus());
+    }
+
+    @Test
+    public void loadConfig_readsFailoverOnStatusAsNumbers() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(PROVIDER_ID, "test-provider");
+        configs.put(PROTOCOL, "openai/v1");
+
+        Map<String, Object> failoverMap = new HashMap<>();
+        failoverMap.put(FAILOVER_ON_STATUS, Arrays.asList(502L, 503L));
+        configs.put(FAILOVER, failoverMap);
+
+        LlmProvider provider = new LlmProvider();
+        handler.loadConfig(provider, configs);
+
+        List<Integer> statuses = provider.getTokenFailoverConfig().getFailoverOnStatus();
+        Assertions.assertEquals(Arrays.asList(502, 503), statuses);
+    }
+
+    @Test
+    public void loadConfig_readsRetryOnFailureConfig() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(PROVIDER_ID, "test-provider");
+        configs.put(PROTOCOL, "openai/v1");
+
+        Map<String, Object> retryMap = new HashMap<>();
+        retryMap.put(RETRY_ENABLED, true);
+        configs.put(RETRY_ON_FAILURE, retryMap);
+
+        LlmProvider provider = new LlmProvider();
+        handler.loadConfig(provider, configs);
+
+        RetryOnFailureConfig retryConfig = provider.getRetryOnFailureConfig();
+        Assertions.assertNotNull(retryConfig);
+        Assertions.assertTrue(retryConfig.getEnabled());
+    }
+
+    @Test
+    public void loadConfig_retryOnFailureNotSet_returnsNull() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(PROVIDER_ID, "test-provider");
+        configs.put(PROTOCOL, "openai/v1");
+
+        LlmProvider provider = new LlmProvider();
+        handler.loadConfig(provider, configs);
+
+        Assertions.assertNull(provider.getRetryOnFailureConfig());
+    }
+
+    @Test
+    public void saveConfig_savesFailoverOnStatus() {
+        Map<String, Object> configs = new HashMap<>();
+
+        LlmProvider provider = new LlmProvider();
+        provider.setName("test-provider");
+        provider.setProtocol("openai/v1");
+        TokenFailoverConfig failoverConfig = TokenFailoverConfig.builder()
+            .enabled(true)
+            .failoverOnStatus(Arrays.asList(502, 503))
+            .build();
+        provider.setTokenFailoverConfig(failoverConfig);
+
+        handler.saveConfig(provider, configs);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> savedFailover = (Map<String, Object>)configs.get(FAILOVER);
+        Assertions.assertNotNull(savedFailover);
+        @SuppressWarnings("unchecked")
+        List<Integer> savedStatuses = (List<Integer>)savedFailover.get(FAILOVER_ON_STATUS);
+        Assertions.assertEquals(Arrays.asList(502, 503), savedStatuses);
+    }
+
+    @Test
+    public void saveConfig_emptyFailoverOnStatus_removesKey() {
+        Map<String, Object> configs = new HashMap<>();
+
+        LlmProvider provider = new LlmProvider();
+        provider.setName("test-provider");
+        provider.setProtocol("openai/v1");
+        TokenFailoverConfig failoverConfig = TokenFailoverConfig.builder()
+            .enabled(true)
+            .failoverOnStatus(Collections.emptyList())
+            .build();
+        provider.setTokenFailoverConfig(failoverConfig);
+
+        handler.saveConfig(provider, configs);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> savedFailover = (Map<String, Object>)configs.get(FAILOVER);
+        Assertions.assertNotNull(savedFailover);
+        Assertions.assertNull(savedFailover.get(FAILOVER_ON_STATUS),
+            "empty failoverOnStatus should be removed from config map");
+    }
+
+    @Test
+    public void saveConfig_savesRetryOnFailureConfig() {
+        Map<String, Object> configs = new HashMap<>();
+
+        LlmProvider provider = new LlmProvider();
+        provider.setName("test-provider");
+        provider.setProtocol("openai/v1");
+        provider.setRetryOnFailureConfig(RetryOnFailureConfig.builder().enabled(false).build());
+
+        handler.saveConfig(provider, configs);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> savedRetry = (Map<String, Object>)configs.get(RETRY_ON_FAILURE);
+        Assertions.assertNotNull(savedRetry);
+        Assertions.assertEquals(false, savedRetry.get(RETRY_ENABLED));
+    }
+
+    @Test
+    public void saveConfig_nullRetryOnFailureConfig_removesKey() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(RETRY_ON_FAILURE, new HashMap<>());
+
+        LlmProvider provider = new LlmProvider();
+        provider.setName("test-provider");
+        provider.setProtocol("openai/v1");
+
+        handler.saveConfig(provider, configs);
+
+        Assertions.assertNull(configs.get(RETRY_ON_FAILURE),
+            "null retryOnFailureConfig should remove key from config map");
+    }
+
+    @Test
+    public void roundTrip_failoverOnStatusAndRetryOnFailure() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(PROVIDER_ID, "test-provider");
+        configs.put(PROTOCOL, "openai/v1");
+        configs.put(PROVIDER_API_TOKENS, Arrays.asList("sk-1", "sk-2"));
+
+        Map<String, Object> failoverMap = new HashMap<>();
+        failoverMap.put(FAILOVER_ENABLED, true);
+        failoverMap.put(FAILOVER_ON_STATUS, Arrays.asList(500, 502, 503));
+        configs.put(FAILOVER, failoverMap);
+
+        Map<String, Object> retryMap = new HashMap<>();
+        retryMap.put(RETRY_ENABLED, false);
+        configs.put(RETRY_ON_FAILURE, retryMap);
+
+        LlmProvider provider = new LlmProvider();
+        handler.loadConfig(provider, configs);
+
+        Map<String, Object> savedConfigs = new HashMap<>();
+        handler.saveConfig(provider, savedConfigs);
+
+        LlmProvider reloaded = new LlmProvider();
+        handler.loadConfig(reloaded, savedConfigs);
+
+        Assertions.assertEquals(Arrays.asList("sk-1", "sk-2"), reloaded.getTokens());
+        Assertions.assertEquals(Arrays.asList(500, 502, 503),
+            reloaded.getTokenFailoverConfig().getFailoverOnStatus());
+        Assertions.assertNotNull(reloaded.getRetryOnFailureConfig());
+        Assertions.assertFalse(reloaded.getRetryOnFailureConfig().getEnabled());
+    }
+}

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandlerTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandlerTest.java
@@ -20,6 +20,7 @@ import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROVI
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.PROTOCOL;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ENABLED;
 import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ON_FAILURE;
+import static com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig.RETRY_ON_STATUS;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -169,9 +170,8 @@ public class AbstractLlmProviderHandlerTest {
     }
 
     @Test
-    public void saveConfig_nullRetryOnFailureConfig_removesKey() {
+    public void saveConfig_nullRetryOnFailureConfig_defaultsToEnabledFalse() {
         Map<String, Object> configs = new HashMap<>();
-        configs.put(RETRY_ON_FAILURE, new HashMap<>());
 
         LlmProvider provider = new LlmProvider();
         provider.setName("test-provider");
@@ -179,8 +179,29 @@ public class AbstractLlmProviderHandlerTest {
 
         handler.saveConfig(provider, configs);
 
-        Assertions.assertNull(configs.get(RETRY_ON_FAILURE),
-            "null retryOnFailureConfig should remove key from config map");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> savedRetry = (Map<String, Object>)configs.get(RETRY_ON_FAILURE);
+        Assertions.assertNotNull(savedRetry);
+        Assertions.assertEquals(false, savedRetry.get(RETRY_ENABLED),
+            "null retryOnFailureConfig should default to enabled: false");
+    }
+
+    @Test
+    public void saveConfig_nullEnabled_defaultsToEnabledFalse() {
+        Map<String, Object> configs = new HashMap<>();
+
+        LlmProvider provider = new LlmProvider();
+        provider.setName("test-provider");
+        provider.setProtocol("openai/v1");
+        provider.setRetryOnFailureConfig(RetryOnFailureConfig.builder().enabled(null).build());
+
+        handler.saveConfig(provider, configs);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> savedRetry = (Map<String, Object>)configs.get(RETRY_ON_FAILURE);
+        Assertions.assertNotNull(savedRetry);
+        Assertions.assertEquals(false, savedRetry.get(RETRY_ENABLED),
+            "retryOnFailureConfig with null enabled should default to enabled: false");
     }
 
     @Test
@@ -213,5 +234,10 @@ public class AbstractLlmProviderHandlerTest {
             reloaded.getTokenFailoverConfig().getFailoverOnStatus());
         Assertions.assertNotNull(reloaded.getRetryOnFailureConfig());
         Assertions.assertFalse(reloaded.getRetryOnFailureConfig().getEnabled());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> savedRetry = (Map<String, Object>)savedConfigs.get(RETRY_ON_FAILURE);
+        Assertions.assertNotNull(savedRetry);
+        Assertions.assertEquals(Arrays.asList(500, 502, 503), savedRetry.get(RETRY_ON_STATUS),
+            "retryOnStatus should equal failoverOnStatus");
     }
-}

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandlerTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandlerTest.java
@@ -241,3 +241,4 @@ public class AbstractLlmProviderHandlerTest {
         Assertions.assertEquals(Arrays.asList(500, 502, 503), savedRetry.get(RETRY_ON_STATUS),
             "retryOnStatus should equal failoverOnStatus");
     }
+}

--- a/frontend/src/interfaces/llm-provider.ts
+++ b/frontend/src/interfaces/llm-provider.ts
@@ -6,6 +6,7 @@ export interface LlmProvider {
   proxyName?: string;
   tokens: string[];
   tokenFailoverConfig?: TokeFailoverConfig;
+  retryOnFailureConfig?: RetryOnFailureConfig;
 }
 
 export interface TokeFailoverConfig {
@@ -15,6 +16,11 @@ export interface TokeFailoverConfig {
   healthCheckInterval?: number;
   healthCheckTimeout?: number;
   healthCheckModel?: string;
+  failoverOnStatus?: number[];
+}
+
+export interface RetryOnFailureConfig {
+  enabled?: boolean;
 }
 
 export enum LlmProviderProtocol {

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -287,7 +287,10 @@
         "claudeVersion": "Claude API Version",
         "claudeCodeMode": "Claude Code Mode (OAuth Token)",
         "zhipuCodePlanMode": "Code Plan Mode",
-        "vllmCustomUrl": "Custom vLLM Service Base URL"
+        "vllmCustomUrl": "Custom vLLM Service Base URL",
+        "failoverOnStatus": "Failover on HTTP Status Codes",
+        "retryOnFailure": "Retry on Failure",
+        "retryOnFailureTooltip": "When enabled, failed requests will be retried before triggering failover. Note: Retry on failure has limited support for streaming responses. It is recommended to disable this when using streaming."
       },
       "rules": {
         "tokenRequired": "Please input auth token",
@@ -298,6 +301,7 @@
         "healthCheckTimeoutRequired": "Please input health check request timeout (ms)",
         "healthCheckIntervalRequired": "Please input health check request interval (ms)",
         "healthCheckModelRequired": "Please input health check request LLM model",
+        "failoverOnStatusRequired": "Please input at least one HTTP status code to trigger failover",
         "protocol": "Please select a request protocol",
         "successThresholdRequired": "Please input min consecuitive sucesses to mark up a token",
         "azureServiceUrlRequired": "Please input Azure service URL",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -287,7 +287,10 @@
         "claudeVersion": "Claude API 版本",
         "claudeCodeMode": "Claude Code 模式（OAuth 令牌）",
         "zhipuCodePlanMode": "Code Plan 模式",
-        "vllmCustomUrl": "自定义 vLLM 服务 BaseURL"
+        "vllmCustomUrl": "自定义 vLLM 服务 BaseURL",
+        "failoverOnStatus": "触发降级的 HTTP 状态码",
+        "retryOnFailure": "失败时重试",
+        "retryOnFailureTooltip": "启用后，在触发降级前会对失败的请求进行重试。注意：失败重试对流式响应支持不佳，使用流式响应时建议关闭此选项。"
       },
       "rules": {
         "tokenRequired": "请输入凭证",
@@ -298,6 +301,7 @@
         "healthCheckTimeoutRequired": "请输入健康检测请求超时时间（毫秒）",
         "healthCheckIntervalRequired": "请输入健康检测请求发起间隔（毫秒）",
         "healthCheckModelRequired": "请输入健康检测请求使用的模型名称",
+        "failoverOnStatusRequired": "请输入至少一个触发降级的 HTTP 状态码",
         "protocol": "请选择请求协议",
         "successThresholdRequired": "请输入最小连续健康检测成功次数",
         "azureServiceUrlRequired": "请输入 Azure 服务 URL",

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -100,6 +100,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
         protocol,
         tokens,
         tokenFailoverConfig = {},
+        retryOnFailureConfig = {},
         proxyName = '',
         rawConfigs = {},
       } = props.value;
@@ -110,6 +111,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
         healthCheckInterval,
         healthCheckTimeout,
         healthCheckModel,
+        failoverOnStatus,
       } = tokenFailoverConfig ?? {};
 
       // providerConfig cannot be used here directly because it is not updated yet
@@ -211,6 +213,8 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
         healthCheckInterval: healthCheckInterval || 5000,
         healthCheckTimeout: healthCheckTimeout || 10000,
         healthCheckModel,
+        failoverOnStatus: (failoverOnStatus || []).map(String),
+        retryOnFailure: retryOnFailureConfig.enabled !== undefined ? retryOnFailureConfig.enabled : true,
         proxyName: proxyName || '',
         rawConfigs,
       });
@@ -260,6 +264,10 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
           healthCheckInterval: values.healthCheckInterval,
           healthCheckTimeout: values.healthCheckTimeout,
           healthCheckModel: values.healthCheckModel,
+          failoverOnStatus: (values.failoverOnStatus || []).map((s: string) => parseInt(s, 10)).filter((n: number) => !isNaN(n)),
+        },
+        retryOnFailureConfig: {
+          enabled: values.retryOnFailure,
         },
         proxyName: values.proxyName,
         // Merge unknown extra fields (set via API, not exposed in the form) back into
@@ -1379,6 +1387,42 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
               ]}
             >
               <Input />
+            </Form.Item>
+
+            {/* 触发降级的 HTTP 状态码 */}
+            <Form.Item
+              name="failoverOnStatus"
+              label={t('llmProvider.providerForm.label.failoverOnStatus')}
+              rules={[
+                {
+                  validator: (_, values: string[]) => {
+                    if (!values || values.length === 0) return Promise.resolve();
+                    const invalid = values.filter(v => isNaN(parseInt(v, 10)) || parseInt(v, 10) < 100 || parseInt(v, 10) > 599);
+                    if (invalid.length > 0) {
+                      return Promise.reject(`Invalid HTTP status code(s): ${invalid.join(', ')}`);
+                    }
+                    return Promise.resolve();
+                  },
+                },
+              ]}
+            >
+              <Select
+                mode="tags"
+                placeholder="e.g. 502, 503, 504"
+                style={{ width: '100%' }}
+                tokenSeparators={[',']}
+              />
+            </Form.Item>
+
+            {/* 失败时重试 */}
+            <Form.Item
+              name="retryOnFailure"
+              label={t('llmProvider.providerForm.label.retryOnFailure')}
+              valuePropName="checked"
+              initialValue
+              tooltip={t('llmProvider.providerForm.label.retryOnFailureTooltip')}
+            >
+              <Switch />
             </Form.Item>
           </>
           : null

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -214,7 +214,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
         healthCheckTimeout: healthCheckTimeout || 10000,
         healthCheckModel,
         failoverOnStatus: (failoverOnStatus || []).map(String),
-        retryOnFailure: retryOnFailureConfig.enabled !== undefined ? retryOnFailureConfig.enabled : true,
+        retryOnFailure: retryOnFailureConfig.enabled !== undefined ? retryOnFailureConfig.enabled : false,
         proxyName: proxyName || '',
         rawConfigs,
       });
@@ -1419,7 +1419,7 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
               name="retryOnFailure"
               label={t('llmProvider.providerForm.label.retryOnFailure')}
               valuePropName="checked"
-              initialValue
+              initialValue={false}
               tooltip={t('llmProvider.providerForm.label.retryOnFailureTooltip')}
             >
               <Switch />


### PR DESCRIPTION

   Add failoverOnStatus to TokenFailoverConfig for triggering failover
   based on specific HTTP response status codes. Extract retry-on-failure
   into a standalone RetryOnFailureConfig, decoupling it from the token
   failover configuration.

### Ⅰ. Describe what this PR did
本 PR 为 AI Provider（ai-proxy 插件）的 Token 降级（failover）与失败重试（retry-on-failure）配置提供 Console 侧完整支持，主要变更如下：
**1. 新增 `failoverOnStatus`（按 HTTP 状态码触发降级）**
- 在 `TokenFailoverConfig` 中新增 `List<Integer> failoverOnStatus` 字段
- 在 `AbstractLlmProviderHandler` 中实现与 ai-proxy 插件配置 `failover.failoverOnStatus` 的读写
- 前端 Provider 表单在启用 Token 降级时，增加「触发降级的 HTTP 状态码」多选/标签输入（如 502、503、504），并校验状态码范围（100–599）

**2. 将 `retryOnFailure` 从 failover 配置中解耦**
- 新增独立模型 `RetryOnFailureConfig`（`enabled`），并在 `LlmProvider` 上增加 `retryOnFailureConfig` 字段
- 因为 [README.md](https://github.com/higress-group/higress/blob/4e0d6914/plugins/wasm-go/extensions/ai-proxy/README.md?plain=1#L107-L107) 中表示目前仅支持对非流式请求进行重试

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
**1.前端 UI 验证**

- 启动 Console，进入 AI 管理 → LLM Provider 创建/编辑 Provider
- 配置多个 API Token，并启用 Token 降级
- 在「触发降级的 HTTP 状态码」中输入 502, 503, 504，保存后重新打开，确认状态码回显正确
- 切换「失败时重试」开关（开/关），保存后重新打开，确认开关状态独立、不受「启用降级」开关影响

**2.配置落盘验证（可选）**

- 保存 Provider 后，检查对应 ai-proxy 配置 yaml 中是否包含：
   - failover.failoverOnStatus: [502, 503, 504]（示例）
   - retryOnFailure.enabled: true / false（与 failover.enabled 独立）
   
 
<img width="481" height="708" alt="Clipboard_Screenshot_1778924244" src="https://github.com/user-attachments/assets/548f8226-20fa-49cc-96f2-63c1cee03a6c" />


### Ⅴ. Special notes for reviews
