### PR TITLE
fix: Fix a possible NPE in SystemServiceImpl

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/service/SystemServiceImpl.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/service/SystemServiceImpl.java
@@ -173,7 +173,7 @@ public class SystemServiceImpl implements SystemService {
 
     @Override
     public void initSystem(User adminUser, Map<String, Object> configs) {
-        if (configService.getBoolean(UserConfigKey.SYSTEM_INITIALIZED)) {
+        if (configService.getBoolean(UserConfigKey.SYSTEM_INITIALIZED, false)) {
             throw new IllegalStateException("System already initialized.");
         }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fix the possible NPE in SystemServiceImpl reported in https://github.com/higress-group/higress/discussions/3259#discussioncomment-17206562


```java
2026-06-06 23:07:36.352 ERROR 70396 --- [nio-8080-exec-7] c.a.h.c.aop.ApiStandardizationAspect     {traceId=b11107e7-fba8-449d-b50e-9fbf01015d7f} : NullPointerException occurs when calling com.alibaba.higress.console.controller.SystemController.initialize

java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "com.alibaba.higress.console.service.ConfigService.getBoolean(String)" is null
	at com.alibaba.higress.console.service.SystemServiceImpl.initSystem(SystemServiceImpl.java:176) ~[classes!/:0.0.1-SNAPSHOT]
	at com.alibaba.higress.console.controller.SystemController.initialize(SystemController.java:86) ~[classes!/:0.0.1-SNAPSHOT]
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
