### PR TITLE
feat(ai): expose reasoning content mode (Qwen) and first-packet timeout in provider form

### DIFF
--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -288,7 +288,12 @@
         "claudeVersion": "Claude API Version",
         "claudeCodeMode": "Claude Code Mode (OAuth Token)",
         "zhipuCodePlanMode": "Code Plan Mode",
-        "vllmCustomUrl": "Custom vLLM Service Base URL"
+        "vllmCustomUrl": "Custom vLLM Service Base URL",
+        "reasoningContentMode": "Reasoning Content Mode",
+        "reasoningModePassthrough": "Pass through (passthrough)",
+        "reasoningModeIgnore": "Ignore (ignore)",
+        "reasoningModeConcat": "Concatenate (concat)",
+        "firstByteTimeout": "First-packet Timeout (ms)"
       },
       "rules": {
         "tokenRequired": "Please input auth token",
@@ -347,7 +352,9 @@
         "zhipuDomainTooltip": "Custom domain for Zhipu AI service. Leave empty to use the default domain (open.bigmodel.cn). Use 'api.z.ai' for international service.",
         "zhipuCodePlanModeTooltip": "Enable Code Plan mode for optimized code generation capabilities.",
         "claudeVersionTooltip": "Anthropic API version header. Default: 2023-06-01",
-        "claudeCodeModeTooltip": "Enable Claude Code mode to use OAuth token authentication instead of API key. Run 'claude setup-token' to get your OAuth token."
+        "claudeCodeModeTooltip": "Enable Claude Code mode to use OAuth token authentication instead of API key. Run 'claude setup-token' to get your OAuth token.",
+        "reasoningContentModeTooltip": "Controls how the reasoning content returned by the model is handled: passthrough returns it as-is; ignore drops it; concat merges it into the main content. Leave empty to use the default (passthrough).",
+        "firstByteTimeoutTooltip": "Timeout in milliseconds for receiving the first response packet from the upstream in a streaming request. Leave empty (0) to disable."
       },
       "placeholder": {
         "azureServiceUrlPlaceholder": "It shall contain \"/chat/completions\" in the path and \"api-version\" in the query string",
@@ -359,6 +366,8 @@
         "qwenFileIdsPlaceholder": "Sample: file-fe-xxx",
         "zhipuDomainPlaceholder": "Sample: api.z.ai (for international service)",
         "vllmCustomUrlPlaceholder": "Sample: http://192.168.0.1:8000/v1",
+        "reasoningContentModePlaceholder": "Default: pass through (passthrough)",
+        "firstByteTimeoutPlaceholder": "Leave empty (0) to disable",
         "claudeCustomUrlPlaceholder": "Sample: https://api.anthropic.com or https://proxy.example.com/anthropic",
         "claudeCustomServiceHostPlaceholder": "Sample: api.anthropic.com",
         "claudeCustomServicePathPlaceholder": "Sample: / or /anthropic"

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -288,7 +288,12 @@
         "claudeVersion": "Claude API 版本",
         "claudeCodeMode": "Claude Code 模式（OAuth 令牌）",
         "zhipuCodePlanMode": "Code Plan 模式",
-        "vllmCustomUrl": "自定义 vLLM 服务 BaseURL"
+        "vllmCustomUrl": "自定义 vLLM 服务 BaseURL",
+        "reasoningContentMode": "推理内容模式",
+        "reasoningModePassthrough": "透传 (passthrough)",
+        "reasoningModeIgnore": "忽略 (ignore)",
+        "reasoningModeConcat": "拼接到正文 (concat)",
+        "firstByteTimeout": "首包超时 (毫秒)"
       },
       "rules": {
         "tokenRequired": "请输入凭证",
@@ -347,7 +352,9 @@
         "zhipuDomainTooltip": "智谱 AI 服务的自定义域名。留空则使用默认域名（open.bigmodel.cn）。国际版请使用 'api.z.ai'。",
         "zhipuCodePlanModeTooltip": "启用 Code Plan 模式以获得优化的代码生成能力。",
         "claudeVersionTooltip": "Anthropic API 版本号。默认值：2023-06-01",
-        "claudeCodeModeTooltip": "启用 Claude Code 模式以使用 OAuth 令牌认证（而非 API Key）。运行 'claude setup-token' 获取 OAuth 令牌。"
+        "claudeCodeModeTooltip": "启用 Claude Code 模式以使用 OAuth 令牌认证（而非 API Key）。运行 'claude setup-token' 获取 OAuth 令牌。",
+        "reasoningContentModeTooltip": "控制如何处理大模型返回的推理内容：passthrough 原样透传；ignore 丢弃；concat 拼接到正文。留空使用默认值 passthrough。",
+        "firstByteTimeoutTooltip": "流式请求中收到上游服务第一个响应包的超时时间（毫秒）。留空（0）表示不开启。"
       },
       "placeholder": {
         "azureServiceUrlPlaceholder": "需包含“/chat/completions”路径和“api-version”查询参数",
@@ -359,6 +366,8 @@
         "qwenFileIdsPlaceholder": "示例：file-fe-xxx",
         "zhipuDomainPlaceholder": "示例：api.z.ai（国际版服务）",
         "vllmCustomUrlPlaceholder": "示例：http://192.168.0.1:8000/v1",
+        "reasoningContentModePlaceholder": "默认：透传 (passthrough)",
+        "firstByteTimeoutPlaceholder": "留空（0）表示不开启",
         "claudeCustomUrlPlaceholder": "示例：https://api.anthropic.com 或 https://proxy.example.com/anthropic",
         "claudeCustomServiceHostPlaceholder": "示例：api.anthropic.com",
         "claudeCustomServicePathPlaceholder": "示例：/ 或 /anthropic"

--- a/frontend/src/pages/ai/components/ProviderForm/index.tsx
+++ b/frontend/src/pages/ai/components/ProviderForm/index.tsx
@@ -788,6 +788,21 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
                 </>
               )
             }
+            <Form.Item
+              label={t('llmProvider.providerForm.label.reasoningContentMode')}
+              tooltip={t('llmProvider.providerForm.tooltips.reasoningContentModeTooltip')}
+              name={["rawConfigs", "reasoningContentMode"]}
+            >
+              <Select
+                allowClear
+                placeholder={t('llmProvider.providerForm.placeholder.reasoningContentModePlaceholder') || ''}
+                options={[
+                  { label: t('llmProvider.providerForm.label.reasoningModePassthrough'), value: 'passthrough' },
+                  { label: t('llmProvider.providerForm.label.reasoningModeIgnore'), value: 'ignore' },
+                  { label: t('llmProvider.providerForm.label.reasoningModeConcat'), value: 'concat' },
+                ]}
+              />
+            </Form.Item>
           </>
         )
       }
@@ -1314,6 +1329,19 @@ const ProviderForm: React.FC = forwardRef((props: { value: any }, ref) => {
           </>
         )
       }
+
+      {/* 通用：流式首包超时（适用于所有供应商） */}
+      <Form.Item
+        label={t('llmProvider.providerForm.label.firstByteTimeout')}
+        tooltip={t('llmProvider.providerForm.tooltips.firstByteTimeoutTooltip')}
+        name={["rawConfigs", "firstByteTimeout"]}
+      >
+        <InputNumber
+          min={0}
+          style={{ width: '100%' }}
+          placeholder={t('llmProvider.providerForm.placeholder.firstByteTimeoutPlaceholder') || ''}
+        />
+      </Form.Item>
 
       {/* 令牌降级 */}
       <Form.Item


### PR DESCRIPTION
## What this PR does

Surface two ai-proxy provider config fields that were previously only settable
through the raw config API:

- **Reasoning content mode** (`reasoningContentMode`) — `passthrough` / `ignore` /
  `concat` select. Shown in the **Qwen** provider block, since only the Qwen
  provider supports it.
- **First-packet timeout** (`firstByteTimeout`) — numeric input (ms) for the
  streaming first-packet timeout, in the **common** section (applies to all
  provider types).

Matching `en-US` and `zh-CN` labels, tooltips and placeholders are added.

## How it was tested

- `npm run build` passes.
- `npm run check-i18n` reports no missing/unused keys for the added entries.

## Review history

Earlier revisions also exposed a provider-level `modelMapping` and a request
`timeout`, scoped to the vLLM block. Per review: `modelMapping` is configured via
`model-mapper` in the AI Route; the request `timeout` only governs auxiliary
context-fetch requests (not exposed in the console) and was dropped;
`reasoningContentMode` is Qwen-only and is now scoped to that provider type.
