### PR TITLE
fix: Fixed the ServiceWeightTable stale state bug

### DIFF
--- a/frontend/src/pages/route/components/RouteForm/index.tsx
+++ b/frontend/src/pages/route/components/RouteForm/index.tsx
@@ -185,7 +185,12 @@ const RouteForm: React.FC = forwardRef((props, ref) => {
   }, [weightedServices, form]);
 
   useImperativeHandle(ref, () => ({
-    reset: () => form.resetFields(),
+    reset: () => {
+      form.resetFields();
+      // Also clear the weighted services state so the ServiceWeightTable
+      // doesn't retain stale data when re-opening the New Route dialog.
+      setWeightedServices([]);
+    },
     handleSubmit: async () => {
       const values = await form.validateFields();
       if (values.domains && !Array.isArray(values.domains)) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Fixed the ServiceWeightTable stale state bug, that trying to create a second route after another one resulting RouteForm showing the previous ServiceWeightTable after opening.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

1. Create a new route with any config.
2. Click the Create Route button again.
3. Check the service selection area. See the difference between v2.2.2 and the fix version.

### Ⅴ. Special notes for reviews
