### PR TITLE
为 Higress Console MCP 服务引入“用户级数据隔离 + 管理员全局可见”机制

### DIFF
--- a/backend/console/pom.xml
+++ b/backend/console/pom.xml
@@ -28,6 +28,11 @@
 			<version>${project.version}</version>
 		</dependency>
 
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java</artifactId>
+        </dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/SessionController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/SessionController.java
@@ -53,6 +53,22 @@ public class SessionController {
         this.sessionService = sessionService;
     }
 
+    @PostMapping("/creatUser")
+    @Operation(summary = "CreatUser")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Logged in successfully."),
+            @ApiResponse(responseCode = "400", description = "Missing user name or password."),
+            @ApiResponse(responseCode = "500", description = "Internal server error")})
+    public ResponseEntity<Response<User>> creatUser(@RequestBody User user) {
+        if (StringUtils.isEmpty(user.getName()) || StringUtils.isEmpty(user.getPassword())) {
+            throw new ValidationException("Missing user name or password.");
+        }
+
+        sessionService.initializeAdmin(user);
+
+        return ControllerUtil.buildResponseEntity(user);
+    }
+
+
     @PostMapping("/login")
     @Operation(summary = "Login")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Logged in successfully."),

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/ai/AiRoutesController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/ai/AiRoutesController.java
@@ -16,6 +16,8 @@ import javax.annotation.Resource;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotBlank;
 
+import com.alibaba.higress.console.model.User;
+import com.alibaba.higress.console.service.SessionUserHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -60,6 +62,11 @@ public class AiRoutesController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Routes listed successfully"),
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<PaginatedResponse<AiRoute>> list(@ParameterObject CommonPageQuery query) {
+        User user = SessionUserHelper.getCurrentUser();
+        String username = user.getName();
+        if(!"admin".equals(username)){
+            query.setUsername(user.getName());
+        }
         PaginatedResult<AiRoute> routes = aiRouteService.list(query);
         return ControllerUtil.buildResponseEntity(routes);
     }
@@ -72,6 +79,8 @@ public class AiRoutesController {
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<Response<AiRoute>> add(@RequestBody AiRoute route) {
         route.validate();
+        User user = SessionUserHelper.getCurrentUser();
+        route.setUsername(user.getName());
         AiRoute newRoute = aiRouteService.add(route);
         return ControllerUtil.buildResponseEntity(newRoute);
     }

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/ai/LlmProvidersController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/ai/LlmProvidersController.java
@@ -16,6 +16,7 @@ import javax.annotation.Resource;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotBlank;
 
+import com.alibaba.higress.console.service.SessionUserHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -60,6 +61,11 @@ public class LlmProvidersController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Providers listed successfully"),
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<PaginatedResponse<LlmProvider>> list(@RequestParam(required = false) CommonPageQuery query) {
+        String name = SessionUserHelper.getCurrentUser().getName();
+        if(!"admin".equals(name)){
+            query = new CommonPageQuery();
+            query.setUsername(name);
+        }
         PaginatedResult<LlmProvider> providers = llmProviderService.list(query);
         return ControllerUtil.buildResponseEntity(providers);
     }
@@ -72,6 +78,7 @@ public class LlmProvidersController {
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<Response<LlmProvider>> add(@RequestBody LlmProvider provider) {
         provider.validate(false);
+        provider.setUsername(SessionUserHelper.getCurrentUser().getName());
         LlmProvider newProvider = llmProviderService.addOrUpdate(provider);
         return ControllerUtil.buildResponseEntity(newProvider);
     }

--- a/backend/console/src/main/java/com/alibaba/higress/console/controller/mcp/McpServerController.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/controller/mcp/McpServerController.java
@@ -17,6 +17,9 @@ import javax.validation.Valid;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotBlank;
 
+import com.alibaba.higress.console.model.User;
+import com.alibaba.higress.console.service.SessionUserHelper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +56,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController("McpServerController")
 @RequestMapping("/v1/mcpServer")
 @Validated
+@Slf4j
 @Tag(name = "Mcp APIs")
 public class McpServerController {
 
@@ -75,6 +79,8 @@ public class McpServerController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Instances saved successfully"),
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<Response<McpServer>> addOrUpdateMcpInstance(@RequestBody McpServer instance) {
+        User user = SessionUserHelper.getCurrentUser();
+        instance.setUsername(user.getName());
         instance = mcpServerService.addOrUpdateWithAuthorization(instance);
         return ControllerUtil.buildResponseEntity(instance);
     }
@@ -84,6 +90,12 @@ public class McpServerController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "McpServers listed successfully"),
         @ApiResponse(responseCode = "500", description = "Internal server error")})
     public ResponseEntity<PaginatedResponse<McpServer>> list(@ParameterObject McpServerPageQuery query) {
+        User user = SessionUserHelper.getCurrentUser();
+        String name = user.getName();
+        log.info("当前用户名为：{}",name);
+        if(!"admin".equals(name)){
+            query.setUsername(name);
+        }
         return ControllerUtil.buildResponseEntity(mcpServerService.list(query));
     }
 

--- a/backend/console/src/main/java/com/alibaba/higress/console/service/SessionServiceImpl.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/service/SessionServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Resource;
@@ -62,6 +63,8 @@ public class SessionServiceImpl implements SessionService {
     private static final String ENCRYPT_IV_KEY = "iv";
     private static final int ENCRYPT_IV_LENGTH = 16;
     private static final String TOKEN_PART_SEPARATOR = "\1";
+    private static final String ADMIN_USERNAME = "admin";
+    private static final String SECRET_NAME_USER_PREFIX = "higress-console-user-";
 
     @Value("${" + SystemConfigKey.ADMIN_COOKIE_NAME_KEY + ":" + SystemConfigKey.ADMIN_COOKIE_NAME_DEFAULT + "}")
     private String cookieName = SystemConfigKey.ADMIN_COOKIE_NAME_DEFAULT;
@@ -70,7 +73,7 @@ public class SessionServiceImpl implements SessionService {
     private int cookieMaxAge = SystemConfigKey.ADMIN_COOKIE_MAX_AGE_DEFAULT;
 
     @Value("${" + SystemConfigKey.SECRET_NAME_KEY + ":" + SystemConfigKey.SECRET_NAME_DEFAULT + "}")
-    private String secretName = SystemConfigKey.SECRET_NAME_DEFAULT;
+    private String defaultSecretName = SystemConfigKey.SECRET_NAME_DEFAULT;
 
     @Value("${" + SystemConfigKey.ADMIN_CONFIG_TTL_KEY + ":" + SystemConfigKey.ADMIN_CONFIG_TTL_DEFAULT + "}")
     private long configTtl = SystemConfigKey.ADMIN_CONFIG_TTL_DEFAULT;
@@ -78,7 +81,8 @@ public class SessionServiceImpl implements SessionService {
     private ConfigService configService;
     private KubernetesClientService kubernetesClientService;
 
-    private final AtomicReference<AdminConfig> adminConfigCache = new AtomicReference<>();
+    // 多用户缓存：key=用户名，value=该用户的AdminConfig
+    private final Map<String, AdminConfig> adminConfigCache = new ConcurrentHashMap<>();
 
     @Resource
     public void setConfigService(ConfigService configService) {
@@ -92,37 +96,44 @@ public class SessionServiceImpl implements SessionService {
 
     @Override
     public boolean isAdminInitialized() {
-        return tryGetAdminConfig() != null;
+        // 仅检查admin账号是否初始化
+        return tryGetAdminConfig(ADMIN_USERNAME) != null;
     }
 
     @Override
     public void initializeAdmin(User user) {
-        boolean initialized = isAdminInitialized();
-        if (initialized) {
-            throw new IllegalStateException("Admin user is already initialized.");
+        String username = user.getName();
+        String targetSecretName = getSecretNameByUsername(username);
+
+        // 检查目标用户是否已初始化
+        if (tryGetAdminConfig(username) != null) {
+            throw new IllegalStateException(String.format("User [%s] is already initialized.", username));
         }
+
         V1Secret secret;
         try {
-            secret = kubernetesClientService.readSecret(secretName);
+            secret = kubernetesClientService.readSecret(targetSecretName);
         } catch (ApiException e) {
-            throw new BusinessException("Unable to load secret from K8s.", e);
+            throw new BusinessException(String.format("Unable to load secret [%s] from K8s.", targetSecretName), e);
         }
+
         Map<String, byte[]> data = new HashMap<>();
-        data.put(USERNAME_KEY, user.getName().getBytes());
+        data.put(USERNAME_KEY, username.getBytes());
         data.put(PASSWORD_KEY, user.getPassword().getBytes());
         data.put(DISPLAY_NAME_KEY, user.getDisplayName().getBytes());
         data.put(ENCRYPT_KEY_KEY, RandomStringUtils.randomGraph(ENCRYPT_KEY_LENGTH).getBytes());
         data.put(ENCRYPT_IV_KEY, RandomStringUtils.randomGraph(ENCRYPT_IV_LENGTH).getBytes());
+
         if (secret == null) {
             secret = new V1Secret();
             V1ObjectMeta metadata = new V1ObjectMeta();
-            metadata.setName(secretName);
+            metadata.setName(targetSecretName);
             secret.setMetadata(metadata);
             secret.setData(data);
             try {
                 kubernetesClientService.createSecret(secret);
             } catch (ApiException e) {
-                throw new BusinessException("Error occurs when trying to add admin secret.", e);
+                throw new BusinessException(String.format("Error occurs when trying to add secret [%s].", targetSecretName), e);
             }
         } else {
             Map<String, byte[]> newData;
@@ -136,20 +147,21 @@ public class SessionServiceImpl implements SessionService {
             try {
                 kubernetesClientService.replaceSecret(secret);
             } catch (ApiException e) {
-                throw new BusinessException("Error occurs when trying to update admin secret.", e);
+                throw new BusinessException(String.format("Error occurs when trying to update secret [%s].", targetSecretName), e);
             }
         }
 
-        adminConfigCache.set(null);
+        // 清除该用户的缓存
+        adminConfigCache.remove(username);
     }
 
     @Override
     public User login(String username, String password) {
-        AdminConfig config = getAdminConfig();
-        if (!config.getUsername().equals(username) || !config.getPassword().equals(password)) {
-            return null;
+        AdminConfig config = getAdminConfig(username);
+        if (config != null && config.getUsername().equals(username) && config.getPassword().equals(password)) {
+            return config.toUser();
         }
-        return config.toUser();
+        return null;
     }
 
     @Override
@@ -183,21 +195,34 @@ public class SessionServiceImpl implements SessionService {
         if (cookies == null || cookies.length == 0) {
             return null;
         }
-        String token = Arrays.stream(cookies).filter(c -> cookieName.equals(c.getName())).map(Cookie::getValue)
-            .findFirst().orElse(null);
+        String token = Arrays.stream(cookies)
+                .filter(c -> cookieName.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
         if (Strings.isNullOrEmpty(token)) {
             return null;
         }
 
-        AdminConfig config = tryGetAdminConfig();
-        if (config == null) {
-            return null;
-        }
-
-        String rawToken;
+        // 解密token获取用户名，再加载对应用户的配置
+        String rawToken = null;
+        String username = null;
         try {
-            rawToken = AesUtil.decrypt(config.getEncryptKey(), config.getEncryptIv(), token);
-        } catch (GeneralSecurityException e) {
+            // 先遍历缓存找能解密token的用户（兜底方案，建议token中包含用户名）
+            for (Map.Entry<String, AdminConfig> entry : adminConfigCache.entrySet()) {
+                AdminConfig config = entry.getValue();
+                try {
+                    rawToken = AesUtil.decrypt(config.getEncryptKey(), config.getEncryptIv(), token);
+                    username = entry.getKey();
+                    break;
+                } catch (GeneralSecurityException e) {
+                    continue;
+                }
+            }
+            if (rawToken == null) {
+                return null;
+            }
+        } catch (Exception e) {
             log.warn("Error occurs when decrypting token: " + token, e);
             return null;
         }
@@ -227,14 +252,14 @@ public class SessionServiceImpl implements SessionService {
     }
 
     private User validateCredential(String username, String password) {
-        AdminConfig config = tryGetAdminConfig();
+        AdminConfig config = tryGetAdminConfig(username);
         if (config == null) {
             return null;
         }
-        if (!config.getUsername().equals(username) || !config.getPassword().equals(password)) {
-            return null;
+        if (config.getUsername().equals(username) && config.getPassword().equals(password)) {
+            return config.toUser();
         }
-        return config.toUser();
+        return null;
     }
 
     @Override
@@ -244,7 +269,7 @@ public class SessionServiceImpl implements SessionService {
             throw new IllegalStateException("Password change is disabled.");
         }
 
-        AdminConfig adminConfig = getAdminConfig();
+        AdminConfig adminConfig = getAdminConfig(username);
         if (!adminConfig.getUsername().equals(username)) {
             throw new ValidationException("Unknown username: " + username);
         }
@@ -252,15 +277,17 @@ public class SessionServiceImpl implements SessionService {
             throw new ValidationException("Incorrect old password.");
         }
 
+        String targetSecretName = getSecretNameByUsername(username);
         V1Secret secret;
         try {
-            secret = kubernetesClientService.readSecret(secretName);
+            secret = kubernetesClientService.readSecret(targetSecretName);
         } catch (ApiException e) {
-            throw new BusinessException("Unable to load secret from K8s.", e);
+            throw new BusinessException(String.format("Unable to load secret [%s] from K8s.", targetSecretName), e);
         }
 
-        assert secret != null;
-        assert MapUtils.isNotEmpty(secret.getData());
+        if (secret == null || MapUtils.isEmpty(secret.getData())) {
+            throw new BusinessException(String.format("Secret [%s] is not exist or empty.", targetSecretName));
+        }
 
         Map<String, byte[]> newData = new HashMap<>(secret.getData());
         newData.put(PASSWORD_KEY, newPassword.getBytes());
@@ -269,10 +296,11 @@ public class SessionServiceImpl implements SessionService {
         try {
             kubernetesClientService.replaceSecret(secret);
         } catch (ApiException e) {
-            throw new BusinessException("Error occurs when trying to update admin secret.", e);
+            throw new BusinessException(String.format("Error occurs when trying to update secret [%s].", targetSecretName), e);
         }
 
-        adminConfigCache.set(null);
+        // 清除该用户的缓存
+        adminConfigCache.remove(username);
     }
 
     private Cookie buildEmptyCookie() {
@@ -283,44 +311,69 @@ public class SessionServiceImpl implements SessionService {
     }
 
     private String generateToken(User user) {
-        AdminConfig config = getAdminConfig();
-        if (!config.getUsername().equals(user.getName())) {
+        String username = user.getName();
+        AdminConfig config = getAdminConfig(username);
+        if (config == null || !config.getUsername().equals(username)) {
             return null;
         }
-        String rawToken = String.join(TOKEN_PART_SEPARATOR, config.getUsername(), config.getPassword(),
-            String.valueOf(System.currentTimeMillis()));
+        String rawToken = String.join(TOKEN_PART_SEPARATOR,
+                config.getUsername(), config.getPassword(), String.valueOf(System.currentTimeMillis()));
         try {
             return AesUtil.encrypt(config.getEncryptKey(), config.getEncryptIv(), rawToken);
         } catch (GeneralSecurityException e) {
-            throw new BusinessException("Error occurs when generating token for user " + user.getName(), e);
+            throw new BusinessException("Error occurs when generating token for user " + username, e);
         }
     }
 
-    private AdminConfig getAdminConfig() {
-        AdminConfig config = tryGetAdminConfig();
+    private AdminConfig getAdminConfig(String username) {
+        AdminConfig config = tryGetAdminConfig(username);
         if (config == null) {
-            throw new IllegalStateException("No valid admin config is available.");
+            throw new IllegalStateException(String.format("No valid config for user [%s] is available.", username));
         }
         return config;
     }
 
-    private AdminConfig tryGetAdminConfig() {
-        AdminConfig localAdminConfig = adminConfigCache.get();
-        if (localAdminConfig == null || !localAdminConfig.isExpired(configTtl)) {
-            localAdminConfig = loadAdminConfig();
+    // 兼容无参调用（仅用于admin）
+    private AdminConfig getAdminConfig() {
+        return getAdminConfig(ADMIN_USERNAME);
+    }
+
+    // 核心改造：根据用户名加载对应Secret
+    private AdminConfig tryGetAdminConfig(String username) {
+        if (StringUtils.isBlank(username)) {
+            return null;
+        }
+
+        // 1. 先查缓存
+        AdminConfig localAdminConfig = adminConfigCache.get(username);
+        // 2. 缓存不存在/过期，重新加载
+        if (localAdminConfig == null || localAdminConfig.isExpired(configTtl)) {
+            localAdminConfig = loadAdminConfig(username);
             if (localAdminConfig != null && localAdminConfig.isValid()) {
                 localAdminConfig.setLastUpdateTimestamp(System.currentTimeMillis());
-                adminConfigCache.set(localAdminConfig);
+                adminConfigCache.put(username, localAdminConfig);
+            } else {
+                adminConfigCache.remove(username);
             }
         }
         return localAdminConfig;
     }
 
-    private AdminConfig loadAdminConfig() {
+    // 兼容原无参方法（仅用于admin）
+    private AdminConfig tryGetAdminConfig() {
+        return tryGetAdminConfig(ADMIN_USERNAME);
+    }
+
+    // 根据用户名加载对应Secret
+    private AdminConfig loadAdminConfig(String username) {
+        log.info("用户名：" + username);
+        String targetSecretName = getSecretNameByUsername(username);
+        log.info("目标用户名：" + targetSecretName);
         V1Secret secret;
         try {
-            secret = kubernetesClientService.readSecret(secretName);
+            secret = kubernetesClientService.readSecret(targetSecretName);
         } catch (ApiException e) {
+            log.warn(String.format("Load secret [%s] failed: %s", targetSecretName, e.getMessage()));
             return null;
         }
         if (secret == null) {
@@ -330,12 +383,22 @@ public class SessionServiceImpl implements SessionService {
         if (MapUtils.isEmpty(data)) {
             return null;
         }
-        AdminConfig adminConfig = AdminConfig.builder().username(getString(data, USERNAME_KEY))
-            .displayName(getString(data, DISPLAY_NAME_KEY)).password(getString(data, PASSWORD_KEY))
-            .encryptKey(getString(data, ENCRYPT_KEY_KEY)).encryptIv(getString(data, ENCRYPT_IV_KEY)).build();
-        // AdminConfig adminConfig = AdminConfig.builder().name("admin").displayName("Admin").password("123456")
-        // .encryptKey("").encryptIv("").build();
+        AdminConfig adminConfig = AdminConfig.builder()
+                .username(getString(data, USERNAME_KEY))
+                .displayName(getString(data, DISPLAY_NAME_KEY))
+                .password(getString(data, PASSWORD_KEY))
+                .encryptKey(getString(data, ENCRYPT_KEY_KEY))
+                .encryptIv(getString(data, ENCRYPT_IV_KEY))
+                .build();
         return adminConfig.isValid() ? adminConfig : null;
+    }
+
+    // 核心方法：根据用户名生成Secret名称
+    private String getSecretNameByUsername(String username) {
+        if (ADMIN_USERNAME.equals(username)) {
+            return defaultSecretName; // admin用默认名称
+        }
+        return SECRET_NAME_USER_PREFIX + username; // 普通用户用前缀+用户名
     }
 
     private static String getString(Map<String, byte[]> map, String key) {
@@ -348,15 +411,10 @@ public class SessionServiceImpl implements SessionService {
     private static class AdminConfig {
 
         private String username;
-
         private String displayName;
-
         private String password;
-
         private String encryptKey;
-
         private String encryptIv;
-
         private long lastUpdateTimestamp;
 
         public boolean isValid() {

--- a/backend/console/src/main/java/com/alibaba/higress/console/util/TestUtil.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/util/TestUtil.java
@@ -1,0 +1,15 @@
+package com.alibaba.higress.console.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class TestUtil {
+    private static final int ENCRYPT_IV_LENGTH = 16;
+    private static final int ENCRYPT_KEY_LENGTH = 32;
+    public static void main(String[] args) {
+        byte[] bytes = RandomStringUtils.randomGraph(ENCRYPT_IV_LENGTH).getBytes();
+        byte[] bytes1 = RandomStringUtils.randomGraph(ENCRYPT_KEY_LENGTH).getBytes();
+        System.out.println(new String(bytes));
+        System.out.println(new String(bytes1));
+    }
+
+}

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiProxyConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/config/AiProxyConfig.java
@@ -33,4 +33,5 @@ public class AiProxyConfig {
 
     public static final String RETRY_ON_FAILURE = "retryOnFailure";
     public static final String RETRY_ENABLED = "enabled";
+    public static final String USER_NAME = "username";
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/CommonPageQuery.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/CommonPageQuery.java
@@ -35,4 +35,8 @@ public class CommonPageQuery {
     public boolean paginationEnabled() {
         return pageNum != null || pageSize != null;
     }
+
+
+    // 用户名称
+    public String username;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Route.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/Route.java
@@ -107,6 +107,12 @@ public class Route implements VersionedDto {
     @Schema(hidden = true)
     private Boolean readonly;
 
+    private String username;
+
+    @Schema(description = "平台标识（1:AI能力接入及管理平台，2:AIEngine，3:IT）")
+    private String platform;
+
+
     public void validate() {
         if (StringUtils.isBlank(name)) {
             throw new ValidationException("name cannot be blank.");

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/AiRoute.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/AiRoute.java
@@ -71,6 +71,9 @@ public class AiRoute {
     private Map<String, String> customConfigs;
     @Schema(description = "Custom labels")
     private Map<String, String> customLabels;
+    // 用户名
+    private String username;
+
 
     public void validate() {
         if (StringUtils.isBlank(name)) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProvider.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/ai/LlmProvider.java
@@ -45,6 +45,9 @@ public class LlmProvider {
     @Schema(description = "Raw configuration key-value pairs used by ai-proxy plugin")
     private Map<String, Object> rawConfigs;
 
+    // 用户名
+    private String username;
+
     public void validate(boolean forUpdate) {
         if (StringUtils.isBlank(name)) {
             throw new IllegalArgumentException("name cannot be blank.");

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServer.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServer.java
@@ -60,4 +60,11 @@ public class McpServer {
      */
     @Schema(description = "Direct route config.")
     private McpServerDirectRouteConfig directRouteConfig;
+
+    @Schema(description = "username")
+    private String username;
+
+    @Schema(description = "平台标识（1:AI能力接入及管理平台，2:AIEngine，3:IT）")
+    private String platform;
+
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerConstants.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerConstants.java
@@ -38,6 +38,9 @@ public class McpServerConstants {
     public static final class Label {
         public static final String MCP_SERVER_BIZ_TYPE_VALUE = "mcp-server";
         public static final String RESOURCE_MCP_SERVER_TYPE_KEY = "higress.io/mcp-server-type";
+
+        public static final String RESOURCE_MCP_SERVER_USERNAME_KEY = "higress.io/mcp-server-username";
+        public static final String RESOURCE_MCP_SERVER_PLATFROM_KEY = "higress.io/mcp-server-platform";
     }
 
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerPageQuery.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerPageQuery.java
@@ -36,4 +36,6 @@ public class McpServerPageQuery extends CommonPageQuery {
     @Schema(description = "Mcp server type")
     private String type;
 
+    @Schema(description = "Mcp server username")
+    private String username;
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AbstractLlmProviderHandler.java
@@ -99,6 +99,7 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
     public void saveConfig(LlmProvider provider, Map<String, Object> configurations) {
         configurations.put(PROVIDER_ID, provider.getName());
         configurations.put(PROVIDER_TYPE, getType());
+        configurations.put("username", provider.getUsername());
 
         LlmProviderProtocol protocol = LlmProviderProtocol.fromValue(provider.getProtocol());
         if (protocol == null) {
@@ -142,7 +143,7 @@ abstract class AbstractLlmProviderHandler implements LlmProviderHandler {
         if (CollectionUtils.isEmpty(endpoints)) {
             throw new ValidationException("No endpoints found for provider: " + providerName);
         }
-        String type = null, protocol = null, contextPath = null;
+        String type = null, protocol = null, contextPath = null, username = null;
         List<String> domains = new ArrayList<>(endpoints.size());
         Integer port = null;
         for (LlmProviderEndpoint endpoint : endpoints) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/AiRouteServiceImpl.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -78,13 +80,13 @@ public class AiRouteServiceImpl implements AiRouteService {
     private static final String ROUTE_FALLBACK_ENVOY_FILTER_CONFIG_PATH = "/templates/envoyfilter-route-fallback.yaml";
 
     private static final ProxyNextUpstreamConfig DEFAULT_PROXY_NEXT_UPSTREAM_CONFIG =
-        new ProxyNextUpstreamConfig(true, 3, 120, new String[] {"error", "timeout", "non_idempotent"});
+            new ProxyNextUpstreamConfig(true, 3, 120000, new String[] {"error", "timeout", "non_idempotent"});
 
     private static final Map<String, String> AI_ROUTE_LABEL_SELECTORS = MapUtil
-        .of(KubernetesConstants.Label.CONFIG_MAP_TYPE_KEY, KubernetesConstants.Label.CONFIG_MAP_TYPE_VALUE_AI_ROUTE);
+            .of(KubernetesConstants.Label.CONFIG_MAP_TYPE_KEY, KubernetesConstants.Label.CONFIG_MAP_TYPE_VALUE_AI_ROUTE);
 
     private static final RoutePredicate DEFAULT_PATH_PREDICATE =
-        new RoutePredicate(RoutePredicateTypeEnum.PRE.name(), "/", true);
+            new RoutePredicate(RoutePredicateTypeEnum.PRE.name(), "/", true);
 
     private final KubernetesModelConverter kubernetesModelConverter;
 
@@ -101,8 +103,8 @@ public class AiRouteServiceImpl implements AiRouteService {
     private final Template routeFallbackEnvoyFilterConfigTemplate;
 
     public AiRouteServiceImpl(KubernetesModelConverter kubernetesModelConverter,
-        KubernetesClientService kubernetesClientService, RouteService routeService,
-        LlmProviderService llmProviderService, WasmPluginInstanceService wasmPluginInstanceService) {
+                              KubernetesClientService kubernetesClientService, RouteService routeService,
+                              LlmProviderService llmProviderService, WasmPluginInstanceService wasmPluginInstanceService) {
         this.kubernetesModelConverter = kubernetesModelConverter;
         this.kubernetesClientService = kubernetesClientService;
         this.routeService = routeService;
@@ -115,11 +117,11 @@ public class AiRouteServiceImpl implements AiRouteService {
 
         try {
             this.routeFallbackEnvoyFilterConfigTemplate =
-                velocityEngine.getTemplate(ROUTE_FALLBACK_ENVOY_FILTER_CONFIG_PATH, StandardCharsets.UTF_8.name());
+                    velocityEngine.getTemplate(ROUTE_FALLBACK_ENVOY_FILTER_CONFIG_PATH, StandardCharsets.UTF_8.name());
             String routeFallbackEnvoyFilterConfig =
-                getRouteFallbackEnvoyFilterConfig(new ArrayList<>(HigressConstants.VALID_FALLBACK_RESPONSE_CODES));
+                    getRouteFallbackEnvoyFilterConfig(new ArrayList<>(HigressConstants.VALID_FALLBACK_RESPONSE_CODES));
             V1alpha3EnvoyFilter filter =
-                kubernetesClientService.loadFromYaml(routeFallbackEnvoyFilterConfig, V1alpha3EnvoyFilter.class);
+                    kubernetesClientService.loadFromYaml(routeFallbackEnvoyFilterConfig, V1alpha3EnvoyFilter.class);
             assert filter != null;
         } catch (Exception e) {
             throw new IllegalStateException("Error occurs when loading route fallback envoy filter  from resource.", e);
@@ -152,8 +154,61 @@ public class AiRouteServiceImpl implements AiRouteService {
         List<V1ConfigMap> configMaps;
         try {
             configMaps = kubernetesClientService.listConfigMap(AI_ROUTE_LABEL_SELECTORS);
+            // 初始化空集合，避免后续流式操作NPE
+            if (configMaps == null) {
+                configMaps = new ArrayList<>();
+                log.info("查询ConfigMap结果为null，已初始化为空集合");
+            }
         } catch (ApiException e) {
             throw new BusinessException("Error occurs when listing ConfigMap.", e);
+        }
+
+        // 根据用户名过滤：流式操作+空值全防护+精细化日志
+        if (StringUtils.isNotBlank(query.username) && !CollectionUtils.isEmpty(configMaps)) {
+            // 临时集合存储过滤结果，原集合用于日志追溯
+            List<V1ConfigMap> filteredConfigMaps = new ArrayList<>();
+            for (V1ConfigMap cm : configMaps) {
+                // 原因1：ConfigMap对象本身为null
+                if (cm == null) {
+                    log.warn("ConfigMap被过滤：对象为null，无法获取配置信息");
+                    continue;
+                }
+                // 获取ConfigMap名称（用于日志唯一标识，排查时可快速定位资源）
+                String cmName = cm.getMetadata() != null ? cm.getMetadata().getName() : "无名称";
+                String cmNamespace = cm.getMetadata() != null ? cm.getMetadata().getNamespace() : "无命名空间";
+                String cmUniqueKey = String.format("[%s/%s]", cmNamespace, cmName);
+
+                // 原因2：ConfigMap的data属性为null或空，无任何配置
+                if (MapUtils.isEmpty(cm.getData())) {
+                    log.warn("ConfigMap{}被过滤：data配置集为null或空，无username字段", cmUniqueKey);
+                    continue;
+                }
+
+                // 获取配置中的username
+                JSONObject data = JSON.parseObject(cm.getData().get("data").toString());
+                String configUsername =data.getString("username");
+                // 原因3：data中无username配置项（值为null）
+                if (configUsername == null) {
+                    log.warn("ConfigMap{}被过滤：data中未配置username字段", cmUniqueKey);
+                    continue;
+                }
+                // 原因4：data中的username与查询条件不匹配
+                if (!query.username.equals(configUsername)) {
+                    log.warn("ConfigMap{}被过滤：配置username[{}]与查询username[{}]不匹配",
+                            cmUniqueKey, configUsername, query.username);
+                    continue;
+                }
+
+                // 所有条件匹配，加入过滤结果
+                filteredConfigMaps.add(cm);
+                log.debug("ConfigMap{}通过过滤：配置username[{}]与查询条件一致", cmUniqueKey, configUsername);
+            }
+
+            // 替换为过滤后的集合
+            configMaps = filteredConfigMaps;
+            // 记录过滤最终结果
+            log.info("根据用户名过滤ConfigMap完成，过滤后总数：{}，查询用户名：{}",
+                    configMaps.size(), query.username);
         }
         return PaginatedResult.createFromFullList(configMaps, query, this::configMap2AiRoute);
     }
@@ -198,7 +253,7 @@ public class AiRouteServiceImpl implements AiRouteService {
                 throw new ResourceConflictException();
             }
             throw new BusinessException(
-                "Error occurs when replacing the ConfigMap generated by AI route: " + route.getName(), e);
+                    "Error occurs when replacing the ConfigMap generated by AI route: " + route.getName(), e);
         }
 
         return configMap2AiRoute(updatedConfigMap);
@@ -252,7 +307,7 @@ public class AiRouteServiceImpl implements AiRouteService {
     private void writeAiRouteFallbackResources(AiRoute aiRoute) {
         AiRouteFallbackConfig fallbackConfig = aiRoute.getFallbackConfig();
         if (fallbackConfig == null || !Boolean.TRUE.equals(fallbackConfig.getEnabled())
-            || CollectionUtils.isEmpty(fallbackConfig.getUpstreams())) {
+                || CollectionUtils.isEmpty(fallbackConfig.getUpstreams())) {
             deleteFallbackRouteResources(aiRoute.getName());
             return;
         }
@@ -290,10 +345,10 @@ public class AiRouteServiceImpl implements AiRouteService {
         StringUtil.replace(envoyFilterBuilder, "${routeName}", originalRouteName);
         StringUtil.replace(envoyFilterBuilder, "${fallbackHeader}", HigressConstants.FALLBACK_FROM_HEADER);
         V1alpha3EnvoyFilter envoyFilter =
-            kubernetesClientService.loadFromYaml(envoyFilterBuilder.toString(), V1alpha3EnvoyFilter.class);
+                kubernetesClientService.loadFromYaml(envoyFilterBuilder.toString(), V1alpha3EnvoyFilter.class);
         try {
             V1alpha3EnvoyFilter existedFilter =
-                kubernetesClientService.readEnvoyFilter(envoyFilter.getMetadata().getName());
+                    kubernetesClientService.readEnvoyFilter(envoyFilter.getMetadata().getName());
             if (existedFilter == null) {
                 kubernetesClientService.createEnvoyFilter(envoyFilter);
             } else {
@@ -302,7 +357,7 @@ public class AiRouteServiceImpl implements AiRouteService {
             }
         } catch (ApiException e) {
             throw new BusinessException(
-                "Error occurs when writing the fallback EnvoyFilter for AI route: " + aiRoute.getName(), e);
+                    "Error occurs when writing the fallback EnvoyFilter for AI route: " + aiRoute.getName(), e);
         }
 
         writeModelMappingResources(fallbackRouteName, fallbackUpStreams);
@@ -320,7 +375,7 @@ public class AiRouteServiceImpl implements AiRouteService {
 
         final String pluginName = BuiltInPluginName.MODEL_ROUTER;
         WasmPluginInstance instance =
-            wasmPluginInstanceService.query(WasmPluginInstanceScope.GLOBAL, null, pluginName, true);
+                wasmPluginInstanceService.query(WasmPluginInstanceScope.GLOBAL, null, pluginName, true);
         if (instance == null) {
             instance = wasmPluginInstanceService.createEmptyInstance(pluginName);
             instance.setInternal(true);
@@ -343,7 +398,7 @@ public class AiRouteServiceImpl implements AiRouteService {
     private void writeModelMappingResources(String routeName, List<AiUpstream> upstreams) {
         if (CollectionUtils.isEmpty(upstreams)) {
             wasmPluginInstanceService.delete(WasmPluginInstanceScope.ROUTE, routeName, BuiltInPluginName.MODEL_MAPPER,
-                true);
+                    true);
             return;
         }
 
@@ -352,7 +407,7 @@ public class AiRouteServiceImpl implements AiRouteService {
             UpstreamService upstreamService = llmProviderService.buildUpstreamService(upstream.getProvider());
 
             Map<WasmPluginInstanceScope, String> targets = MapUtil.of(WasmPluginInstanceScope.ROUTE, routeName,
-                WasmPluginInstanceScope.SERVICE, upstreamService.getName());
+                    WasmPluginInstanceScope.SERVICE, upstreamService.getName());
 
             if (MapUtils.isEmpty(upstream.getModelMapping())) {
                 wasmPluginInstanceService.delete(targets, pluginName, true);
@@ -386,7 +441,7 @@ public class AiRouteServiceImpl implements AiRouteService {
         }
 
         WasmPluginInstance existedInstance = wasmPluginInstanceService.query(WasmPluginInstanceScope.ROUTE, routeName,
-            BuiltInPluginName.AI_STATISTICS, false);
+                BuiltInPluginName.AI_STATISTICS, false);
         if (existedInstance != null) {
             return;
         }
@@ -450,7 +505,7 @@ public class AiRouteServiceImpl implements AiRouteService {
             if (modelPredicate.getMatchType().equals(RoutePredicateTypeEnum.REGULAR.toString())) {
                 // Shouldn't happen as we have checked it in the caller.
                 throw new IllegalArgumentException(
-                    "Regular expression match is not supported for model routing header.");
+                        "Regular expression match is not supported for model routing header.");
             }
             regexBuilder.append(escapeForRegexMatch(modelPredicate.getMatchValue()));
             if (RoutePredicateTypeEnum.PRE == RoutePredicateTypeEnum.fromName(modelPredicate.getMatchType())) {
@@ -512,7 +567,7 @@ public class AiRouteServiceImpl implements AiRouteService {
         } catch (ApiException e) {
             if (e.getCode() != HttpStatus.NOT_FOUND) {
                 throw new BusinessException(
-                    "Error occurs when deleting the fallback EnvoyFilter: " + originalResourceName, e);
+                        "Error occurs when deleting the fallback EnvoyFilter: " + originalResourceName, e);
             }
         }
 
@@ -536,6 +591,6 @@ public class AiRouteServiceImpl implements AiRouteService {
 
     private static String buildFallbackRouteResourceName(String routeName) {
         return CommonKey.AI_ROUTE_PREFIX + routeName + HigressConstants.FALLBACK_ROUTE_NAME_SUFFIX
-            + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX;
+                + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX;
     }
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/LlmProviderServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.higress.sdk.constant.plugin.BuiltInPluginName;
@@ -147,6 +148,9 @@ public class LlmProviderServiceImpl implements LlmProviderService {
 
         Map<String, Object> providerConfig =
             provider.getRawConfigs() != null ? new HashMap<>(provider.getRawConfigs()) : new HashMap<>();
+        if (StringUtils.isNotBlank(provider.getUsername())) {
+            providerConfig.put("username", provider.getUsername());
+        }
         handler.saveConfig(provider, providerConfig);
 
         boolean found = false;
@@ -247,7 +251,19 @@ public class LlmProviderServiceImpl implements LlmProviderService {
 
     @Override
     public PaginatedResult<LlmProvider> list(CommonPageQuery query) {
-        return PaginatedResult.createFromFullList(new ArrayList<>(getProviders().values()), query);
+        // 获取所有provider
+        SortedMap<String, LlmProvider> allProviders = getProviders();
+        // 过滤username
+        Collection<LlmProvider> filteredProviders = allProviders.values().stream()
+                .filter(provider -> {
+                    // 如果username为空，不过滤；否则匹配username
+                    if (ObjectUtils.isEmpty(query)||StringUtils.isBlank(query.username)) {
+                        return true;
+                    }
+                    return query.username.equals(provider.getRawConfigs().get("username"));
+                })
+                .collect(Collectors.toList());
+        return PaginatedResult.createFromFullList(new ArrayList<>(filteredProviders), query);
     }
 
     @Override

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServerHelper.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServerHelper.java
@@ -183,6 +183,8 @@ public class McpServerHelper {
         result.setName(mcpServerName);
         result.setServices(route.getServices());
         result.setDomains(route.getDomains());
+        result.setUsername(route.getCustomLabels().get(McpServerConstants.Label.RESOURCE_MCP_SERVER_USERNAME_KEY));
+        result.setPlatform(route.getCustomLabels().get(McpServerConstants.Label.RESOURCE_MCP_SERVER_PLATFROM_KEY));
 
         Map<String, String> customConfigs = route.getCustomConfigs();
         if (MapUtils.isNotEmpty(customConfigs)) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServiceContextImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/McpServiceContextImpl.java
@@ -214,6 +214,12 @@ public class McpServiceContextImpl implements McpServerService {
             McpServerTypeEnum mcpServerTypeEnum = McpServerTypeEnum.fromName(type);
             resultList.removeIf(mcpServer -> !mcpServerTypeEnum.equals(mcpServer.getType()));
         }
+
+        // 新增：按用户名过滤
+        String username = query.getUsername();
+        if (StringUtils.isNotBlank(username)) {
+            resultList.removeIf(mcpServer -> !StringUtils.contains(mcpServer.getUsername(), username));
+        }
     }
 
     // TODO: Use another way instead of customLabels to determine whether the route is bound to mcpServer

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/save/AbstractMcpServerSaveStrategy.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/save/AbstractMcpServerSaveStrategy.java
@@ -199,6 +199,16 @@ public abstract class AbstractMcpServerSaveStrategy implements McpServerSaveStra
         labelsMap.put(KubernetesConstants.Label.INTERNAL_KEY, Boolean.TRUE.toString());
         labelsMap.put(KubernetesConstants.Label.RESOURCE_BIZ_TYPE_KEY, MCP_SERVER_BIZ_TYPE_VALUE);
         labelsMap.put(McpServerConstants.Label.RESOURCE_MCP_SERVER_TYPE_KEY, mcpInstance.getType().name());
+
+        // 新增：存储用户名到Route标签
+        if (StringUtils.isNotBlank(mcpInstance.getUsername())) {
+            labelsMap.put(McpServerConstants.Label.RESOURCE_MCP_SERVER_USERNAME_KEY, mcpInstance.getUsername());
+        }
+
+        // 新增上线状态到Route标签
+        if(StringUtils.isNotBlank(mcpInstance.getPlatform())){
+            labelsMap.put(McpServerConstants.Label.RESOURCE_MCP_SERVER_PLATFROM_KEY, String.valueOf(mcpInstance.getPlatform()));
+        }
         route.setCustomLabels(labelsMap);
     }
 


### PR DESCRIPTION
# 背景

当前 Higress Console 在 MCP 服务管理及用户体系上存在以下限制：

- 默认仅支持单一用户（admin），不支持多用户登录
- 所有用户共享同一数据视图，缺乏用户隔离能力
- 不同用户之间的数据无隔离，存在潜在的数据安全风险
- 无法满足企业场景或 SaaS 环境下的多用户/多租户需求

在实际使用场景中：

- 不同用户需要独立使用 MCP 服务
- 用户数据需要严格隔离
- 管理员需要具备全局查看和管理能力

---

## 设计目标

本次改造旨在实现以下核心能力：

1. 支持多用户登录（Multi-user Support）
2. 实现 MCP 服务的用户级数据隔离（User-level Data Isolation）
3. 支持管理员（admin）查看和管理所有用户数据
4. 在实现新功能的同时，保持对现有系统的最小侵入

---

## 方案设计

### 1. 多用户支持机制（核心能力）

原系统仅支持单一用户（admin），本次改造通过扩展用户存储机制，实现多用户能力：

- 每个用户对应一个独立的 Kubernetes Secret：
higress-console-user--<username>

- Secret 中存储用户信息：

- adminUsername
- adminPassword（Base64编码）
- adminDisplayName
- 加密参数（iv / key）

- 登录流程调整：

```text
用户输入 username/password
    ↓
根据 username 查找对应 Secret
    ↓
校验密码
    ↓
创建 Session（登录态）

✅ 支持多用户独立登录
✅ 兼容原有 admin 用户

### 2. 用户维度数据隔离机制
在 MCP 服务数据访问中引入用户隔离：


引入当前用户标识（user identity）


所有数据默认按用户过滤：
Plain Textwhere user = currentUser显示更多行


保证：

普通用户只能访问自身数据
不同用户之间数据完全隔离


### 3. 管理员特权机制
增加管理员（admin）全局访问能力：

判断当前用户是否为 admin
对 admin 用户放开数据访问限制：

Plain Textif (isAdmin) {    返回所有用户数据} else {    仅返回当前用户数据}显示更多行
✅ admin 拥有全局视图
✅ 普通用户仅限自身数据

### 4. 数据访问层改造
对 MCP 服务的数据访问路径进行统一改造：


Controller 层

从 Session / 登录态中解析当前用户
传递 user context 至下游



Service 层

增加用户上下文参数
在业务逻辑中统一控制数据访问范围



DAO / Client 层

在查询和写操作中增加用户过滤条件
确保所有数据操作均遵循隔离规则



✅ 实现全链路一致的数据隔离

### 5. 用户信息来源
用户身份来源于系统登录态：

从当前 Session / Token 中获取用户信息
与现有认证机制兼容
不依赖前端传参，避免越权风险

✅ 保证安全性与一致性

### 6. 向后兼容性
本次改造保证对现有系统的低侵入性：

原有单用户模式仍可正常使用
不修改现有 API 接口定义
不涉及数据迁移
对已有功能无破坏性影响
