### PR TITLE
feat: publish Console chart to OCI

### DIFF
--- a/.github/workflows/deploy-to-oss.yaml
+++ b/.github/workflows/deploy-to-oss.yaml
@@ -4,19 +4,83 @@ on:
   push:
     tags:
     - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Console chart version to package and validate without publishing"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: console-chart-publish-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  deploy-to-oss:
+  validate-chart:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    env:
+      CONSOLE_CHART_REGISTRY: ${{ vars.CONSOLE_CHART_REGISTRY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize dry-run Helm chart index
+        run: |
+          set -euo pipefail
+          mkdir -p ./artifact
+          printf 'apiVersion: v1\nentries: {}\n' > ./artifact/index.yaml
+
+      - id: calc-version
+        name: Calculate Version Number
+        run: |
+          set -euo pipefail
+          version='${{ inputs.version }}'
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "Version=$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.14.4
+
+      - name: Build Artifact
+        env:
+          VERSION: ${{ steps.calc-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          helm package helm --debug --app-version "$VERSION" --version "$VERSION" -d ./artifact
+          helm repo index --url https://higress.io/helm-charts/ --merge ./artifact/index.yaml ./artifact
+          cp ./artifact/index.yaml ./artifact/cn-index.yaml
+          sed -i 's/higress\.io/higress\.cn/g' ./artifact/cn-index.yaml
+
+      - name: Validate packaged Helm chart without publishing
+        env:
+          VERSION: ${{ steps.calc-version.outputs.version }}
+          CHART_PACKAGE: ./artifact/higress-console-${{ steps.calc-version.outputs.version }}.tgz
+          DRY_RUN: true
+        run: tools/publish_console_chart.sh
+
+  deploy-to-oss:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    # The registry credentials are scoped to this protected environment.
+    environment: console-chart-production
     env:
       OSS_ENDPOINT: ${{ vars.OSS_ENDPOINT || 'oss-cn-hongkong.aliyuncs.com' }}
       OSS_REGION: ${{ vars.OSS_REGION || 'cn-hongkong' }}
       OSS_BUCKET: ${{ vars.OSS_BUCKET || 'higress-ai' }}
       OSS_HELM_CHART_PATH: ${{ vars.OSS_HELM_CHART_PATH || '/helm-charts' }}
       OSS_API_DOCS_DIR_PATH: ${{ vars.OSS_API_DOCS_DIR_PATH || '/swagger/' }}
+      CONSOLE_CHART_REGISTRY: ${{ vars.CONSOLE_CHART_REGISTRY }}
+      CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS: ${{ vars.CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Aliyun CLI
         run: |
@@ -31,19 +95,41 @@ jobs:
       - id: calc-version
         name: Calculate Version Number
         run: |
-          version=$(echo ${{ github.ref_name }} | cut -c2-)
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          test "$GITHUB_REF_NAME" = "v$version"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           echo "Version=$version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Build Artifact
-        uses: stefanprodan/kube-tools@v1
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
-          helmv3: 3.7.2
-          command: |
-            helmv3 package helm --debug --app-version ${{steps.calc-version.outputs.version}} --version ${{steps.calc-version.outputs.version}} -d ./artifact
-            helmv3 repo index --url https://higress.io/helm-charts/ --merge ./artifact/index.yaml ./artifact
-            cp ./artifact/index.yaml ./artifact/cn-index.yaml
-            sed -i 's/higress\.io/higress\.cn/g' ./artifact/cn-index.yaml
+          version: v3.14.4
+
+      - name: Build Artifact
+        env:
+          VERSION: ${{ steps.calc-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          helm package helm --debug --app-version "$VERSION" --version "$VERSION" -d ./artifact
+          helm repo index --url https://higress.io/helm-charts/ --merge ./artifact/index.yaml ./artifact
+          cp ./artifact/index.yaml ./artifact/cn-index.yaml
+          sed -i 's/higress\.io/higress\.cn/g' ./artifact/cn-index.yaml
+
+      - name: Install ORAS for OCI chart digest resolution
+        uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+        with:
+          version: 1.2.3
+
+      - name: Publish or verify exact packaged Helm chart in OCI
+        env:
+          VERSION: ${{ steps.calc-version.outputs.version }}
+          CHART_PACKAGE: ./artifact/higress-console-${{ steps.calc-version.outputs.version }}.tgz
+          DRY_RUN: false
+          CONSOLE_CHART_REGISTRY_USERNAME: ${{ secrets.CONSOLE_CHART_REGISTRY_USERNAME }}
+          CONSOLE_CHART_REGISTRY_PASSWORD: ${{ secrets.CONSOLE_CHART_REGISTRY_PASSWORD }}
+        run: tools/publish_console_chart.sh
 
       - name: Upload Helm Charts to OSS
         run: ./aliyun oss cp ./artifact/ oss://$OSS_BUCKET$OSS_HELM_CHART_PATH/ -r -f -e $OSS_ENDPOINT --access-key-id ${{ secrets.ACCESS_KEYID }} --access-key-secret ${{ secrets.ACCESS_KEYSECRET }} --region $OSS_REGION

--- a/.github/workflows/publish-plugin-release-provenance.yaml
+++ b/.github/workflows/publish-plugin-release-provenance.yaml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: console-plugin-release-provenance-${{ github.event.release.id }}
+  cancel-in-progress: false
+
 jobs:
   provenance:
     runs-on: ubuntu-latest
@@ -33,8 +37,25 @@ jobs:
           commit=$(git rev-parse "refs/tags/$TAG^{commit}")
           test -f backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json
           test -n "$CHART_REGISTRY"
-          chart_ref="$CHART_REGISTRY/higress-console:${TAG#v}"
-          chart_digest=$(oras manifest fetch "$chart_ref" --descriptor --format json | jq -r .digest)
+          version="${TAG#v}"
+          test "$TAG" = "v$version"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$CHART_REGISTRY" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?(/[a-z0-9][a-z0-9._-]*)+$ ]]
+          chart_ref="$CHART_REGISTRY/higress-console:$version"
+          chart_descriptor=""
+          for attempt in $(seq 1 30); do
+            if chart_descriptor=$(oras manifest fetch "$chart_ref" --descriptor --format json 2>/tmp/chart-descriptor.err); then
+              break
+            fi
+            sleep 10
+          done
+          if [ -z "$chart_descriptor" ]; then
+            cat /tmp/chart-descriptor.err >&2
+            echo "published Console OCI chart is unavailable: $chart_ref" >&2
+            exit 1
+          fi
+          chart_digest=$(jq -er '.digest' <<<"$chart_descriptor")
+          [[ "$chart_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
           lock=$(jq -cS . backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json)
           properties=$(sha256sum backend/sdk/src/main/resources/plugins/plugins.properties | awk '{print $1}')
           specs=$(find backend/sdk/src/main/resources/plugins -name spec.yaml -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')

--- a/.github/workflows/sync-plugin-snapshot.yaml
+++ b/.github/workflows/sync-plugin-snapshot.yaml
@@ -23,6 +23,8 @@ concurrency:
 jobs:
   render:
     runs-on: ubuntu-latest
+    # CONSOLE_RELEASE_APP_PRIVATE_KEY is scoped to this protected environment.
+    environment: console-plugin-sync
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         if: ${{ !inputs.dry_run }}

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -1,0 +1,61 @@
+<!--
+Copyright 2026 alibaba
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Console release automation configuration
+
+The Console tag workflow packages `helm/` once and publishes that exact package
+to both the existing HTTPS Helm repository and an OCI Helm repository. OCI
+publication is an immutable release prerequisite: the workflow creates a version
+tag only when it is absent, or reuses it only when its Helm chart content layer
+has the same SHA-256 as the locally packaged chart.
+
+## Console environments
+
+Configure these protected Environments in `higress-group/higress-console`:
+
+| Environment | Allowed deployment refs | Variables | Secrets |
+| --- | --- | --- | --- |
+| `console-chart-production` | Release tags matching `v*.*.*` | `CONSOLE_CHART_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com/higress`; `CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS=true` | `CONSOLE_CHART_REGISTRY_USERNAME`, `CONSOLE_CHART_REGISTRY_PASSWORD`; existing OSS publisher secrets `ACCESS_KEYID`, `ACCESS_KEYSECRET` if they are not retained as repository secrets |
+| `console-plugin-sync` | `main` | `CONSOLE_RELEASE_APP_ID` | `CONSOLE_RELEASE_APP_PRIVATE_KEY` |
+
+The OCI publisher credential must write only the
+`higress/higress-console` repository. It is not a plugin or plugin-server
+publisher credential. The snapshot receiver uses the release automation GitHub
+App private key only from `console-plugin-sync`; its dry run never requests an
+App token or creates a branch/PR.
+
+The Standalone receiver has a separate protected Environment in
+`higress-group/higress-standalone`: `standalone-release-sync` (normally limited
+to `main`), with `STANDALONE_RELEASE_APP_ID` and
+`STANDALONE_RELEASE_APP_PRIVATE_KEY`. Do not reuse the release-manager App for
+either receiver.
+
+## Registry prerequisite and dry run
+
+Before setting `CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS=true`, configure the ACR
+repository `higress/higress-console` so non-`latest` tags cannot be overwritten
+and verify the setting with a conflicting-tag negative test. This is an external
+ACR control; the workflow guard is an operator confirmation, not a replacement
+for registry enforcement. A tag release fails closed unless the variable is
+exactly `true`.
+
+Use **Run workflow** with a semantic `version` only to validate chart packaging:
+the manual path runs in the separate `validate-chart` job, does not enter
+`console-chart-production`, receives no publisher credentials, and writes
+neither OCI nor OSS artifacts. A tagged release is the only path that enters
+`console-chart-production` and publishes the OCI reference
+`<CONSOLE_CHART_REGISTRY>/higress-console:<version>` before the release
+provenance workflow resolves and records its digest.

--- a/tools/publish_console_chart.sh
+++ b/tools/publish_console_chart.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 alibaba
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Publish a release chart only when its exact OCI tag is absent. Existing tags
+# must contain the byte-identical package, so retries cannot silently cover a
+# mutable-tag overwrite.
+set -euo pipefail
+
+: "${CONSOLE_CHART_REGISTRY:?CONSOLE_CHART_REGISTRY must be configured}"
+: "${VERSION:?VERSION must be configured}"
+: "${CHART_PACKAGE:?CHART_PACKAGE must be configured}"
+: "${DRY_RUN:=false}"
+
+test -f "$CHART_PACKAGE" || { echo "packaged Console chart is missing: $CHART_PACKAGE" >&2; exit 1; }
+test "$(tar -xOf "$CHART_PACKAGE" higress-console/Chart.yaml | awk '$1 == "name:" { print $2; exit }')" = higress-console
+test "$(tar -xOf "$CHART_PACKAGE" higress-console/Chart.yaml | awk '$1 == "version:" { print $2; exit }')" = "$VERSION"
+[[ "$CONSOLE_CHART_REGISTRY" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?(/[a-z0-9][a-z0-9._-]*)+$ ]]
+
+if [ "$DRY_RUN" = true ]; then
+  echo "Dry run: packaged Console OCI chart was validated; no registry or OSS write was attempted." >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 0
+fi
+
+test "$CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS" = true || {
+  echo "CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS=true is required before production chart publication" >&2
+  exit 1
+}
+: "${CONSOLE_CHART_REGISTRY_USERNAME:?CONSOLE_CHART_REGISTRY_USERNAME must be configured}"
+: "${CONSOLE_CHART_REGISTRY_PASSWORD:?CONSOLE_CHART_REGISTRY_PASSWORD must be configured}"
+
+registry_host="${CONSOLE_CHART_REGISTRY%%/*}"
+chart_ref="$CONSOLE_CHART_REGISTRY/higress-console:$VERSION"
+package_digest="sha256:$(sha256sum "$CHART_PACKAGE" | awk '{print $1}')"
+
+printf '%s' "$CONSOLE_CHART_REGISTRY_PASSWORD" | helm registry login "$registry_host" --username "$CONSOLE_CHART_REGISTRY_USERNAME" --password-stdin
+printf '%s' "$CONSOLE_CHART_REGISTRY_PASSWORD" | oras login "$registry_host" --username "$CONSOLE_CHART_REGISTRY_USERNAME" --password-stdin
+
+descriptor_error=/tmp/console-chart-descriptor.err
+if descriptor=$(oras manifest fetch "$chart_ref" --descriptor --format json 2>"$descriptor_error"); then
+  digest=$(jq -er '.digest' <<<"$descriptor")
+  [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+  manifest=$(oras manifest fetch "$chart_ref@$digest" --raw)
+  layer_digest=$(jq -er '[.layers[] | select(.mediaType == "application/vnd.cncf.helm.chart.content.v1.tar+gzip")] | if length == 1 then .[0].digest else error("expected one Helm chart content layer") end' <<<"$manifest")
+  if [ "$layer_digest" != "$package_digest" ]; then
+    echo "immutable Console chart tag conflict: $chart_ref contains $layer_digest, expected $package_digest" >&2
+    exit 1
+  fi
+  {
+    echo "### OCI Helm chart"
+    echo
+    echo "- Reused existing exact package: \`$chart_ref@$digest\`"
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 0
+fi
+
+if ! grep -Eqi 'not found|404|manifest unknown|name unknown' "$descriptor_error"; then
+  cat "$descriptor_error" >&2
+  echo "unable to determine whether Console OCI chart tag already exists: $chart_ref" >&2
+  exit 1
+fi
+
+helm push "$CHART_PACKAGE" "oci://$CONSOLE_CHART_REGISTRY"
+published=$(oras manifest fetch "$chart_ref" --descriptor --format json)
+digest=$(jq -er '.digest' <<<"$published")
+[[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+manifest=$(oras manifest fetch "$chart_ref@$digest" --raw)
+layer_digest=$(jq -er '[.layers[] | select(.mediaType == "application/vnd.cncf.helm.chart.content.v1.tar+gzip")] | if length == 1 then .[0].digest else error("expected one Helm chart content layer") end' <<<"$manifest")
+test "$layer_digest" = "$package_digest"
+{
+  echo "### OCI Helm chart"
+  echo
+  echo "- Reference: \`$chart_ref\`"
+  echo "- Digest: \`$digest\`"
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/tools/test_publish_console_chart.py
+++ b/tools/test_publish_console_chart.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright 2026 alibaba
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused behavior tests for the Console OCI chart publisher."""
+
+import hashlib
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import textwrap
+from typing import Optional
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISHER = ROOT / "tools" / "publish_console_chart.sh"
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-to-oss.yaml"
+CHART_MEDIA_TYPE = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+
+
+class ConsoleChartPublisherTest(unittest.TestCase):
+    def make_chart(self, directory: Path) -> Path:
+        chart = directory / "higress-console-1.2.3.tgz"
+        source = directory / "Chart.yaml"
+        source.write_text("apiVersion: v2\nname: higress-console\nversion: 1.2.3\n", encoding="utf-8")
+        with tarfile.open(chart, "w:gz") as archive:
+            archive.add(source, arcname="higress-console/Chart.yaml")
+        return chart
+
+    def write_mock_tools(self, directory: Path) -> Path:
+        bin_dir = directory / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "helm").write_text(
+            "#!/bin/sh\n"
+            "echo \"helm $*\" >> \"$CALL_LOG\"\n"
+            "if [ \"$1\" = push ]; then printf published > \"$FAKE_STATE\"; fi\n",
+            encoding="utf-8",
+        )
+        (bin_dir / "oras").write_text(
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                echo "oras $*" >> "$CALL_LOG"
+                if [ "$1" = login ]; then exit 0; fi
+                if [ "$1 $2" != 'manifest fetch' ]; then exit 1; fi
+                mode=${ORAS_MODE:?}
+                if [ "$mode" = absent ] && [ ! -s "$FAKE_STATE" ]; then
+                  echo 'manifest unknown' >&2
+                  exit 1
+                fi
+                if [ "$mode" = incompatible ]; then layer=sha256:$(printf z | tr z 0 | head -c 64); else layer=$PACKAGE_DIGEST; fi
+                if [ "$4" = --raw ]; then
+                  printf '{"layers":[{"mediaType":"%s","digest":"%s"}]}' '"""
+            )
+            + CHART_MEDIA_TYPE
+            + """' "$layer"
+                else
+                  printf '{"digest":"sha256:%064d"}' 0
+                fi
+                """,
+            encoding="utf-8",
+        )
+        for command in bin_dir.iterdir():
+            command.chmod(0o755)
+        return bin_dir
+
+    def run_publisher(self, chart: Optional[Path], mode: str, *, dry_run: bool = False, immutable_tags: str = "true", password: Optional[str] = "password"):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            bin_dir = self.write_mock_tools(directory)
+            call_log = directory / "calls.log"
+            state = directory / "state"
+            summary = directory / "summary.md"
+            package_digest = "sha256:" + hashlib.sha256(chart.read_bytes()).hexdigest() if chart else "sha256:" + "0" * 64
+            environment = {
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+                "CONSOLE_CHART_REGISTRY": "registry.example/higress",
+                "CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS": immutable_tags,
+                "CONSOLE_CHART_REGISTRY_USERNAME": "publisher",
+                "VERSION": "1.2.3",
+                "CHART_PACKAGE": str(chart or directory / "missing.tgz"),
+                "DRY_RUN": str(dry_run).lower(),
+                "ORAS_MODE": mode,
+                "PACKAGE_DIGEST": package_digest,
+                "CALL_LOG": str(call_log),
+                "FAKE_STATE": str(state),
+                "GITHUB_STEP_SUMMARY": str(summary),
+            }
+            if password is not None:
+                environment["CONSOLE_CHART_REGISTRY_PASSWORD"] = password
+            result = subprocess.run([str(PUBLISHER)], env=environment, text=True, capture_output=True)
+            return result, call_log.read_text(encoding="utf-8") if call_log.exists() else "", summary.read_text(encoding="utf-8") if summary.exists() else ""
+
+    def test_rejects_absent_credential_without_registry_calls(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            result, calls, _ = self.run_publisher(self.make_chart(Path(raw_directory)), "absent", password=None)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CONSOLE_CHART_REGISTRY_PASSWORD", result.stderr)
+        self.assertEqual(calls, "")
+
+    def test_rejects_missing_packaged_chart_without_registry_calls(self):
+        result, calls, _ = self.run_publisher(None, "absent")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("packaged Console chart is missing", result.stderr)
+        self.assertEqual(calls, "")
+
+    def test_requires_explicit_immutable_tag_prerequisite_without_registry_calls(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            result, calls, _ = self.run_publisher(self.make_chart(Path(raw_directory)), "absent", immutable_tags="false")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS=true", result.stderr)
+        self.assertEqual(calls, "")
+
+    def test_reuses_identical_existing_chart_without_push(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            result, calls, summary = self.run_publisher(self.make_chart(Path(raw_directory)), "same")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("helm push", calls)
+        self.assertIn("Reused existing exact package", summary)
+
+    def test_rejects_incompatible_existing_chart_without_push(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            result, calls, _ = self.run_publisher(self.make_chart(Path(raw_directory)), "incompatible")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("immutable Console chart tag conflict", result.stderr)
+        self.assertNotIn("helm push", calls)
+
+    def test_absent_chart_tag_is_published_and_verified(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            result, calls, summary = self.run_publisher(self.make_chart(Path(raw_directory)), "absent")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("helm push", calls)
+        self.assertIn("Digest", summary)
+
+    def test_dry_run_does_not_call_registry_or_require_credentials(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            result, calls, summary = self.run_publisher(self.make_chart(Path(raw_directory)), "absent", dry_run=True, password=None)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(calls, "")
+        self.assertIn("no registry or OSS write was attempted", summary)
+
+    def test_dispatch_validation_job_has_no_production_environment_or_publisher_credentials(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        validation_job = workflow.split("  validate-chart:\n", 1)[1].split("  deploy-to-oss:\n", 1)[0]
+        production_job = workflow.split("  deploy-to-oss:\n", 1)[1]
+        self.assertIn("if: ${{ github.event_name == 'workflow_dispatch' }}", validation_job)
+        self.assertNotIn("environment:", validation_job)
+        self.assertNotIn("CONSOLE_CHART_REGISTRY_USERNAME", validation_job)
+        self.assertNotIn("CONSOLE_CHART_REGISTRY_PASSWORD", validation_job)
+        self.assertIn("DRY_RUN: true", validation_job)
+        self.assertIn("if: ${{ github.event_name == 'push' }}", production_job)
+        self.assertIn("environment: console-chart-production", production_job)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Publish the exact release chart package to OCI and resolve its digest before Console provenance is emitted.
- Fail closed unless immutable-tag readiness is explicitly configured; reuse an existing tag only when its Helm content layer exactly matches the package.
- Add a credential-free manual validation job and protect the snapshot receiver with its Environment.

## Validation

- `python3 tools/test_publish_console_chart.py` (8 passing)
- `bash -n tools/publish_console_chart.sh`
- `actionlint` for the three changed workflows
- `helm lint helm`

## Traceability

- Design: https://github.com/higress-group/higress/issues/4442
- TASK-4442010: https://github.com/higress-group/higress/issues/4442#issuecomment-5266749068

## Agent-assisted contribution

This PR was implemented with Codex assistance and independently reviewed before submission. Production publishing remains disabled until the external ACR immutable-tag prerequisite and publisher credentials are configured.