### PR TITLE
feat: support custom headers for MCP direct route upstream requests

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerDirectRouteConfig.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/mcp/McpServerDirectRouteConfig.java
@@ -12,6 +12,10 @@
  */
 package com.alibaba.higress.sdk.model.mcp;
 
+import java.util.List;
+
+import com.alibaba.higress.sdk.model.route.Header;
+
 import lombok.Data;
 
 /**
@@ -24,5 +28,9 @@ public class McpServerDirectRouteConfig {
      * transportType: streamable,sse
      */
     private String transportType;
+    /**
+     * Custom headers sent to the upstream MCP Server (e.g., authentication)
+     */
+    private List<Header> headers;
 
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/detail/DirectRoutingDetailStrategy.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/detail/DirectRoutingDetailStrategy.java
@@ -12,6 +12,9 @@
  */
 package com.alibaba.higress.sdk.service.mcp.detail;
 
+import java.util.Collections;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -22,6 +25,7 @@ import com.alibaba.higress.sdk.model.mcp.McpServerConfigMap;
 import com.alibaba.higress.sdk.model.mcp.McpServerConstants;
 import com.alibaba.higress.sdk.model.mcp.McpServerDirectRouteConfig;
 import com.alibaba.higress.sdk.model.mcp.McpServerTypeEnum;
+import com.alibaba.higress.sdk.model.route.HeaderControlConfig;
 import com.alibaba.higress.sdk.service.RouteService;
 import com.alibaba.higress.sdk.service.consumer.ConsumerService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
@@ -60,6 +64,22 @@ public class DirectRoutingDetailStrategy extends AbstractMcpServerDetailStrategy
             path = StringUtils.join(path, generateUpstreamPathPrefix());
         }
         config.setPath(path);
+
+        // Restore custom headers from route's headerControl config.
+        // Prefer "set" (request-header-control-update) as saved by the current version; fall back to "add" for
+        // configurations created by earlier versions that used request-header-control-add.
+        HeaderControlConfig headerControl = route.getHeaderControl();
+        if (headerControl != null && headerControl.getRequest() != null) {
+            if (CollectionUtils.isNotEmpty(headerControl.getRequest().getSet())) {
+                config.setHeaders(headerControl.getRequest().getSet());
+            } else if (CollectionUtils.isNotEmpty(headerControl.getRequest().getAdd())) {
+                config.setHeaders(headerControl.getRequest().getAdd());
+            } else {
+                config.setHeaders(Collections.emptyList());
+            }
+        } else {
+            config.setHeaders(Collections.emptyList());
+        }
     }
 
     private String generateUpstreamPathPrefix() {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/save/DirectRoutingSaveStrategy.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/mcp/save/DirectRoutingSaveStrategy.java
@@ -12,6 +12,7 @@
  */
 package com.alibaba.higress.sdk.service.mcp.save;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,6 +29,8 @@ import com.alibaba.higress.sdk.model.mcp.McpServerConfigMap;
 import com.alibaba.higress.sdk.model.mcp.McpServerConstants;
 import com.alibaba.higress.sdk.model.mcp.McpServerDirectRouteConfig;
 import com.alibaba.higress.sdk.model.mcp.McpServerTypeEnum;
+import com.alibaba.higress.sdk.model.route.HeaderControlConfig;
+import com.alibaba.higress.sdk.model.route.HeaderControlStageConfig;
 import com.alibaba.higress.sdk.model.route.RewriteConfig;
 import com.alibaba.higress.sdk.model.route.UpstreamService;
 import com.alibaba.higress.sdk.service.RouteService;
@@ -94,6 +97,24 @@ public class DirectRoutingSaveStrategy extends AbstractMcpServerSaveStrategy {
             rewriteConfig.setHost(serviceDomainName);
         }
         route.setRewrite(rewriteConfig);
+
+        // Configure custom headers sent to the upstream MCP Server (e.g., authentication).
+        // Use "set" (mapped to request-header-control-update) instead of "add" so that user-configured headers
+        // override client-sent headers with the same name. This is required when MCP Server consumer auth is enabled:
+        // the client may send an Authorization header for Higress authentication, but the upstream should receive the
+        // custom Authorization header configured here instead of the client's credential.
+        if (CollectionUtils.isNotEmpty(directRouteConfig.getHeaders())) {
+            HeaderControlConfig headerControl = HeaderControlConfig.builder()
+                .enabled(Boolean.TRUE)
+                .request(HeaderControlStageConfig.builder()
+                    .set(new ArrayList<>(directRouteConfig.getHeaders()))
+                    .build())
+                .build();
+            route.setHeaderControl(headerControl);
+        } else {
+            // Explicitly clear headerControl when no headers are configured
+            route.setHeaderControl(null);
+        }
 
     }
 

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -948,7 +948,9 @@
       "dbOtherParamsPlaceholder": "Format: key1=value1&key2=value2",
       "ssePathRule": "Path (SSE): /mcp-servers/<1>{{currentMcpServerName}}</1>/sse",
       "httpPathRule": "Path (Streamable HTTP): /mcp-servers/<1>{{currentMcpServerName}}</1>",
-      "nameDefault": "MCP Service Name"
+      "nameDefault": "MCP Service Name",
+      "customHeaders": "Custom Headers",
+      "addHeader": "Add Header"
     },
     "deleteConfirm": "Are you sure you want to delete <1>{{currentMcpServerName}}</1>?",
     "detail": {

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -948,7 +948,9 @@
       "dbOtherParamsPlaceholder": "格式：key1=value1&key2=value2",
       "ssePathRule": "路径 (SSE) : /mcp-servers/<1>{{currentMcpServerName}}</1>/sse",
       "httpPathRule": "路径 (Streamable HTTP) : /mcp-servers/<1>{{currentMcpServerName}}</1>",
-      "nameDefault": "MCP服务名称"
+      "nameDefault": "MCP服务名称",
+      "customHeaders": "自定义请求头",
+      "addHeader": "添加请求头"
     },
     "deleteConfirm": "确定删除 <1>{{currentMcpServerName}}</1> 吗？",
     "detail": {

--- a/frontend/src/pages/mcp/components/McpFormDrawer.tsx
+++ b/frontend/src/pages/mcp/components/McpFormDrawer.tsx
@@ -105,6 +105,7 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
           formValues.directRoute_service = record?.services?.[0]?.name;
           formValues.directRoute_transportType = record.directRouteConfig.transportType;
           formValues.directRoute_path = record.directRouteConfig.path;
+          formValues.directRoute_headers = record.directRouteConfig.headers || [];
         }
 
         form.setFieldsValue(formValues);
@@ -271,6 +272,7 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
       submitData.directRouteConfig = {
         path: values.directRoute_path,
         transportType: values.directRoute_transportType,
+        headers: values.directRoute_headers || [],
       };
     }
 
@@ -580,6 +582,42 @@ const McpFormDrawer: React.FC<McpFormDrawerProps> = ({ visible, mode, name, onCl
                 {t('mcp.form.ssePathTip') || 'SSE 传输路径必须以 /sse 结尾'}
               </div>
             )}
+            {/* 向上游发送的自定义请求头 */}
+            <div style={{ marginTop: 16 }}>
+              <div style={{ marginBottom: 8, fontWeight: 500 }}>
+                {t('mcp.form.customHeaders')}
+              </div>
+              <Form.List name="directRoute_headers">
+                {(fields, { add, remove }) => (
+                  <>
+                    {fields.map(({ key, name, ...restField }) => (
+                      <div key={key} style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+                        <Form.Item
+                          {...restField}
+                          name={[name, 'key']}
+                          style={{ flex: 1, marginBottom: 0 }}
+                          rules={[{ required: true, message: '请输入 Header Key' }]}
+                        >
+                          <Input placeholder="如: Authorization" />
+                        </Form.Item>
+                        <Form.Item
+                          {...restField}
+                          name={[name, 'value']}
+                          style={{ flex: 2, marginBottom: 0 }}
+                          rules={[{ required: true, message: '请输入 Header Value' }]}
+                        >
+                          <Input placeholder="如: Bearer xxx" />
+                        </Form.Item>
+                        <Button onClick={() => remove(name)}>-</Button>
+                      </div>
+                    ))}
+                    <Button type="dashed" onClick={() => add()} block>
+                      + {t('mcp.form.addHeader')}
+                    </Button>
+                  </>
+                )}
+              </Form.List>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

This PR adds the ability to configure custom request headers for MCP Server's DIRECT_ROUTE type. When a DIRECT_ROUTE MCP server sends requests to the upstream service, the configured headers (e.g., Authorization: Bearer xxx) will be included via the Higress headerControl plugin.

Changes include:
- **Backend (SDK)**: Added  field to  model
- **Backend (Save)**:  writes headers to  annotation; clears it when headers are empty
- **Backend (Detail)**:  restores headers from  annotation
- **Frontend**: Added header configuration form in  with key-value inputs
- **i18n**: Added  and  translation keys for zh-CN and en-US

### Ⅱ. Does this pull request fix one issue?

No related issue found.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

The changes are primarily data model extensions and UI form additions. The headerControl plugin integration relies on existing  serialization logic which is already covered by existing tests.

### Ⅳ. Describe how to verify it

1. Create a new MCP Server with type 
2. In the header configuration section, add custom headers (e.g., )
3. Save the MCP Server
4. Check the generated K8s Ingress annotation contains  with the configured headers
5. Edit the MCP Server and verify headers are correctly loaded back
6. Delete all headers and save; verify  is removed

### Ⅴ. Special notes for reviews

- **Scope**: Only affects  type MCP servers.  and  types are unaffected.
- **Backward compatibility**: Existing MCP servers without headers continue to work as before.
- **Risk**: If rolling back to an older JAR version, the  field will be ignored (no crash), but editing and saving will drop the headers.
- **Security note**: Header values are stored in plain text in K8s Ingress annotations. If this is a concern, a future enhancement could support referencing K8s Secrets.