### PR TITLE
fix: pin fastjson to 1.2.83_noneautotype for autoType RCE protection

### DIFF
--- a/backend/console/src/test/java/com/alibaba/higress/console/security/FastjsonAutotypeGuardTest.java
+++ b/backend/console/src/test/java/com/alibaba/higress/console/security/FastjsonAutotypeGuardTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.higress.console.security;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for fastjson 1.2.83_noneautotype dependency pin.
+ *
+ * The 1.2.83_noneautotype build replaces {@code ParserConfig.checkAutoType}
+ * with a blanket throw — any class name passed via {@code @type} triggers
+ * a {@code JSONException} whose message contains "autoType". This test fails
+ * the build if the dependency is ever downgraded or replaced with a fastjson
+ * variant that re-enables autoType, which would re-introduce the historical
+ * RCE gadgets.
+ *
+ * <p><b>Probe class selection rationale:</b> {@code java.util.HashMap} and
+ * {@code java.util.LinkedHashMap} are handled by a HARDCODED branch in
+ * {@code DefaultJSONParser} (around line 327-330) that runs BEFORE
+ * {@code checkAutoType} in BOTH 1.2.83 and 1.2.83_noneautotype. Using
+ * HashMap/LinkedHashMap as the {@code @type} target would NOT discriminate
+ * between the two versions — both would silently instantiate via the
+ * hardcoded branch.
+ *
+ * <p>{@code java.util.Date} is a basic JDK class that is not in the hardcoded
+ * branch, not in fastjson's deny list, and has a no-arg constructor, so it
+ * exercises the {@code checkAutoType} path:
+ * <ul>
+ *   <li>1.2.83: {@code checkAutoType} allows Date → instance is created via
+ *       reflection → no exception (RED — test fails because no throw)</li>
+ *   <li>1.2.83_noneautotype: {@code checkAutoType} throws
+ *       {@code JSONException("safeMode not support autoType : java.util.Date")}
+ *       (GREEN — test passes because throw is expected)</li>
+ * </ul>
+ */
+class FastjsonAutotypeGuardTest {
+
+    @Test
+    void parseObject_withTypeField_throwsOnAutoType() {
+        String json = "{\"@type\":\"java.util.Date\",\"foo\":\"bar\"}";
+
+        // 1.2.83_noneautotype: throws JSONException("safeMode not support autoType : java.util.Date").
+        // 1.2.83: throws JSONException("syntax error, ...") — checkAutoType allows Date (basic JDK class,
+        //         not in the deny list), a Date instance is constructed via reflection, then setting the
+        //         unknown "foo" property fails and the parser surfaces a "syntax error". The discriminator
+        //         is the exception message: 1.2.83's message lacks "autoType", 1.2.83_noneautotype's
+        //         message contains "autoType".
+        JSONException ex = assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertTrue(
+            ex.getMessage() != null && ex.getMessage().toLowerCase().contains("autotype"),
+            "Expected error message to mention autoType, got: " + ex.getMessage()
+        );
+    }
+
+    @Test
+    void parseObjectWithClass_withTypeField_throwsOnAutoType() {
+        String json = "{\"@type\":\"java.util.Date\",\"foo\":\"bar\"}";
+
+        // Same discriminator as above: 1.2.83_noneautotype throws with "autoType" in the message,
+        // 1.2.83 throws "syntax error" (Date allowed, reflection succeeds, "foo" setter fails).
+        JSONException ex = assertThrows(JSONException.class, () -> JSON.parseObject(json, Object.class));
+        assertTrue(
+            ex.getMessage() != null && ex.getMessage().toLowerCase().contains("autotype"),
+            "Expected error message to mention autoType, got: " + ex.getMessage()
+        );
+    }
+}

--- a/backend/console/src/test/java/com/alibaba/higress/console/security/FastjsonAutotypeGuardTest.java
+++ b/backend/console/src/test/java/com/alibaba/higress/console/security/FastjsonAutotypeGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2026 Alibaba Group Holding Ltd.
+ * Copyright (c) 2022-2024 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -57,7 +57,7 @@
 		<guava.version>31.1-jre</guava.version>
 		<commons-lang3.version>3.13.0</commons-lang3.version>
 		<commons-collection4.version>4.4</commons-collection4.version>
-		<fastjson.version>1.2.83</fastjson.version>
+		<fastjson.version>1.2.83_noneautotype</fastjson.version>
 		<!-- https://github.com/kubernetes-client/java/wiki/2.-Versioning-and-Compatibility -->
 		<k8s-client.version>17.0.0</k8s-client.version>
 		<bouncycastle.version>1.46</bouncycastle.version>


### PR DESCRIPTION
## Summary

Pin `com.alibaba:fastjson` from `1.2.83` to `1.2.83_noneautotype`, removing the `@type` / autoType deserialization code path at the bytecode level to eliminate the historical fastjson RCE gadget chains.

## Changes

- `backend/pom.xml:60` — bump `<fastjson.version>` from `1.2.83` to `1.2.83_noneautotype`
- `backend/console/src/test/java/com/alibaba/higress/console/security/FastjsonAutotypeGuardTest.java` — new regression guard test (85 lines)

## Why `1.2.83_noneautotype`

`1.2.83_noneautotype` is an Alibaba-published variant of `1.2.83` available on Maven Central (group `com.alibaba`, Apache 2.0). It replaces `ParserConfig.checkAutoType` with a blanket `throw new JSONException("safeMode not support autoType : " + typeName)`, which is more thorough than configuring `ParserConfig.safeMode = true` at runtime — even code that explicitly opts in has no path to bypass it.

Public API classes (`com.alibaba.fastjson.JSON`, `JSONObject`, `JSONArray`) entry points are identical to `1.2.83`; the serialization path (`toJSONString`) is unaffected. **No** existing DAO / Service call sites are touched.

## Probe class selection for the guard test

`java.util.HashMap` and `java.util.LinkedHashMap` cannot be used as the `@type` probe because they are handled by a hardcoded branch in `DefaultJSONParser` (around line 327-330) that runs **before** `checkAutoType` in both `1.2.83` and `1.2.83_noneautotype` — the hardcoded branch is not modified by the `_noneautotype` build.

`java.util.Date` is used instead: it is a basic JDK class that is not in the hardcoded branch, not in fastjson's deny list, and has a no-arg constructor, so it exercises the `checkAutoType` path. The discriminator between the two versions is the exception message:

| fastjson version | Exception thrown | Message |
|---|---|---|
| `1.2.83` | `JSONException` | `"syntax error, ..."` (checkAutoType allows Date, instance is constructed, setting unknown `foo` property fails) |
| `1.2.83_noneautotype` | `JSONException` | `"safeMode not support autoType : java.util.Date"` |

The test asserts both the throw and that the message contains `"autoType"`.

## Test Plan

- [x] `./mvnw -pl console -am test -Dmaven.gitcommitid.skip=true` — console 2/2 pass (new guard test)
- [x] `./mvnw -pl sdk -am test -Dmaven.gitcommitid.skip=true` — sdk 252/252 pass (no regressions)
- [x] Working tree clean; single commit (squash complete)

## Risk

- Business regression risk: `grep -r "@type" backend/console/src/` shows no business code using `@type` for deserialization, so the upgrade is transparent to existing functionality.
- Serialization path is unaffected.
- Rollback: a single `git revert` of the commit.
