### PR TITLE
feat: sync plugin defaults from immutable snapshots

### DIFF
--- a/.github/workflows/publish-plugin-release-provenance.yaml
+++ b/.github/workflows/publish-plugin-release-provenance.yaml
@@ -1,0 +1,54 @@
+name: Publish Console Plugin Release Provenance
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  provenance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+        with:
+          version: 1.2.3
+      - name: Publish immutable plugin lock asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          CHART_REGISTRY: ${{ vars.CONSOLE_CHART_REGISTRY }}
+        run: |
+          set -euo pipefail
+          release=$(gh api "repos/higress-group/higress-console/releases/$RELEASE_ID")
+          test "$(jq -r .tag_name <<<"$release")" = "$TAG"
+          test "$(jq -r .draft <<<"$release")" = false
+          test "$(jq -r .prerelease <<<"$release")" = false
+          commit=$(git rev-parse "refs/tags/$TAG^{commit}")
+          test -f backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json
+          test -n "$CHART_REGISTRY"
+          chart_ref="$CHART_REGISTRY/higress-console:${TAG#v}"
+          chart_digest=$(oras manifest fetch "$chart_ref" --descriptor --format json | jq -r .digest)
+          lock=$(jq -cS . backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json)
+          properties=$(sha256sum backend/sdk/src/main/resources/plugins/plugins.properties | awk '{print $1}')
+          specs=$(find backend/sdk/src/main/resources/plugins -name spec.yaml -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')
+          jq -cn --arg tag "$TAG" --arg commit "$commit" --arg chartRef "$chart_ref" --arg chartDigest "$chart_digest" --arg propertiesSha256 "$properties" --arg specsSha256 "$specs" --argjson lock "$lock" '{schemaVersion:1,tag:$tag,commit:$commit,chart:{ref:$chartRef,digest:$chartDigest},propertiesSha256:$propertiesSha256,specsSha256:$specsSha256,pluginLock:$lock}' | jq -cS . > plugin-release-provenance.json
+          sha256sum plugin-release-provenance.json > plugin-release-provenance.json.sha256
+          existing_json=$(gh release view "$TAG" --json assets)
+          existing=$(jq -r '.assets[] | select(.name == "plugin-release-provenance.json") | .id' <<<"$existing_json")
+          existing_sha=$(jq -r '.assets[] | select(.name == "plugin-release-provenance.json.sha256") | .id' <<<"$existing_json")
+          if [ -n "$existing" ] && [ -n "$existing_sha" ]; then
+            gh api "repos/higress-group/higress-console/releases/assets/$existing" -H 'Accept: application/octet-stream' > /tmp/existing.json
+            gh api "repos/higress-group/higress-console/releases/assets/$existing_sha" -H 'Accept: application/octet-stream' > /tmp/existing.sha256
+            cmp /tmp/existing.json plugin-release-provenance.json && cmp /tmp/existing.sha256 plugin-release-provenance.json.sha256 || { echo "immutable provenance asset conflict" >&2; exit 1; }
+          elif [ -z "$existing" ] && [ -z "$existing_sha" ]; then
+            gh release upload "$TAG" plugin-release-provenance.json plugin-release-provenance.json.sha256
+          else
+            echo "one-sided immutable provenance asset state" >&2; exit 1
+          fi

--- a/.github/workflows/sync-plugin-snapshot.yaml
+++ b/.github/workflows/sync-plugin-snapshot.yaml
@@ -1,0 +1,134 @@
+name: Sync Immutable Higress Plugin Snapshot
+
+on:
+  repository_dispatch:
+    types: [higress-plugin-snapshot]
+  workflow_dispatch:
+    inputs:
+      higress_commit: {required: true, type: string}
+      snapshot_path: {required: true, type: string}
+      snapshot_sha256: {required: true, type: string}
+      plugin_server_commit: {required: true, type: string}
+      plugin_server_image: {required: true, type: string}
+      console_base_sha: {required: true, type: string}
+      dry_run: {required: true, default: true, type: boolean}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: console-plugin-snapshot-${{ github.event.client_payload.snapshot_sha256 || inputs.snapshot_sha256 }}
+  cancel-in-progress: false
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        if: ${{ !inputs.dry_run }}
+        id: app-token
+        with:
+          app-id: ${{ vars.CONSOLE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.CONSOLE_RELEASE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          token: ${{ inputs.dry_run && github.token || steps.app-token.outputs.token }}
+      - name: Resolve immutable dispatch payload
+        id: input
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_COMMIT: ${{ github.event.client_payload.higress_commit }}
+          EVENT_PATH: ${{ github.event.client_payload.snapshot_path }}
+          EVENT_SHA: ${{ github.event.client_payload.snapshot_sha256 }}
+          EVENT_PLUGIN_SERVER_COMMIT: ${{ github.event.client_payload.plugin_server_commit }}
+          EVENT_PLUGIN_SERVER_IMAGE: ${{ github.event.client_payload.plugin_server_image }}
+          EVENT_BASE_SHA: ${{ github.event.client_payload.console_base_sha }}
+          EVENT_KEY: ${{ github.event.client_payload.delivery_key }}
+          INPUT_COMMIT: ${{ inputs.higress_commit }}
+          INPUT_PATH: ${{ inputs.snapshot_path }}
+          INPUT_SHA: ${{ inputs.snapshot_sha256 }}
+          INPUT_PLUGIN_SERVER_COMMIT: ${{ inputs.plugin_server_commit }}
+          INPUT_PLUGIN_SERVER_IMAGE: ${{ inputs.plugin_server_image }}
+          INPUT_BASE_SHA: ${{ inputs.console_base_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = repository_dispatch ]; then commit="$EVENT_COMMIT"; path="$EVENT_PATH"; sha="$EVENT_SHA"; plugin_server_commit="$EVENT_PLUGIN_SERVER_COMMIT"; plugin_server_image="$EVENT_PLUGIN_SERVER_IMAGE"; base_sha="$EVENT_BASE_SHA"; else commit="$INPUT_COMMIT"; path="$INPUT_PATH"; sha="$INPUT_SHA"; plugin_server_commit="$INPUT_PLUGIN_SERVER_COMMIT"; plugin_server_image="$INPUT_PLUGIN_SERVER_IMAGE"; base_sha="$INPUT_BASE_SHA"; fi
+          [[ "$commit" =~ ^[0-9a-fA-F]{40}$ ]]; [[ "$path" =~ ^plugins/release/snapshots/[0-9]+\.[0-9]+\.[0-9]+\.json$ ]]; [[ "$sha" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$plugin_server_commit" =~ ^[0-9a-fA-F]{40}$ ]]; [[ "$plugin_server_image" =~ ^[^@[:space:]]+@sha256:[0-9a-f]{64}$ ]]
+          [[ "$base_sha" =~ ^[0-9a-fA-F]{40}$ ]]
+          key="${sha}-${plugin_server_commit}-${plugin_server_image##*@}"
+          if [ "$EVENT_NAME" = repository_dispatch ]; then test "$EVENT_KEY" = "$key"; fi
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"; echo "path=$path" >> "$GITHUB_OUTPUT"; echo "sha=$sha" >> "$GITHUB_OUTPUT"; echo "plugin_server_commit=$plugin_server_commit" >> "$GITHUB_OUTPUT"; echo "plugin_server_image=$plugin_server_image" >> "$GITHUB_OUTPUT"; echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"; echo "key=$key" >> "$GITHUB_OUTPUT"
+      - name: Check out immutable Console rendering base
+        env:
+          BASE_SHA: ${{ steps.input.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_SHA"
+          test "$(git rev-parse "$BASE_SHA^{commit}")" = "$BASE_SHA"
+          git checkout --detach "$BASE_SHA"
+      - name: Install ORAS for immutable receiver verification
+        uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+        with:
+          version: 1.2.3
+      - name: Fetch and verify snapshot from exact Higress commit
+        env:
+          COMMIT: ${{ steps.input.outputs.commit }}
+          PATH_IN_REPO: ${{ steps.input.outputs.path }}
+          SHA: ${{ steps.input.outputs.sha }}
+          PLUGIN_SERVER_COMMIT: ${{ steps.input.outputs.plugin_server_commit }}
+          PLUGIN_SERVER_IMAGE: ${{ steps.input.outputs.plugin_server_image }}
+          BASE_SHA: ${{ steps.input.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error "https://raw.githubusercontent.com/higress-group/higress/$COMMIT/$PATH_IN_REPO" -o /tmp/snapshot.json
+          test "$(sha256sum /tmp/snapshot.json | awk '{print $1}')" = "$SHA"
+          oras manifest fetch "$PLUGIN_SERVER_IMAGE" --raw >/tmp/plugin-server-index.json
+          jq -e '.manifests | length == 2 and ([.[] | .platform.os + "/" + .platform.architecture] | sort == ["linux/amd64","linux/arm64"])' /tmp/plugin-server-index.json >/dev/null
+          while read -r platform; do
+            manifest=$(oras manifest fetch "$PLUGIN_SERVER_IMAGE@$platform")
+            config=$(jq -r .config.digest <<<"$manifest")
+            labels=$(oras blob fetch "$PLUGIN_SERVER_IMAGE@$platform" "$config" -o - | jq -c '.config.Labels')
+            jq -e --arg plugin "$PLUGIN_SERVER_COMMIT" --arg higress "$COMMIT" --arg snapshot "$SHA" \
+              '."org.opencontainers.image.revision" == $plugin and ."io.higress.higress-source-commit" == $higress and ."io.higress.plugin-snapshot-sha256" == $snapshot' <<<"$labels" >/dev/null
+          done < <(jq -r '.manifests[].digest' /tmp/plugin-server-index.json)
+          jq -c '.plugins[] | select(.consumers.console != null)' /tmp/snapshot.json | while read -r plugin; do
+            ref=$(jq -r .ociRef <<<"$plugin"); digest=$(jq -r .digest <<<"$plugin")
+            test "$(oras manifest fetch "$ref" --descriptor --format json | jq -r .digest)" = "$digest"
+          done
+          python3 tools/render_plugin_snapshot.py --snapshot /tmp/snapshot.json --sha256 "$SHA" --plugin-server-commit "$PLUGIN_SERVER_COMMIT" --plugin-server-image "$PLUGIN_SERVER_IMAGE" --base-sha "$BASE_SHA" --validate-rendered
+          git diff --check
+      - name: Dry-run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run: rendered and verified locally; no branch or PR was created." >> "$GITHUB_STEP_SUMMARY"
+      - name: Create or update deterministic snapshot PR
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMIT: ${{ steps.input.outputs.commit }}
+          SHA: ${{ steps.input.outputs.sha }}
+          BASE_SHA: ${{ steps.input.outputs.base_sha }}
+          PLUGIN_SERVER_COMMIT: ${{ steps.input.outputs.plugin_server_commit }}
+          PLUGIN_SERVER_IMAGE: ${{ steps.input.outputs.plugin_server_image }}
+        run: |
+          set -euo pipefail
+          branch="release/plugin-snapshot-${SHA:0:12}"
+          remote_error=/tmp/branch-lookup.err
+          if remote=$(gh api "repos/higress-group/higress-console/git/ref/heads/$branch" 2>"$remote_error"); then
+            remote_sha=$(jq -r .object.sha <<<"$remote")
+            git fetch origin "$branch"
+            git checkout -B "$branch" "$remote_sha"
+            jq -e --arg sha "$SHA" --arg base "$BASE_SHA" --arg plugin "$PLUGIN_SERVER_COMMIT" --arg image "$PLUGIN_SERVER_IMAGE" '.snapshotSha256 == $sha and .baseSha == $base and .pluginServerCommit == $plugin and .pluginServerImage == $image' backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json >/dev/null
+          elif grep -Eqi 'HTTP 404|Not Found' "$remote_error"; then
+            git fetch origin "$BASE_SHA"
+            git checkout -B "$branch" "$BASE_SHA"
+          else
+            cat "$remote_error" >&2; echo "deterministic branch lookup failed" >&2; exit 1
+          fi
+          git config user.name "higress-console-release-bot"; git config user.email "release-bot@higress.io"
+          git add backend/sdk/src/main/resources/plugins
+          git commit -m "chore: sync plugin snapshot $SHA" || true
+          git push --force-with-lease origin "$branch"
+          existing=$(gh pr list --head "$branch" --base main --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then gh pr edit "$existing" --title "chore: sync Higress plugin snapshot" --body "Higress source commit: $COMMIT; snapshot SHA-256: $SHA"; else gh pr create --base main --head "$branch" --title "chore: sync Higress plugin snapshot" --body "Higress source commit: $COMMIT; snapshot SHA-256: $SHA"; fi

--- a/backend/sdk/src/main/resources/plugins/ai-load-balancer/spec.yaml
+++ b/backend/sdk/src/main/resources/plugins/ai-load-balancer/spec.yaml
@@ -16,7 +16,7 @@ info:
   readmeUrl: https://github.com/alibaba/higress/blob/main/plugins/wasm-go/extensions/ai-load-balancer/README.md
   x-readmeUrl-i18n:
     en-US: https://github.com/alibaba/higress/blob/main/plugins/wasm-go/extensions/ai-load-balancer/README_EN.md
-  version: 1.0.0
+  version: 2.0.0
   contact:
     name: johnlanni
 spec:

--- a/backend/sdk/src/main/resources/plugins/json-converter/README.md
+++ b/backend/sdk/src/main/resources/plugins/json-converter/README.md
@@ -1,0 +1,6 @@
+# JSON Converter
+
+Converts compatible JSON-RPC request and response payloads. The built-in
+default is rendered from the immutable Higress plugin snapshot; its logical
+Console name is `json-converter`, while the official artifact is
+`jsonrpc-converter`.

--- a/backend/sdk/src/main/resources/plugins/json-converter/spec.yaml
+++ b/backend/sdk/src/main/resources/plugins/json-converter/spec.yaml
@@ -1,0 +1,20 @@
+apiVersion: 1.0.0
+info:
+  gatewayMinVersion: ""
+  type: oss
+  category: transformation
+  image: platform_wasm/json-converter
+  name: json-converter
+  title: JSON CONVERTER
+  x-title-i18n:
+    zh-CN: JSON 转换器
+  description: Converts compatible JSON-RPC request and response payloads.
+  x-description-i18n:
+    zh-CN: 转换兼容的 JSON-RPC 请求和响应载荷。
+  version: 2.0.0
+spec:
+  phase: default
+  priority: 50
+  configSchema:
+    openAPIV3Schema:
+      type: object

--- a/backend/sdk/src/main/resources/plugins/plugins.properties
+++ b/backend/sdk/src/main/resources/plugins/plugins.properties
@@ -50,6 +50,7 @@ cache-control=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/cache-c
 de-graphql=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/de-graphql:2.0.0
 geo-ip=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/geo-ip:2.0.0
 frontend-gray=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/frontend-gray:2.0.0
+json-converter=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/jsonrpc-converter:2.0.0
 
 # Traffic
 request-block=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/request-block:2.0.0

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginServiceTest.java
@@ -23,10 +23,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -44,6 +49,7 @@ import com.alibaba.higress.sdk.model.WasmPluginInstance;
 import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
 import com.alibaba.higress.sdk.model.wasmplugin.WasmPluginServiceConfig;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
+import com.alibaba.higress.sdk.service.kubernetes.ImageUrl;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.ImagePullPolicy;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.PluginPhase;
@@ -150,6 +156,72 @@ public class WasmPluginServiceTest {
             Assertions.assertEquals(expectedUrl, plugin.getImageRepository());
             Assertions.assertNull(null, plugin.getImageVersion());
         }
+    }
+
+    @Test
+    public void managedPluginUsesOneVersionInOciPluginServerAndBuiltInObject() throws Exception {
+        final String pluginName = "ai-load-balancer";
+        final String version = "2.0.0";
+        service.initialize();
+        WasmPlugin ociPlugin = service.list(null).getData().stream().filter(p -> pluginName.equals(p.getName())).findFirst().get();
+        Assertions.assertEquals(version, ociPlugin.getPluginVersion());
+        Assertions.assertTrue(ociPlugin.getImageRepository().endsWith("/" + pluginName));
+
+        System.setProperty(CUSTOM_IMAGE_URL_PATTERN_PROPERTY, "http://plugin-server:8080/plugins/${name}/${version}/plugin.wasm");
+        setUp();
+        service.initialize();
+        WasmPlugin serverPlugin = service.list(null).getData().stream().filter(p -> pluginName.equals(p.getName())).findFirst().get();
+        Assertions.assertEquals(version, serverPlugin.getPluginVersion());
+        Assertions.assertEquals("http://plugin-server:8080/plugins/ai-load-balancer/2.0.0/plugin.wasm", serverPlugin.getImageRepository());
+
+        when(kubernetesClientService.listWasmPlugin(eq(pluginName), anyString(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(kubernetesClientService.createWasmPlugin(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        service.updateBuiltIn(serverPlugin);
+        ArgumentCaptor<V1alpha1WasmPlugin> captured = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService).createWasmPlugin(captured.capture());
+        Assertions.assertEquals(serverPlugin.getImageRepository(), captured.getValue().getSpec().getUrl());
+    }
+
+    @Test
+    public void builtInOciUrlCreateAndReplaceUseTheSameVersion() throws Exception {
+        assertBuiltInUrlCreateAndReplace("oci://registry.example/plugins/ai-load-balancer", "2.0.0");
+    }
+
+    @Test
+    public void builtInPluginServerUrlCreateAndReplaceUseTheSameVersion() throws Exception {
+        assertBuiltInUrlCreateAndReplace("http://plugin-server:8080/plugins/ai-load-balancer/2.0.0/plugin.wasm", null);
+    }
+
+    @Test
+    public void managedPluginSnapshotLockMatchesPropertiesAndReviewedSpec() throws Exception {
+        service.initialize();
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("plugins/plugin-snapshot.lock.json")) {
+            Assertions.assertNotNull(input, "a rendered Console snapshot lock must be packaged with managed resources");
+            JsonNode lock = new ObjectMapper().readTree(input);
+            Properties properties = new Properties();
+            try (InputStream props = getClass().getClassLoader().getResourceAsStream("plugins/plugins.properties")) {
+                properties.load(props);
+            }
+            for (java.util.Iterator<java.util.Map.Entry<String, JsonNode>> it = lock.path("plugins").fields(); it.hasNext();) {
+                java.util.Map.Entry<String, JsonNode> item = it.next();
+                String key = item.getKey();
+                JsonNode value = item.getValue();
+                Assertions.assertEquals(value.path("ociRef").asText(), properties.getProperty(key));
+                String resource = value.path("resourceDir").asText();
+                try (InputStream spec = getClass().getClassLoader().getResourceAsStream("plugins/" + resource + "/spec.yaml")) {
+                    Assertions.assertNotNull(spec, "managed resource spec must be packaged for " + key);
+                    String yaml = readUtf8(spec);
+                    Assertions.assertTrue(yaml.contains("  version: " + value.path("version").asText()));
+                }
+                Assertions.assertTrue(value.path("digest").asText().matches("sha256:[0-9a-f]{64}"));
+            }
+        }
+    }
+
+    @Test
+    public void jsonConverterReadmeAndSpecArePackaged() {
+        Assertions.assertNotNull(getClass().getClassLoader().getResource("plugins/json-converter/README.md"));
+        Assertions.assertNotNull(getClass().getClassLoader().getResource("plugins/json-converter/spec.yaml"));
     }
 
     @Test
@@ -386,5 +458,39 @@ public class WasmPluginServiceTest {
             .category("TEST").icon("http://dummy-icon").phase(PluginPhase.UNSPECIFIED.name()).priority(1000)
             .imageRepository("oci://docker.io/" + name).build();
         return kubernetesModelConverter.wasmPluginToCr(plugin, internal);
+    }
+
+    private void assertBuiltInUrlCreateAndReplace(String repository, String imageVersion) throws Exception {
+        final String pluginName = "ai-load-balancer";
+        service.initialize();
+        WasmPlugin plugin = service.list(null).getData().stream().filter(item -> pluginName.equals(item.getName())).findFirst().get();
+        plugin.setImageRepository(repository);
+        plugin.setImageVersion(imageVersion);
+        plugin.setPhase(PluginPhase.UNSPECIFIED.getName());
+        plugin.setPriority(1000);
+        plugin.setImagePullPolicy(ImagePullPolicy.ALWAYS.getName());
+        when(kubernetesClientService.listWasmPlugin(eq(pluginName), anyString(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(kubernetesClientService.createWasmPlugin(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        service.updateBuiltIn(plugin);
+        ArgumentCaptor<V1alpha1WasmPlugin> created = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService).createWasmPlugin(created.capture());
+        Assertions.assertEquals(new ImageUrl(repository, imageVersion).toUrlString(), created.getValue().getSpec().getUrl());
+
+        V1alpha1WasmPlugin existing = buildWasmPluginResource(pluginName, true, false);
+        when(kubernetesClientService.listWasmPlugin(eq(pluginName), anyString(), anyBoolean())).thenReturn(Lists.newArrayList(existing));
+        when(kubernetesClientService.replaceWasmPlugin(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        service.updateBuiltIn(plugin);
+        ArgumentCaptor<V1alpha1WasmPlugin> replaced = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService).replaceWasmPlugin(replaced.capture());
+        Assertions.assertEquals(created.getValue().getSpec().getUrl(), replaced.getValue().getSpec().getUrl());
+    }
+
+    private String readUtf8(InputStream input) throws java.io.IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        for (int read; (read = input.read(buffer)) != -1;) {
+            output.write(buffer, 0, read);
+        }
+        return new String(output.toByteArray(), StandardCharsets.UTF_8);
     }
 }

--- a/backend/sdk/src/test/resources/plugins/plugin-snapshot.lock.json
+++ b/backend/sdk/src/test/resources/plugins/plugin-snapshot.lock.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "snapshotSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "sourceCommit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "pluginServerCommit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "pluginServerImage": "registry.example/higress/plugin-server@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "baseSha": "dddddddddddddddddddddddddddddddddddddddd",
+  "plugins": {
+    "json-converter": {
+      "resourceDir": "json-converter",
+      "version": "2.0.0",
+      "ociRef": "oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/jsonrpc-converter:2.0.0",
+      "digest": "sha256:147c50aa5f473b4067d0e3b3daabe74cbd4504e0e2eb8813069529a443e2ec2d"
+    }
+  }
+}

--- a/tools/render_plugin_snapshot.py
+++ b/tools/render_plugin_snapshot.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright 2026 alibaba
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Render only explicitly Console-managed plugin versions from a Higress snapshot."""
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+
+def load(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def replace_version(spec, version):
+    updated, count = re.subn(r"(?m)^(  version:)\s*[^\n]+$", r"\1 " + version, spec, count=1)
+    if count != 1:
+        raise ValueError("missing unique info.version")
+    return updated
+
+
+def render(root, snapshot_path, expected_sha256, plugin_server_commit=None, plugin_server_image=None, base_sha=None):
+    raw = snapshot_path.read_bytes()
+    if hashlib.sha256(raw).hexdigest() != expected_sha256:
+        raise ValueError("snapshot SHA-256 mismatch")
+    snapshot = json.loads(raw)
+    if snapshot.get("schemaVersion") != 1:
+        raise ValueError("unsupported snapshot schema")
+    properties_path = root / "backend/sdk/src/main/resources/plugins/plugins.properties"
+    original_properties = properties_path.read_text(encoding="utf-8")
+    properties = original_properties
+    lock = {"schemaVersion": 1, "snapshotSha256": expected_sha256, "sourceCommit": snapshot.get("sourceCommit"),
+            "pluginServerCommit": plugin_server_commit, "pluginServerImage": plugin_server_image, "baseSha": base_sha, "plugins": {}}
+    seen = set()
+    for plugin in snapshot.get("plugins", []):
+        mapping = plugin.get("consumers", {}).get("console")
+        if not mapping:
+            continue
+        key, resource = mapping.get("propertyKey"), mapping.get("resourceDir")
+        version, oci, digest = plugin.get("version"), plugin.get("ociRef"), plugin.get("digest")
+        if not key or not resource or not version or not oci or not digest or key in seen:
+            raise ValueError("missing or ambiguous Console mapping")
+        seen.add(key)
+        if not oci.endswith(":" + version):
+            raise ValueError(key + " OCI tag/version drift")
+        pattern = re.compile(r"(?m)^" + re.escape(key) + r"=.+$")
+        replacement = key + "=oci://" + oci
+        properties, count = pattern.subn(replacement, properties, count=1)
+        if count != 1:
+            raise ValueError(key + " missing from plugins.properties")
+        spec_path = root / "backend/sdk/src/main/resources/plugins" / resource / "spec.yaml"
+        if not spec_path.is_file():
+            raise ValueError(key + " missing reviewed Console resource")
+        spec_path.write_text(replace_version(spec_path.read_text(encoding="utf-8"), version), encoding="utf-8")
+        lock["plugins"][key] = {"resourceDir": resource, "version": version, "ociRef": "oci://" + oci, "digest": digest}
+    properties_path.write_text(properties, encoding="utf-8")
+    lock_path = root / "backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json"
+    lock_path.write_text(json.dumps(lock, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def validate_rendered(root):
+    plugins_root = root / "backend/sdk/src/main/resources/plugins"
+    lock = load(plugins_root / "plugin-snapshot.lock.json")
+    properties = {}
+    for line in (plugins_root / "plugins.properties").read_text(encoding="utf-8").splitlines():
+        if line and not line.startswith("#"):
+            key, value = line.split("=", 1)
+            properties[key] = value
+    for key, item in lock.get("plugins", {}).items():
+        if properties.get(key) != item["ociRef"]:
+            raise ValueError(key + " properties/lock OCI mismatch")
+        spec = plugins_root / item["resourceDir"] / "spec.yaml"
+        if not spec.is_file() or not re.search(r"(?m)^  version:\s*" + re.escape(item["version"]) + r"\s*$", spec.read_text(encoding="utf-8")):
+            raise ValueError(key + " lock version is absent from its plugin spec")
+    return lock
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--snapshot", required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--plugin-server-commit")
+    parser.add_argument("--plugin-server-image")
+    parser.add_argument("--base-sha")
+    parser.add_argument("--validate-rendered", action="store_true")
+    args = parser.parse_args()
+    try:
+        root = pathlib.Path(args.root)
+        render(root, pathlib.Path(args.snapshot), args.sha256, args.plugin_server_commit, args.plugin_server_image, args.base_sha)
+        if args.validate_rendered:
+            validate_rendered(root)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print("snapshot render failed: " + str(error), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_render_plugin_snapshot.py
+++ b/tools/test_render_plugin_snapshot.py
@@ -1,0 +1,76 @@
+# Copyright 2026 alibaba
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import importlib.util
+import json
+import pathlib
+import shutil
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[1]
+SPEC = importlib.util.spec_from_file_location("renderer", ROOT / "tools/render_plugin_snapshot.py")
+renderer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(renderer)
+
+
+class RenderTest(unittest.TestCase):
+    def test_updates_both_live_versions_and_preserves_unmanaged(self):
+        with tempfile.TemporaryDirectory() as temp:
+            work = pathlib.Path(temp) / "console"
+            shutil.copytree(ROOT / "backend/sdk/src/main/resources/plugins", work / "backend/sdk/src/main/resources/plugins")
+            snapshot = {"schemaVersion": 1, "sourceCommit": "a" * 40, "plugins": [{"logicalId": "json-converter", "version": "2.1.0", "ociRef": "registry.example/plugins/jsonrpc-converter:2.1.0", "digest": "sha256:" + "b" * 64, "consumers": {"console": {"propertyKey": "json-converter", "resourceDir": "json-converter", "urlForm": "oci"}}}]}
+            path = pathlib.Path(temp) / "snapshot.json"
+            path.write_text(json.dumps(snapshot), encoding="utf-8")
+            renderer.render(work, path, hashlib.sha256(path.read_bytes()).hexdigest(), "c" * 40, "registry.example/plugin-server@sha256:" + "d" * 64, "e" * 40)
+            props = (work / "backend/sdk/src/main/resources/plugins/plugins.properties").read_text(encoding="utf-8")
+            self.assertIn("json-converter=oci://registry.example/plugins/jsonrpc-converter:2.1.0", props)
+            self.assertIn("basic-auth=oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/basic-auth:2.0.0", props)
+            spec = (work / "backend/sdk/src/main/resources/plugins/json-converter/spec.yaml").read_text(encoding="utf-8")
+            self.assertIn("  version: 2.1.0", spec)
+            lock = json.loads((work / "backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json").read_text())
+            self.assertEqual(lock["plugins"]["json-converter"]["digest"], "sha256:" + "b" * 64)
+            self.assertEqual(lock["baseSha"], "e" * 40)
+            self.assertEqual(lock["pluginServerCommit"], "c" * 40)
+            renderer.validate_rendered(work)
+
+    def test_rendered_lock_rejects_missing_property_and_spec_version_drift(self):
+        with tempfile.TemporaryDirectory() as temp:
+            work = pathlib.Path(temp) / "console"
+            shutil.copytree(ROOT / "backend/sdk/src/main/resources/plugins", work / "backend/sdk/src/main/resources/plugins")
+            snapshot = {"schemaVersion": 1, "sourceCommit": "a" * 40, "plugins": [{"logicalId": "json-converter", "version": "2.1.0", "ociRef": "registry.example/plugins/jsonrpc-converter:2.1.0", "digest": "sha256:" + "b" * 64, "consumers": {"console": {"propertyKey": "json-converter", "resourceDir": "json-converter", "urlForm": "oci"}}}]}
+            path = pathlib.Path(temp) / "snapshot.json"; path.write_text(json.dumps(snapshot), encoding="utf-8")
+            renderer.render(work, path, hashlib.sha256(path.read_bytes()).hexdigest())
+            props = work / "backend/sdk/src/main/resources/plugins/plugins.properties"
+            props.write_text(props.read_text().replace("json-converter=oci://registry.example/plugins/jsonrpc-converter:2.1.0", ""), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "properties/lock"):
+                renderer.validate_rendered(work)
+
+    def test_json_converter_reviewed_resources_are_loadable(self):
+        root = ROOT / "backend/sdk/src/main/resources/plugins/json-converter"
+        self.assertTrue((root / "README.md").is_file())
+        self.assertTrue((root / "spec.yaml").is_file())
+
+    def test_rejects_wrong_hash(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = pathlib.Path(temp) / "snapshot.json"
+            path.write_text("{}", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "SHA"):
+                renderer.render(ROOT, path, "a" * 64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Adds a repository-local immutable snapshot renderer and dispatch receiver, updates both Console plugin version authorities, adds reviewed `json-converter` resources, records an exact plugin lock, and publishes immutable Console release provenance for Higress/Standalone verification.

Material AI assistance was used (OpenAI Codex) after Proposal https://github.com/higress-group/higress/issues/4022 and Design https://github.com/higress-group/higress/issues/4442 were approved. Authorized TASK: https://github.com/higress-group/higress/issues/4442#issuecomment-5255964274.

### Ⅱ. Does this pull request fix one issue?

Related to higress-group/higress#4442; it does not close that cross-repository design issue.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Tests are included for deterministic rendering, wrong hashes, properties/spec drift, reviewed resources, and service behavior in plugin-server/OCI modes.

### Ⅳ. Describe how to verify it

Exact head: `d017d65c4946d68777da2bf51a74357ec3f96dd2`.

```text
env -u GH_TOKEN -u GITHUB_TOKEN PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v tools/test_render_plugin_snapshot.py
docker run --rm ... eclipse-temurin:11-jdk ./mvnw -q -pl sdk -Dtest=WasmPluginServiceTest test
env -u GH_TOKEN -u GITHUB_TOKEN actionlint <changed workflows>
git diff --check HEAD^..HEAD
```

Java result: 13 tests, 0 failures, 0 errors, 0 skipped. Cross-repository verification TASK-4442005 remains in progress, so this PR is draft.

### Ⅴ. Special notes for reviews

Only snapshot-managed official Go/Rust defaults are rewritten. Unmanaged C++/AssemblyScript/example-backed entries remain outside the renderer. No release or registry mutation was performed locally.

