### PR TITLE
feat: make frontend request timeout configurable via localStorage

### DIFF
--- a/frontend/src/services/request.tsx
+++ b/frontend/src/services/request.tsx
@@ -2,9 +2,10 @@ import { Modal } from "antd";
 import axios from "axios";
 import i18next from 'i18next';
 import { ErrorComp } from './exception';
+import { resolveRequestTimeout } from './timeout';
 
 const request = axios.create({
-  timeout: 5 * 1000,
+  timeout: resolveRequestTimeout(),
   baseURL: process.env.ICE_CORE_MODE === "development" ? "/api" : "",
   headers: {
     "Content-Type": "application/json",

--- a/frontend/src/services/timeout.test.ts
+++ b/frontend/src/services/timeout.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  DEFAULT_REQUEST_TIMEOUT,
+  REQUEST_TIMEOUT_STORAGE_KEY,
+  resolveRequestTimeout,
+} from './timeout.ts';
+
+/** Build a minimal storage stub returning a fixed value for the timeout key. */
+function stubStorage(value: string | null): Pick<Storage, 'getItem'> {
+  return {
+    getItem: (key: string) => (key === REQUEST_TIMEOUT_STORAGE_KEY ? value : null),
+  };
+}
+
+test('returns the configured value for a valid integer string', () => {
+  assert.equal(resolveRequestTimeout(stubStorage('120000')), 120000);
+});
+
+test('returns the configured value for a valid decimal string', () => {
+  assert.equal(resolveRequestTimeout(stubStorage('60000.5')), 60000.5);
+});
+
+test('falls back to default when the key is missing (null)', () => {
+  assert.equal(resolveRequestTimeout(stubStorage(null)), DEFAULT_REQUEST_TIMEOUT);
+});
+
+test('falls back to default for an empty string', () => {
+  assert.equal(resolveRequestTimeout(stubStorage('')), DEFAULT_REQUEST_TIMEOUT);
+});
+
+test('falls back to default for a non-numeric string', () => {
+  assert.equal(resolveRequestTimeout(stubStorage('abc')), DEFAULT_REQUEST_TIMEOUT);
+});
+
+test('falls back to default for a negative number', () => {
+  assert.equal(resolveRequestTimeout(stubStorage('-5')), DEFAULT_REQUEST_TIMEOUT);
+});
+
+test('falls back to default for zero', () => {
+  assert.equal(resolveRequestTimeout(stubStorage('0')), DEFAULT_REQUEST_TIMEOUT);
+});
+
+test('default timeout constant is 60 seconds', () => {
+  assert.equal(DEFAULT_REQUEST_TIMEOUT, 60 * 1000);
+});

--- a/frontend/src/services/timeout.ts
+++ b/frontend/src/services/timeout.ts
@@ -1,0 +1,23 @@
+export const REQUEST_TIMEOUT_STORAGE_KEY = 'requestTimeout';
+export const DEFAULT_REQUEST_TIMEOUT = 60 * 1000;
+
+/**
+ * Resolve the request timeout in milliseconds.
+ *
+ * Reads `requestTimeout` (a millisecond string) from localStorage and falls
+ * back to {@link DEFAULT_REQUEST_TIMEOUT} when the value is missing, not a
+ * finite number, or not strictly positive.
+ *
+ * @param storage - Storage source, defaults to `localStorage`; injectable for testing.
+ * @returns The resolved timeout in milliseconds.
+ */
+export function resolveRequestTimeout(
+  storage: Pick<Storage, 'getItem'> = localStorage,
+): number {
+  const raw = storage.getItem(REQUEST_TIMEOUT_STORAGE_KEY);
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_REQUEST_TIMEOUT;
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary

- Raise the default axios request timeout from **5s to 60s**.
- Allow overriding it through the `requestTimeout` localStorage key (value in **milliseconds**).
- Extract `resolveRequestTimeout()` into `frontend/src/services/timeout.ts` as a pure, testable function. Missing / non-numeric / non-positive values fall back to the 60s default.
- The value is read once at `axios.create()` time (changing localStorage takes effect after a page refresh).

## Behavior

| localStorage `requestTimeout` | Effective timeout |
| --- | --- |
| unset | 60000 ms |
| `"120000"` | 120000 ms |
| `"abc"` / `"-5"` / `"0"` | 60000 ms (fallback) |

## Test plan

- [x] Unit tests via `node:test` (8 cases: valid int / decimal / missing / empty / NaN / negative / zero / default constant) — all pass.
- [x] `eslint` clean on all changed files.
- [x] Manual: confirm a >5s request no longer aborts prematurely.