### PR TITLE
fix: avoid appending an extra trailing slash to Claude custom URL on reload

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/ClaudeLlmProviderHandler.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/ai/ClaudeLlmProviderHandler.java
@@ -82,6 +82,11 @@ public class ClaudeLlmProviderHandler extends AbstractLlmProviderHandler {
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
+        // Omit root paths so a URL without a trailing slash isn't rewritten with an extra "/" on reload.
+        // stripEnd also collapses all-slash paths like "//".
+        if (StringUtils.stripEnd(path, "/").isEmpty()) {
+            path = "";
+        }
         String host = endpoint.getAddress().trim();
         int port = endpoint.getPort() != null ? endpoint.getPort()
             : (V1McpBridge.PROTOCOL_HTTP.equals(endpoint.getProtocol()) ? DEFAULT_HTTP_PORT : DEFAULT_HTTPS_PORT);

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/ClaudeLlmProviderHandlerTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/ai/ClaudeLlmProviderHandlerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.sdk.service.ai;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.alibaba.higress.sdk.constant.plugin.config.AiProxyConfig;
+import com.alibaba.higress.sdk.model.ai.LlmProvider;
+
+/**
+ * Tests for {@link ClaudeLlmProviderHandler}, focused on rebuilding the Claude custom URL in
+ * {@link ClaudeLlmProviderHandler#loadConfig}. A URL entered without a trailing slash must not be rewritten with an
+ * extra "/" on every config reload, since {@link com.alibaba.higress.sdk.model.ai.LlmProviderEndpoint} defaults a
+ * missing context path to "/".
+ */
+public class ClaudeLlmProviderHandlerTest {
+
+    private static final String PROVIDER_NAME = "test-claude";
+    private static final String CUSTOM_URL_KEY = "claudeCustomUrl";
+
+    private ClaudeLlmProviderHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        handler = new ClaudeLlmProviderHandler();
+    }
+
+    @Test
+    @DisplayName("keeps a custom URL without a trailing slash unchanged instead of appending an extra '/'")
+    public void loadConfig_customUrlWithoutTrailingSlash_isNotRewrittenWithExtraSlash() {
+        LlmProvider provider = loadConfigWithCustomUrl("https://api.test.com");
+
+        Assertions.assertEquals("https://api.test.com", customUrlOf(provider));
+    }
+
+    @Test
+    @DisplayName("keeps the custom URL stable across repeated reloads so no slash accumulates")
+    public void loadConfig_customUrlWithoutTrailingSlash_isStableAcrossReloads() {
+        LlmProvider firstReload = loadConfigWithCustomUrl("https://api.test.com");
+        String afterFirstReload = customUrlOf(firstReload);
+        Assertions.assertEquals("https://api.test.com", afterFirstReload);
+
+        // Feeding the rebuilt URL back in emulates a subsequent config reload; it must not grow another slash.
+        LlmProvider secondReload = loadConfigWithCustomUrl(afterFirstReload);
+        Assertions.assertEquals(afterFirstReload, customUrlOf(secondReload));
+    }
+
+    @Test
+    @DisplayName("preserves a non-root context path on the custom URL")
+    public void loadConfig_customUrlWithContextPath_isPreserved() {
+        LlmProvider provider = loadConfigWithCustomUrl("https://api.test.com/custom/v1");
+
+        Assertions.assertEquals("https://api.test.com/custom/v1", customUrlOf(provider));
+    }
+
+    @Test
+    @DisplayName("collapses an all-slash context path so no trailing slash is left behind")
+    public void loadConfig_customUrlWithOnlySlashesPath_collapsesTrailingSlash() {
+        LlmProvider provider = loadConfigWithCustomUrl("https://api.test.com//");
+
+        Assertions.assertEquals("https://api.test.com", customUrlOf(provider));
+    }
+
+    @Test
+    @DisplayName("keeps a non-default port and still avoids appending an extra '/'")
+    public void loadConfig_customUrlWithCustomPort_preservesPortWithoutExtraSlash() {
+        LlmProvider provider = loadConfigWithCustomUrl("https://api.test.com:8443");
+
+        Assertions.assertEquals("https://api.test.com:8443", customUrlOf(provider));
+    }
+
+    @Test
+    @DisplayName("drops the custom URL when it points at the default Claude endpoint")
+    public void loadConfig_defaultEndpoint_removesCustomUrl() {
+        LlmProvider provider = loadConfigWithCustomUrl("https://api.anthropic.com/");
+
+        Assertions.assertFalse(provider.getRawConfigs().containsKey(CUSTOM_URL_KEY));
+    }
+
+    private LlmProvider loadConfigWithCustomUrl(String customUrl) {
+        Map<String, Object> configurations = new HashMap<>();
+        configurations.put(AiProxyConfig.PROVIDER_ID, PROVIDER_NAME);
+        configurations.put(CUSTOM_URL_KEY, customUrl);
+        LlmProvider provider = new LlmProvider();
+        Assertions.assertTrue(handler.loadConfig(provider, configurations));
+        return provider;
+    }
+
+    private static String customUrlOf(LlmProvider provider) {
+        return (String)provider.getRawConfigs().get(CUSTOM_URL_KEY);
+    }
+}


### PR DESCRIPTION
 ### Ⅰ. Describe what this PR did

  Fixes an issue where a Claude provider's custom URL entered without a trailing slash (e.g. `https://api.test.com`) gets an extra `/` appended every time the configuration is reloaded, ending up as `https://api.test.com/`.

  Root cause: in `ClaudeLlmProviderHandler.loadConfig`, the endpoint is reconstructed back into a URL. LlmProviderEndpoint#getServiceContextPath` defaults a blank path to `"/"` (via `StringUtils.firstNonEmpty(path, "/")`), so the reconstructed `claudeCustomUrl` always carries a root `/`.

  The fix omits the root path when rebuilding the URL. It uses `StringUtils.stripEnd(path, "/").isEmpty()` so that both a single `/` and all-slash paths like `//` collapse to empty.

  ### Ⅱ. Does this pull request fix one issue?

  fixes #

  ### Ⅲ. Why don't you add test cases (unit test/integration test)?

  The change is a small, self-contained normalization at the URL-rebuild step.

  ### Ⅳ. Describe how to verify it

  1. Create/edit a Claude LLM provider with a custom URL `https://api.test.com` (no trailing slash) and save.
  2. Reopen the provider config and confirm the custom URL stays `https://api.test.com` instead of becoming https://api.test.com/`.
  3. Confirm a non-root path such as `https://api.test.com/v1` is preserved unchanged.

  ### Ⅴ. Special notes for reviews

  - Single-file change: `backend/sdk/.../service/ai/ClaudeLlmProviderHandler.java` (5 lines added).
  - Non-root paths are untouched; only the redundant root `/` is dropped.
  - `mvnw compile` on the `sdk` module passes (exit 0).
