### PR TITLE
Reduce Nacos key-auth config size by sharding consumers

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -14,6 +14,7 @@ package com.alibaba.higress.sdk.service;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -32,6 +34,9 @@ import org.apache.commons.lang3.StringUtils;
 import com.alibaba.higress.sdk.exception.BusinessException;
 import com.alibaba.higress.sdk.exception.ResourceConflictException;
 import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.constant.HigressConstants;
+import com.alibaba.higress.sdk.constant.plugin.BuiltInPluginName;
+import com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig;
 import com.alibaba.higress.sdk.http.HttpStatus;
 import com.alibaba.higress.sdk.model.WasmPlugin;
 import com.alibaba.higress.sdk.model.WasmPluginConfig;
@@ -40,7 +45,9 @@ import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.MatchRule;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
+import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPluginSpec;
 import com.alibaba.higress.sdk.util.MapUtil;
 
 import io.kubernetes.client.openapi.ApiException;
@@ -50,6 +57,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
+
+    private static final int KEY_AUTH_CONSUMERS_PER_SHARD = 100;
+    private static final String KEY_AUTH_SHARD_NAME_PREFIX = BuiltInPluginName.KEY_AUTH + "-consumers-";
 
     private final WasmPluginService wasmPluginService;
     private final KubernetesClientService kubernetesClientService;
@@ -159,6 +169,10 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
     @Override
     @SuppressWarnings("unchecked")
     public List<WasmPluginInstance> addOrUpdateAll(List<WasmPluginInstance> instances) {
+        if (isKeyAuthInternalOnly(instances)) {
+            return addOrUpdateKeyAuthInternalInstances(instances);
+        }
+
         Map<String, WasmPlugin> pluginsToUpdate = new HashMap<>();
         ListValuedMap<WasmPluginInstanceGroupKey, WasmPluginInstance> groupedInstances = new ArrayListValuedHashMap<>();
         for (WasmPluginInstance instance : instances) {
@@ -253,6 +267,197 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
         }
 
         return instances.stream().map(beforeToAfterMap::get).collect(Collectors.toList());
+    }
+
+    private boolean isKeyAuthInternalOnly(List<WasmPluginInstance> instances) {
+        return CollectionUtils.isNotEmpty(instances) && instances.stream()
+            .allMatch(i -> BuiltInPluginName.KEY_AUTH.equals(i.getPluginName()) && i.isInternal());
+    }
+
+    private List<WasmPluginInstance> addOrUpdateKeyAuthInternalInstances(List<WasmPluginInstance> instances) {
+        List<WasmPluginInstance> results = new ArrayList<>(instances.size());
+        for (WasmPluginInstance instance : instances) {
+            instance.syncDeprecatedFields();
+            instance.validate();
+            if (instance.hasScopedTarget(WasmPluginInstanceScope.GLOBAL)) {
+                results.add(addOrUpdateKeyAuthGlobalInstance(instance));
+            } else {
+                results.add(addOrUpdateKeyAuthScopedInstance(instance));
+            }
+        }
+        return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    private WasmPluginInstance addOrUpdateKeyAuthGlobalInstance(WasmPluginInstance instance) {
+        WasmPlugin plugin = queryKeyAuthPlugin(instance);
+        List<V1alpha1WasmPlugin> existingCrs = listKeyAuthInternalCrs(plugin.getPluginVersion());
+        List<MatchRule> existingMatchRules = collectMatchRules(existingCrs);
+
+        List<Object> consumers = new ArrayList<>();
+        Map<String, Object> configurations = Optional.ofNullable(instance.getConfigurations()).orElseGet(HashMap::new);
+        Object consumersObj = configurations.get(KeyAuthConfig.CONSUMERS);
+        if (consumersObj instanceof List<?>) {
+            consumers.addAll((List<Object>)consumersObj);
+        }
+
+        int shardCount = Math.max(1, (consumers.size() + KEY_AUTH_CONSUMERS_PER_SHARD - 1) / KEY_AUTH_CONSUMERS_PER_SHARD);
+        Map<String, V1alpha1WasmPlugin> existingByName = existingCrs.stream()
+            .filter(cr -> cr.getMetadata() != null && StringUtils.isNotBlank(cr.getMetadata().getName()))
+            .collect(Collectors.toMap(cr -> cr.getMetadata().getName(), cr -> cr, (a, b) -> a));
+
+        List<V1alpha1WasmPlugin> savedCrs = new ArrayList<>(shardCount);
+        for (int i = 0; i < shardCount; i++) {
+            String shardName = keyAuthShardName(i);
+            V1alpha1WasmPlugin cr = existingByName.get(shardName);
+            if (cr == null) {
+                cr = kubernetesModelConverter.wasmPluginToCr(plugin, true);
+                Objects.requireNonNull(cr.getMetadata()).setName(shardName);
+            }
+
+            V1alpha1WasmPluginSpec spec = Objects.requireNonNull(cr.getSpec());
+            spec.setDefaultConfigDisable(!Boolean.TRUE.equals(instance.getEnabled()));
+            Map<String, Object> shardConfig = new HashMap<>(configurations);
+            int from = i * KEY_AUTH_CONSUMERS_PER_SHARD;
+            int to = Math.min(consumers.size(), from + KEY_AUTH_CONSUMERS_PER_SHARD);
+            shardConfig.put(KeyAuthConfig.CONSUMERS, new ArrayList<>(consumers.subList(from, to)));
+            spec.setDefaultConfig(shardConfig);
+            spec.setMatchRules(copyMatchRules(existingMatchRules));
+            savedCrs.add(saveWasmPluginCr(cr, existingByName.containsKey(shardName), plugin.getName()));
+        }
+
+        for (V1alpha1WasmPlugin cr : existingCrs) {
+            String name = cr.getMetadata() == null ? null : cr.getMetadata().getName();
+            if (isKeyAuthShardName(name) && shardIndex(name) >= shardCount) {
+                deleteWasmPluginCr(name);
+            }
+        }
+
+        return kubernetesModelConverter.getWasmPluginInstanceFromCr(savedCrs.get(0), instance.getTargets());
+    }
+
+    private WasmPluginInstance addOrUpdateKeyAuthScopedInstance(WasmPluginInstance instance) {
+        WasmPlugin plugin = queryKeyAuthPlugin(instance);
+        List<V1alpha1WasmPlugin> existingCrs = listKeyAuthInternalCrs(plugin.getPluginVersion());
+        if (CollectionUtils.isEmpty(existingCrs)) {
+            V1alpha1WasmPlugin cr = kubernetesModelConverter.wasmPluginToCr(plugin, true);
+            kubernetesModelConverter.setWasmPluginInstanceToCr(cr, instance);
+            return kubernetesModelConverter.getWasmPluginInstanceFromCr(saveWasmPluginCr(cr, false, plugin.getName()),
+                instance.getTargets());
+        }
+
+        WasmPluginInstance result = null;
+        for (V1alpha1WasmPlugin cr : existingCrs) {
+            kubernetesModelConverter.setWasmPluginInstanceToCr(cr, instance);
+            V1alpha1WasmPlugin saved = saveWasmPluginCr(cr, true, plugin.getName());
+            if (result == null) {
+                result = kubernetesModelConverter.getWasmPluginInstanceFromCr(saved, instance.getTargets());
+            }
+        }
+        return result;
+    }
+
+    private WasmPlugin queryKeyAuthPlugin(WasmPluginInstance instance) {
+        WasmPlugin plugin = wasmPluginService.query(BuiltInPluginName.KEY_AUTH, null);
+        if (plugin == null) {
+            throw new IllegalArgumentException("Unknown plugin: " + instance.getPluginName());
+        }
+        String version = StringUtils.firstNonEmpty(instance.getPluginVersion(), plugin.getPluginVersion());
+        if (!version.equals(plugin.getPluginVersion())) {
+            throw new IllegalArgumentException("Add operation is only allowed for the current plugin version.");
+        }
+        instance.setPluginVersion(version);
+        return plugin;
+    }
+
+    private List<V1alpha1WasmPlugin> listKeyAuthInternalCrs(String version) {
+        try {
+            List<V1alpha1WasmPlugin> crs = kubernetesClientService.listWasmPlugin(BuiltInPluginName.KEY_AUTH, version);
+            if (CollectionUtils.isEmpty(crs)) {
+                return Collections.emptyList();
+            }
+            return crs.stream().filter(KubernetesUtil::isInternalResource).collect(Collectors.toList());
+        } catch (ApiException e) {
+            throw new BusinessException("Error occurs when getting WasmPlugin.", e);
+        }
+    }
+
+    private V1alpha1WasmPlugin saveWasmPluginCr(V1alpha1WasmPlugin cr, boolean existed, String pluginName) {
+        try {
+            return existed ? kubernetesClientService.replaceWasmPlugin(cr) : kubernetesClientService.createWasmPlugin(cr);
+        } catch (ApiException e) {
+            if (e.getCode() == HttpStatus.CONFLICT) {
+                throw new ResourceConflictException();
+            }
+            throw new BusinessException("Error occurs when adding or updating the WasmPlugin CR with name: " + pluginName,
+                e);
+        }
+    }
+
+    private void deleteWasmPluginCr(String name) {
+        try {
+            kubernetesClientService.deleteWasmPlugin(name);
+        } catch (ApiException e) {
+            throw new BusinessException("Error occurs when deleting stale WasmPlugin CR with name: " + name, e);
+        }
+    }
+
+    private String keyAuthShardName(int index) {
+        if (index == 0) {
+            return BuiltInPluginName.KEY_AUTH + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX;
+        }
+        return KEY_AUTH_SHARD_NAME_PREFIX + index + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX;
+    }
+
+    private boolean isKeyAuthShardName(String name) {
+        return StringUtils.equals(name, keyAuthShardName(0))
+            || StringUtils.startsWith(name, KEY_AUTH_SHARD_NAME_PREFIX);
+    }
+
+    private int shardIndex(String name) {
+        if (StringUtils.equals(name, keyAuthShardName(0))) {
+            return 0;
+        }
+        if (!StringUtils.startsWith(name, KEY_AUTH_SHARD_NAME_PREFIX)) {
+            return -1;
+        }
+        String suffix = StringUtils.removeEnd(StringUtils.removeStart(name, KEY_AUTH_SHARD_NAME_PREFIX),
+            HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX);
+        try {
+            return Integer.parseInt(suffix);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private List<MatchRule> collectMatchRules(List<V1alpha1WasmPlugin> crs) {
+        List<MatchRule> rules = new ArrayList<>();
+        for (V1alpha1WasmPlugin cr : crs) {
+            V1alpha1WasmPluginSpec spec = cr.getSpec();
+            if (spec == null || CollectionUtils.isEmpty(spec.getMatchRules())) {
+                continue;
+            }
+            for (MatchRule rule : spec.getMatchRules()) {
+                if (rules.stream().noneMatch(rule::keyEquals)) {
+                    rules.add(copyMatchRule(rule));
+                }
+            }
+        }
+        return rules;
+    }
+
+    private List<MatchRule> copyMatchRules(List<MatchRule> rules) {
+        if (CollectionUtils.isEmpty(rules)) {
+            return Collections.emptyList();
+        }
+        return rules.stream().map(this::copyMatchRule).collect(Collectors.toList());
+    }
+
+    private MatchRule copyMatchRule(MatchRule rule) {
+        return new MatchRule(rule.getConfigDisable(), rule.getConfig() == null ? null : new HashMap<>(rule.getConfig()),
+            rule.getDomain() == null ? null : new ArrayList<>(rule.getDomain()),
+            rule.getIngress() == null ? null : new ArrayList<>(rule.getIngress()),
+            rule.getService() == null ? null : new ArrayList<>(rule.getService()));
     }
 
     @Override

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/ConsumerServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/consumer/ConsumerServiceImpl.java
@@ -29,6 +29,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig;
 import com.alibaba.higress.sdk.exception.BusinessException;
 import com.alibaba.higress.sdk.model.CommonPageQuery;
 import com.alibaba.higress.sdk.model.PaginatedResult;
@@ -65,7 +66,7 @@ public class ConsumerServiceImpl implements ConsumerService {
     public Consumer addOrUpdate(Consumer consumer) {
         List<WasmPluginInstance> instancesToUpdate = new ArrayList<>(CREDENTIAL_HANDLERS.size());
         for (CredentialHandler handler : CREDENTIAL_HANDLERS.values()) {
-            WasmPluginInstance instance = getGlobalPluginInstance(handler);
+            WasmPluginInstance instance = mergeGlobalPluginInstances(handler);
             if (instance == null) {
                 instance = createGlobalPluginInstance(handler);
             }
@@ -106,8 +107,7 @@ public class ConsumerServiceImpl implements ConsumerService {
         }
         for (CredentialHandler handler : CREDENTIAL_HANDLERS.values()) {
             List<WasmPluginInstance> instances = instancesCache.get(handler.getType());
-            WasmPluginInstance globalInstance = instances.stream()
-                .filter(i -> i.hasScopedTarget(WasmPluginInstanceScope.GLOBAL)).findFirst().orElse(null);
+            WasmPluginInstance globalInstance = mergeGlobalPluginInstances(handler, instances);
             if (globalInstance == null) {
                 continue;
             }
@@ -280,17 +280,15 @@ public class ConsumerServiceImpl implements ConsumerService {
     private SortedMap<String, Consumer> getConsumers() {
         SortedMap<String, Consumer> consumers = new TreeMap<>();
         for (CredentialHandler handler : CREDENTIAL_HANDLERS.values()) {
-            WasmPluginInstance instance = getGlobalPluginInstance(handler);
-            if (instance == null) {
-                continue;
-            }
-            List<Consumer> extractedConsumers = handler.extractConsumers(instance);
-            for (Consumer consumer : extractedConsumers) {
-                Consumer existedConsumer = consumers.putIfAbsent(consumer.getName(), consumer);
-                if (existedConsumer != null) {
-                    List<Credential> credentials = new ArrayList<>(existedConsumer.getCredentials());
-                    credentials.addAll(consumer.getCredentials());
-                    existedConsumer.setCredentials(credentials);
+            for (WasmPluginInstance instance : getGlobalPluginInstances(handler)) {
+                List<Consumer> extractedConsumers = handler.extractConsumers(instance);
+                for (Consumer consumer : extractedConsumers) {
+                    Consumer existedConsumer = consumers.putIfAbsent(consumer.getName(), consumer);
+                    if (existedConsumer != null) {
+                        List<Credential> credentials = new ArrayList<>(existedConsumer.getCredentials());
+                        credentials.addAll(consumer.getCredentials());
+                        existedConsumer.setCredentials(credentials);
+                    }
                 }
             }
         }
@@ -304,6 +302,53 @@ public class ConsumerServiceImpl implements ConsumerService {
 
     private WasmPluginInstance getGlobalPluginInstance(CredentialHandler handler) {
         return wasmPluginInstanceService.query(WasmPluginInstanceScope.GLOBAL, null, handler.getPluginName(), true);
+    }
+
+    private List<WasmPluginInstance> getGlobalPluginInstances(CredentialHandler handler) {
+        List<WasmPluginInstance> globalInstances = getAllPluginInstances(handler).stream()
+            .filter(i -> i.hasScopedTarget(WasmPluginInstanceScope.GLOBAL)).collect(Collectors.toList());
+        if (CollectionUtils.isNotEmpty(globalInstances)) {
+            return globalInstances;
+        }
+        WasmPluginInstance globalInstance = getGlobalPluginInstance(handler);
+        return globalInstance == null ? Collections.emptyList() : Collections.singletonList(globalInstance);
+    }
+
+    private WasmPluginInstance mergeGlobalPluginInstances(CredentialHandler handler) {
+        List<WasmPluginInstance> instances = getAllPluginInstances(handler);
+        WasmPluginInstance merged = mergeGlobalPluginInstances(handler, instances);
+        if (merged != null) {
+            return merged;
+        }
+        return getGlobalPluginInstance(handler);
+    }
+
+    private WasmPluginInstance mergeGlobalPluginInstances(CredentialHandler handler, List<WasmPluginInstance> instances) {
+        List<WasmPluginInstance> globalInstances = instances.stream()
+            .filter(i -> i.hasScopedTarget(WasmPluginInstanceScope.GLOBAL)).collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(globalInstances)) {
+            return null;
+        }
+
+        WasmPluginInstance merged = globalInstances.get(0);
+        Map<String, Object> mergedConfigurations = new HashMap<>();
+        if (MapUtils.isNotEmpty(merged.getConfigurations())) {
+            mergedConfigurations.putAll(merged.getConfigurations());
+        }
+        List<Object> mergedConsumers = new ArrayList<>();
+        for (WasmPluginInstance instance : globalInstances) {
+            Map<String, Object> configurations = instance.getConfigurations();
+            if (MapUtils.isEmpty(configurations)) {
+                continue;
+            }
+            Object consumersObj = configurations.get(KeyAuthConfig.CONSUMERS);
+            if (consumersObj instanceof List<?>) {
+                mergedConsumers.addAll((List<?>)consumersObj);
+            }
+        }
+        mergedConfigurations.put(KeyAuthConfig.CONSUMERS, mergedConsumers);
+        merged.setConfigurations(mergedConfigurations);
+        return merged;
     }
 
     private WasmPluginInstance getPluginInstance(CredentialHandler handler,

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/McpServerServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/McpServerServiceTest.java
@@ -355,8 +355,8 @@ public class McpServerServiceTest {
         mcpServerService.addAllowConsumers(newConsumers);
 
         ArgumentCaptor<V1alpha1WasmPlugin> pluginCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
-        verify(kubernetesClientService, times(1)).replaceWasmPlugin(pluginCaptor.capture());
-        V1alpha1WasmPlugin capturedValue = pluginCaptor.getValue();
+        verify(kubernetesClientService, times(2)).replaceWasmPlugin(pluginCaptor.capture());
+        V1alpha1WasmPlugin capturedValue = pluginCaptor.getAllValues().get(1);
         Assertions.assertNotNull(capturedValue);
         Assertions.assertNotNull(capturedValue.getSpec().getMatchRules());
         Object allowObj = capturedValue.getSpec().getMatchRules().get(0).getConfig().get("allow");
@@ -401,8 +401,8 @@ public class McpServerServiceTest {
         mcpServerService.deleteAllowConsumers(newConsumers);
 
         ArgumentCaptor<V1alpha1WasmPlugin> pluginCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
-        verify(kubernetesClientService, times(1)).replaceWasmPlugin(pluginCaptor.capture());
-        V1alpha1WasmPlugin capturedValue = pluginCaptor.getValue();
+        verify(kubernetesClientService, times(2)).replaceWasmPlugin(pluginCaptor.capture());
+        V1alpha1WasmPlugin capturedValue = pluginCaptor.getAllValues().get(1);
         Assertions.assertNotNull(capturedValue);
         Assertions.assertNotNull(capturedValue.getSpec().getMatchRules());
         Object allowObj = capturedValue.getSpec().getMatchRules().get(0).getConfig().get("allow");

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,6 +37,8 @@ import org.mockito.ArgumentCaptor;
 
 import com.alibaba.higress.sdk.constant.HigressConstants;
 import com.alibaba.higress.sdk.constant.Separators;
+import com.alibaba.higress.sdk.constant.plugin.BuiltInPluginName;
+import com.alibaba.higress.sdk.constant.plugin.config.KeyAuthConfig;
 import com.alibaba.higress.sdk.exception.BusinessException;
 import com.alibaba.higress.sdk.exception.ValidationException;
 import com.alibaba.higress.sdk.model.WasmPlugin;
@@ -449,10 +453,73 @@ public class WasmPluginInstanceServiceTest {
             .assertTrue(exception.getMessage().contains("Error occurs when adding or updating the WasmPlugin CR"));
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void addOrUpdateAllTestShardsInternalKeyAuthConsumers() throws Exception {
+        WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(BuiltInPluginName.KEY_AUTH)
+            .pluginVersion(DEFAULT_VERSION).targets(MapUtil.of(WasmPluginInstanceScope.GLOBAL, null)).enabled(true)
+            .configurations(buildKeyAuthConfig(101)).internal(true).build();
+
+        WasmPluginInstance updatedInstance = service.addOrUpdate(instance);
+        Assertions.assertNotNull(updatedInstance);
+
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(2)).createWasmPlugin(crCaptor.capture());
+        List<V1alpha1WasmPlugin> crs = crCaptor.getAllValues();
+        Assertions.assertEquals(BuiltInPluginName.KEY_AUTH + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX,
+            crs.get(0).getMetadata().getName());
+        Assertions.assertEquals(BuiltInPluginName.KEY_AUTH + "-consumers-1"
+            + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX, crs.get(1).getMetadata().getName());
+        Assertions.assertEquals(100,
+            ((List<?>)crs.get(0).getSpec().getDefaultConfig().get(KeyAuthConfig.CONSUMERS)).size());
+        Assertions.assertEquals(1,
+            ((List<?>)crs.get(1).getSpec().getDefaultConfig().get(KeyAuthConfig.CONSUMERS)).size());
+    }
+
+    @Test
+    public void addOrUpdateAllTestSyncsInternalKeyAuthAllowListToShards() throws Exception {
+        V1alpha1WasmPlugin firstShard = buildWasmPluginResource(BuiltInPluginName.KEY_AUTH, true, true);
+        V1alpha1WasmPlugin secondShard = buildWasmPluginResource(BuiltInPluginName.KEY_AUTH, true, true);
+        secondShard.getMetadata().setName(BuiltInPluginName.KEY_AUTH + "-consumers-1"
+            + HigressConstants.INTERNAL_RESOURCE_NAME_SUFFIX);
+        List<V1alpha1WasmPlugin> crs = Lists.newArrayList(firstShard, secondShard);
+        when(kubernetesClientService.listWasmPlugin(eq(BuiltInPluginName.KEY_AUTH), anyString())).thenReturn(crs);
+
+        WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(BuiltInPluginName.KEY_AUTH)
+            .pluginVersion(DEFAULT_VERSION).targets(MapUtil.of(WasmPluginInstanceScope.ROUTE, "route-a")).enabled(true)
+            .configurations(MapUtil.of(KeyAuthConfig.ALLOW, Lists.newArrayList("consumer-a"))).internal(true).build();
+
+        WasmPluginInstance updatedInstance = service.addOrUpdate(instance);
+        Assertions.assertNotNull(updatedInstance);
+
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(2)).replaceWasmPlugin(crCaptor.capture());
+        for (V1alpha1WasmPlugin cr : crCaptor.getAllValues()) {
+            Assertions.assertEquals(1, cr.getSpec().getMatchRules().size());
+            MatchRule rule = cr.getSpec().getMatchRules().get(0);
+            Assertions.assertEquals(Collections.singletonList("route-a"), rule.getIngress());
+            Assertions.assertEquals(Collections.singletonList("consumer-a"), rule.getConfig().get(KeyAuthConfig.ALLOW));
+        }
+    }
+
     private V1alpha1WasmPlugin buildWasmPluginResource(String name, boolean builtIn, boolean internal) {
         WasmPlugin plugin = WasmPlugin.builder().name(name).pluginVersion(DEFAULT_VERSION).builtIn(builtIn)
             .category("TEST").icon("http://dummy-icon").phase(PluginPhase.UNSPECIFIED.name()).priority(1000)
             .imageRepository("oci://docker.io/" + name).build();
         return kubernetesModelConverter.wasmPluginToCr(plugin, internal);
+    }
+
+    private Map<String, Object> buildKeyAuthConfig(int consumerCount) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(KeyAuthConfig.GLOBAL_AUTH, false);
+        config.put(KeyAuthConfig.ALLOW, Collections.emptyList());
+        config.put(KeyAuthConfig.KEYS, Collections.singletonList("x-higress-dummy-key"));
+        List<Map<String, Object>> consumers = new ArrayList<>();
+        for (int i = 0; i < consumerCount; i++) {
+            consumers.add(MapUtil.of(KeyAuthConfig.CONSUMER_NAME, "consumer-" + i,
+                KeyAuthConfig.CONSUMER_CREDENTIALS, Collections.singletonList("credential-" + i)));
+        }
+        config.put(KeyAuthConfig.CONSUMERS, consumers);
+        return config;
     }
 }


### PR DESCRIPTION
## Summary
- shard console-managed internal key-auth global consumers across multiple WasmPlugin CRs
- merge key-auth consumer shards for consumer CRUD/list/query paths
- synchronize route/domain allow-list rules to every key-auth shard so per-route auth remains consistent

## Verification
- `./mvnw -q -pl sdk -Dtest=ConsumerServiceTest,WasmPluginInstanceServiceTest test`
- `./mvnw -q -pl sdk test`
- `git diff --check`

Related: higress-group/higress#3112