### PR TITLE
feat: add Basic Auth notice and security scheme to Swagger UI

### DIFF
--- a/backend/console/src/main/java/com/alibaba/higress/console/config/SwaggerConfig.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/config/SwaggerConfig.java
@@ -12,6 +12,7 @@
  */
 package com.alibaba.higress.console.config;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -33,11 +34,14 @@ import com.alibaba.higress.sdk.model.route.RoutePredicateTypeEnum;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
@@ -54,9 +58,22 @@ public class SwaggerConfig {
         Info apiInfo = new Info().title("Higress Console")
             .contact(new Contact().name("Higress Authors").url("https://github.com/higress-group/higress-console"))
             .description(
-                "Higress is a next-generation cloud-native gateway based on Alibaba's internal gateway practices.")
+                "Higress is a next-generation cloud-native gateway based on Alibaba's internal gateway practices."
+                    + "\n\n## API Authentication\n\n"
+                    + "Accessing this console API requires authentication via HTTP **Basic Auth**."
+                    + "Use the administrator account's username and password as credentials,"
+                    + "or enter the credentials via the **Authorize** button at the top right of the page before making a request.")
             .license(new License().name("Apache 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"));
         openApi.info(apiInfo);
+
+        Components components = openApi.getComponents();
+        if (components == null) {
+            components = new Components();
+            openApi.components(components);
+        }
+        components.addSecuritySchemes("basicAuth",
+            new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("basic")
+                .description("Use HTTP Basic Auth to provide the administrator account's username and password"));
 
         registerClassSchema(openApi, CapabilityKey.class);
         registerClassSchema(openApi, RoutePredicateTypeEnum.class);
@@ -70,6 +87,10 @@ public class SwaggerConfig {
 
         Map<String, Schema> schemas = openApi.getComponents().getSchemas();
         openApi.getComponents().setSchemas(new TreeMap<>(schemas));
+
+        SecurityRequirement securityRequirement = new SecurityRequirement();
+        securityRequirement.addList("basicAuth");
+        openApi.setSecurity(Collections.singletonList(securityRequirement));
     }
 
     private void registerClassSchema(OpenAPI openApi, Class<?> clazz) {

--- a/backend/console/src/main/java/com/alibaba/higress/console/config/SwaggerConfig.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/config/SwaggerConfig.java
@@ -60,9 +60,10 @@ public class SwaggerConfig {
             .description(
                 "Higress is a next-generation cloud-native gateway based on Alibaba's internal gateway practices."
                     + "\n\n## API Authentication\n\n"
-                    + "Accessing this console API requires authentication via HTTP **Basic Auth**."
-                    + "Use the administrator account's username and password as credentials,"
-                    + "or enter the credentials via the **Authorize** button at the top right of the page before making a request.")
+                    + "Most operations in this console API require authentication via HTTP **Basic Auth**. "
+                    + "Use the administrator account's username and password as credentials, "
+                    + "or enter the credentials via the **Authorize** button at the top right of the page before making a request. "
+                    + "A few endpoints (such as login and system initialization) are anonymous and do not require credentials.")
             .license(new License().name("Apache 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"));
         openApi.info(apiInfo);
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Append an "API Authentication" section to the OpenAPI description informing users that the API requires HTTP Basic Auth, and register a basicAuth security scheme so Swagger UI exposes an Authorize button for entering admin credentials.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/2321bd10-75ad-436c-9032-a984422d0527" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/470e0061-2d76-4767-866a-3c5e30c1485d" />

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
