### PR TITLE
fix: Trim trailing whitespaces in higress-config YAML data before submission

### DIFF
--- a/frontend/src/pages/system/index.tsx
+++ b/frontend/src/pages/system/index.tsx
@@ -2,6 +2,7 @@ import CodeEditor, { CodeEditorRef } from '@/components/CodeEditor';
 import { Mode } from '@/interfaces/config';
 import { getHigressConfig, updateHigressConfig } from '@/services/system';
 import store from '@/store';
+import { stripTrailingSpaces } from '@/utils';
 import { PageContainer } from '@ant-design/pro-layout';
 import { useRequest } from 'ahooks';
 import { Button, Form, message } from 'antd';
@@ -32,7 +33,8 @@ const SystemSettings: React.FC = () => {
 
   const handleSubmit = async () => {
     try {
-      const updatedConfigYaml = await updateHigressConfig(configYaml);
+      const cleanedConfigYaml = stripTrailingSpaces(configYaml);
+      const updatedConfigYaml = await updateHigressConfig(cleanedConfigYaml);
       setConfigYaml(updatedConfigYaml);
       codeEditorRef.current?.pushContent(updatedConfigYaml);
       message.success(t('plugins.saveSuccess'));

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -47,6 +47,14 @@ export const getOfficialSiteLink = (path: string) => {
   return `https://higress.io${langPrefix}${basePath}`;
 };
 
+// Remove trailing spaces and tabs from every line, preserving line breaks.
+export const stripTrailingSpaces = (text: string): string => {
+  if (!text) {
+    return text;
+  }
+  return text.replace(/[ \t]+$/gm, '');
+};
+
 // Detect non-ASCII characters
 export const containsNonAscii = (str: string): boolean => /[^\x00-\x7F]/.test(str);
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

If YAML contains a string with line trailing spaces, snakeyaml will use double quote to represent the value during serialization, causing the value hard to edit.

Before submission:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/28bae3e9-33a6-4cf3-96f6-7420debeaed3" />

After submission:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/5d043dc1-3442-410d-b489-850d07d3076e" />

This PR fixes the issue by trimming all line trailing whitespaces.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
