### PR TITLE
feat: add CSP plugin to built-in plugin list

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/BuiltInPluginName.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/BuiltInPluginName.java
@@ -60,4 +60,5 @@ public final class BuiltInPluginName {
     public static final String BOT_DETECT = "bot-detect";
     public static final String WAF = "waf";
     public static final String CORS = "cors";
+    public static final String CSP = "csp";
 }

--- a/backend/sdk/src/main/resources/plugins/csp/README.md
+++ b/backend/sdk/src/main/resources/plugins/csp/README.md
@@ -1,0 +1,88 @@
+---
+title: CSP 内容安全策略
+keywords: [higress, csp, content security policy, 安全]
+description: CSP 内容安全策略插件配置参考
+---
+
+## 功能说明
+
+`csp` 插件用于为 HTTP 响应统一注入 [Content-Security-Policy（内容安全策略）](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/CSP)响应头，可显著降低 XSS（跨站脚本）等注入类攻击的风险。
+
+支持强制模式与仅上报（Report-Only）模式，可在强制现有策略的同时并行灰度更严格的候选策略，并可选择是否覆盖上游服务已设置的 CSP 响应头。
+
+## 运行属性
+
+插件执行阶段：`默认阶段`
+
+插件执行优先级：`330`
+
+## 配置字段
+
+| 名称 | 数据类型 | 填写要求 | 默认值 | 描述 |
+| -------- | -------- | -------- | -------- | -------- |
+| policy | string | 必填 | - | CSP 策略字符串，例如 `default-src 'self'; img-src *` |
+| report_only | bool | 选填 | false | 为 `true` 时使用 `Content-Security-Policy-Report-Only` 响应头，仅上报违规而不强制拦截，便于灰度验证策略 |
+| report_only_policy | string | 选填 | - | 可选。设置后在强制策略之外额外注入一个 `Content-Security-Policy-Report-Only` 响应头，用于强制现有策略的同时灰度验证更严格的候选策略。不可与 `report_only: true` 同时使用 |
+| override | bool | 选填 | true | 为 `true` 时先清除上游已设置的 CSP 响应头（强制与仅上报两种变体都会被清除）再注入本插件策略；为 `false` 时若响应中已存在**同名**（同一变体）的 CSP 响应头则保留原值，不注入该变体；上游仅设置了另一变体时，本插件仍会注入自己的变体 |
+
+> 在 `report_only: true` 且 `override: true`（默认）时，插件会一并移除上游的强制 `Content-Security-Policy`，确保仅上报模式不会残留上游的强制拦截。
+
+> `policy` 为空会导致插件配置校验失败，插件不会生效。
+
+> 插件仅注入响应头，不校验 `policy` / `report_only_policy` 的 CSP 语法，策略字符串原样下发，请自行确保拼写正确。
+
+> CSP 响应头会注入到所有匹配路由的响应上（浏览器仅对 HTML 文档生效，其余响应无害）。如需仅作用于特定路由，请通过路由级 matchRule 收窄插件生效范围。
+
+## 配置示例
+
+### 强制模式（默认）
+
+```yaml
+policy: "default-src 'self'; img-src *; script-src 'self'"
+```
+
+响应将携带：
+
+```
+Content-Security-Policy: default-src 'self'; img-src *; script-src 'self'
+```
+
+### 仅上报模式（灰度验证策略，不拦截）
+
+```yaml
+policy: "default-src 'self'; report-to csp-endpoint"
+report_only: true
+```
+
+响应将携带：
+
+```
+Content-Security-Policy-Report-Only: default-src 'self'; report-to csp-endpoint
+```
+
+> 仅上报模式若不配置 `report-to` / `report-uri` 指令，违规信息只会出现在浏览器控制台，不会上报到收集端点。
+
+### 强制现有策略 + 灰度验证更严格的新策略
+
+CSP 上线的标准做法：保持当前策略强制生效，同时用 `Content-Security-Policy-Report-Only` 观察更严格的候选策略，验证无误后再切换为强制。
+
+```yaml
+policy: "default-src 'self'; img-src *"
+report_only_policy: "default-src 'self'; img-src 'self'"
+```
+
+响应将同时携带：
+
+```
+Content-Security-Policy: default-src 'self'; img-src *
+Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self'
+```
+
+### 不覆盖上游已有的 CSP 响应头
+
+```yaml
+policy: "default-src 'self'"
+override: false
+```
+
+若上游响应已包含**同名**（同一变体）的 CSP 响应头，则保留其原值、不注入该变体；否则注入本插件配置的策略。上游仅设置了另一变体时，本插件仍会注入自己的变体。

--- a/backend/sdk/src/main/resources/plugins/csp/README_EN.md
+++ b/backend/sdk/src/main/resources/plugins/csp/README_EN.md
@@ -1,0 +1,88 @@
+---
+title: CSP Content Security Policy
+keywords: [higress, csp, content security policy, security]
+description: CSP Content Security Policy plugin configuration reference
+---
+
+## Description
+
+The `csp` plugin injects a [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) response header into HTTP responses, which significantly reduces the risk of XSS (cross-site scripting) and other injection attacks.
+
+It supports both enforcing mode and report-only mode, can validate a stricter candidate policy in parallel while the current one stays enforced, and can optionally preserve a CSP header already set by the upstream service.
+
+## Runtime Properties
+
+Plugin execution phase: `default phase`
+
+Plugin execution priority: `330`
+
+## Configuration Fields
+
+| Name | Type | Requirement | Default | Description |
+| -------- | -------- | -------- | -------- | -------- |
+| policy | string | Required | - | The CSP directive string, e.g. `default-src 'self'; img-src *` |
+| report_only | bool | Optional | false | When `true`, uses the `Content-Security-Policy-Report-Only` header so violations are reported but not enforced, which is useful for validating a policy before rollout |
+| report_only_policy | string | Optional | - | Optional. When set, injects an extra `Content-Security-Policy-Report-Only` header alongside the enforced policy, so a stricter candidate policy can be validated while the current one stays enforced. Cannot be combined with `report_only: true` |
+| override | bool | Optional | true | When `true`, removes any CSP header already set by the upstream (both the enforcing and the report-only variant) before injecting the configured policy; when `false`, keeps an existing upstream header of the **same variant** untouched, while still injecting its own variant if the upstream set only the other one |
+
+> When `report_only: true` and `override: true` (default), the plugin also strips the upstream's enforcing `Content-Security-Policy`, so report-only mode never leaves an upstream enforcing policy in effect.
+
+> An empty `policy` fails the plugin configuration validation and the plugin will not take effect.
+
+> The plugin only injects headers; it does not validate the CSP syntax of `policy` / `report_only_policy`. The strings are emitted as-is, so make sure they are spelled correctly.
+
+> The CSP header is injected on every response of the matched routes (browsers only apply it to HTML documents; it is harmless on other responses). To scope it to specific routes, narrow the plugin with a route-level matchRule.
+
+## Configuration Examples
+
+### Enforcing mode (default)
+
+```yaml
+policy: "default-src 'self'; img-src *; script-src 'self'"
+```
+
+The response will carry:
+
+```
+Content-Security-Policy: default-src 'self'; img-src *; script-src 'self'
+```
+
+### Report-only mode (validate a policy without blocking)
+
+```yaml
+policy: "default-src 'self'; report-to csp-endpoint"
+report_only: true
+```
+
+The response will carry:
+
+```
+Content-Security-Policy-Report-Only: default-src 'self'; report-to csp-endpoint
+```
+
+> Without a `report-to` / `report-uri` directive, report-only violations only appear in the browser console and are not sent to a collection endpoint.
+
+### Enforce the current policy while validating a stricter one
+
+The standard CSP rollout: keep the current policy enforced while observing a stricter candidate via `Content-Security-Policy-Report-Only`, then switch it to enforcing once validated.
+
+```yaml
+policy: "default-src 'self'; img-src *"
+report_only_policy: "default-src 'self'; img-src 'self'"
+```
+
+The response will carry both:
+
+```
+Content-Security-Policy: default-src 'self'; img-src *
+Content-Security-Policy-Report-Only: default-src 'self'; img-src 'self'
+```
+
+### Keep the upstream CSP header if present
+
+```yaml
+policy: "default-src 'self'"
+override: false
+```
+
+If the upstream response already contains a CSP header of the **same variant**, its value is preserved and that variant is not injected; otherwise the configured policy is injected. If the upstream set only the other variant, the plugin still injects its own.

--- a/backend/sdk/src/main/resources/plugins/csp/spec.yaml
+++ b/backend/sdk/src/main/resources/plugins/csp/spec.yaml
@@ -1,0 +1,113 @@
+apiVersion: 1.0.0
+info:
+  gatewayMinVersion: ""
+  type: oss
+  category: security
+  name: csp
+  image: platform_wasm/csp
+  title: CSP Content Security Policy
+  x-title-i18n:
+    zh-CN: CSP 内容安全策略
+  description: Injects the Content-Security-Policy response header to reduce XSS and other injection risks, with support for report-only mode and upstream header override control.
+  x-description-i18n:
+    zh-CN: 为 HTTP 响应注入 Content-Security-Policy 响应头，降低 XSS 等注入类攻击风险，支持仅上报模式与上游响应头覆盖控制。
+  iconUrl: https://img.alicdn.com/imgextra/i1/O1CN01jKT9vC1O059vNaq5u_!!6000000001642-2-tps-42-42.png
+  readmeUrl: https://github.com/alibaba/higress/blob/main/plugins/wasm-go/extensions/csp/README.md
+  x-readmeUrl-i18n:
+    en-US: https://github.com/alibaba/higress/blob/main/plugins/wasm-go/extensions/csp/README_EN.md
+  version: 1.0.0
+  contact:
+    name: Higress Team
+    url: http://higress.io/
+    email: admin@higress.io
+spec:
+  phase: default
+  priority: 330
+  configSchema:
+    openAPIV3Schema:
+      type: object
+      properties:
+        policy:
+          type: string
+          title: CSP Policy
+          x-title-i18n:
+            zh-CN: CSP 策略
+          description: The CSP directive string, e.g. default-src 'self'; img-src *. Required and must be non-empty.
+          x-description-i18n:
+            zh-CN: CSP 策略字符串，例如 default-src 'self'; img-src *。必填且不能为空。
+        report_only:
+          type: boolean
+          title: Report-Only Mode
+          x-title-i18n:
+            zh-CN: 仅上报模式
+          description: When true, uses the Content-Security-Policy-Report-Only header so violations are reported but not enforced, which is useful for validating a policy before rollout.
+          x-description-i18n:
+            zh-CN: 为 true 时使用 Content-Security-Policy-Report-Only 响应头，仅上报违规而不强制拦截，便于灰度验证策略。
+          default: false
+        report_only_policy:
+          type: string
+          title: Report-Only Candidate Policy
+          x-title-i18n:
+            zh-CN: 灰度验证策略
+          description: Optional. When set, injects an extra Content-Security-Policy-Report-Only header alongside the enforced policy, so a stricter candidate policy can be validated while the current one stays enforced. Cannot be combined with report_only true.
+          x-description-i18n:
+            zh-CN: 可选。设置后在强制策略之外额外注入一个 Content-Security-Policy-Report-Only 响应头，用于强制现有策略的同时灰度验证更严格的候选策略。不可与 report_only 为 true 同时使用。
+        override:
+          type: boolean
+          title: Override Upstream Header
+          x-title-i18n:
+            zh-CN: 覆盖上游响应头
+          description: When true (default), removes any CSP header already set by the upstream (both variants) before injecting the configured policy; when false, keeps an existing upstream header of the same variant untouched while still injecting the other configured variant.
+          x-description-i18n:
+            zh-CN: 为 true（默认）时先清除上游已设置的 CSP 响应头（两种变体都会被清除）再注入本插件策略；为 false 时若响应中已存在同名（同一变体）的 CSP 响应头则保留原值、不注入该变体，另一变体仍会正常注入。
+          default: true
+      required:
+        - policy
+      example:
+        policy: "default-src 'self'; img-src *; script-src 'self'"
+        report_only: false
+        override: true
+  routeConfigSchema:
+    openAPIV3Schema:
+      type: object
+      properties:
+        policy:
+          type: string
+          title: CSP Policy
+          x-title-i18n:
+            zh-CN: CSP 策略
+          description: The CSP directive string, e.g. default-src 'self'; img-src *. Required and must be non-empty.
+          x-description-i18n:
+            zh-CN: CSP 策略字符串，例如 default-src 'self'; img-src *。必填且不能为空。
+        report_only:
+          type: boolean
+          title: Report-Only Mode
+          x-title-i18n:
+            zh-CN: 仅上报模式
+          description: When true, uses the Content-Security-Policy-Report-Only header so violations are reported but not enforced, which is useful for validating a policy before rollout.
+          x-description-i18n:
+            zh-CN: 为 true 时使用 Content-Security-Policy-Report-Only 响应头，仅上报违规而不强制拦截，便于灰度验证策略。
+          default: false
+        report_only_policy:
+          type: string
+          title: Report-Only Candidate Policy
+          x-title-i18n:
+            zh-CN: 灰度验证策略
+          description: Optional. When set, injects an extra Content-Security-Policy-Report-Only header alongside the enforced policy, so a stricter candidate policy can be validated while the current one stays enforced. Cannot be combined with report_only true.
+          x-description-i18n:
+            zh-CN: 可选。设置后在强制策略之外额外注入一个 Content-Security-Policy-Report-Only 响应头，用于强制现有策略的同时灰度验证更严格的候选策略。不可与 report_only 为 true 同时使用。
+        override:
+          type: boolean
+          title: Override Upstream Header
+          x-title-i18n:
+            zh-CN: 覆盖上游响应头
+          description: When true (default), removes any CSP header already set by the upstream (both variants) before injecting the configured policy; when false, keeps an existing upstream header of the same variant untouched while still injecting the other configured variant.
+          x-description-i18n:
+            zh-CN: 为 true（默认）时先清除上游已设置的 CSP 响应头（两种变体都会被清除）再注入本插件策略；为 false 时若响应中已存在同名（同一变体）的 CSP 响应头则保留原值、不注入该变体，另一变体仍会正常注入。
+          default: true
+      required:
+        - policy
+      example:
+        policy: "default-src 'self'; img-src *; script-src 'self'"
+        report_only: false
+        override: true

--- a/backend/sdk/src/main/resources/plugins/plugins.properties
+++ b/backend/sdk/src/main/resources/plugins/plugins.properties
@@ -63,3 +63,4 @@ traffic-tag=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/traffic-t
 bot-detect=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/bot-detect:2.0.0
 waf=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/waf:2.0.0
 cors=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/cors:2.0.0
+csp=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/csp:2.0.0


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Registers the `csp` plugin as a built-in plugin so it shows up in the console plugin market:

- adds the `CSP` constant to `BuiltInPluginName`
- adds the `csp` entry to `plugins.properties`
- adds `plugins/csp/` (spec.yaml + README) describing the config schema (`policy`, `report_only`, `report_only_policy`, `override`)

### Ⅱ. Does this pull request fix one issue?

Companion to the plugin PR higress-group/higress#4111 (higress-group/higress#1706).

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Covered by the existing `WasmPluginServiceTest`, which validates that every entry in `plugins.properties` registers and its spec loads. No new logic is introduced.

### Ⅳ. Describe how to verify it

- `./mvnw -pl sdk test -Dtest=WasmPluginServiceTest`
- Or run the console and open Plugin Management → Security → CSP: the config form renders `policy`, `report_only`, `report_only_policy`, `override`, with defaults `report_only=false` and `override=true`.
<img width="1905" height="807" alt="Screenshot 2026-07-07 at 9 42 55 PM" src="https://github.com/user-attachments/assets/500e78c6-a37c-4d54-8ea8-7361707d1f34" />
<img width="1916" height="956" alt="Screenshot 2026-07-07 at 9 42 13 PM" src="https://github.com/user-attachments/assets/e1e14a22-403b-48ba-9cd0-5e148f51b694" />


### Ⅴ. Special notes for reviews

The OCI image tag is `2.0.0` to match the current built-in plugin release wave. The plugin implementation is submitted separately in higress-group/higress#4111.
