### PR TITLE
fix: align ORAS setup action with CLI pin

### DIFF
--- a/.github/workflows/deploy-to-oss.yaml
+++ b/.github/workflows/deploy-to-oss.yaml
@@ -118,7 +118,7 @@ jobs:
           sed -i 's/higress\.io/higress\.cn/g' ./artifact/cn-index.yaml
 
       - name: Install ORAS for OCI chart digest resolution
-        uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
 

--- a/.github/workflows/publish-plugin-release-provenance.yaml
+++ b/.github/workflows/publish-plugin-release-provenance.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
-      - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+      - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Publish immutable plugin lock asset

--- a/.github/workflows/sync-plugin-snapshot.yaml
+++ b/.github/workflows/sync-plugin-snapshot.yaml
@@ -70,7 +70,7 @@ jobs:
           test "$(git rev-parse "$BASE_SHA^{commit}")" = "$BASE_SHA"
           git checkout --detach "$BASE_SHA"
       - name: Install ORAS for immutable receiver verification
-        uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1.2.0
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
       - name: Fetch and verify snapshot from exact Higress commit

--- a/tools/test_publish_console_chart.py
+++ b/tools/test_publish_console_chart.py
@@ -164,6 +164,21 @@ class ConsoleChartPublisherTest(unittest.TestCase):
         self.assertIn("if: ${{ github.event_name == 'push' }}", production_job)
         self.assertIn("environment: console-chart-production", production_job)
 
+    def test_release_workflows_pair_oras_setup_metadata_with_pinned_cli(self):
+        oras_setup = "oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3"
+        oras_setup_with_cli = oras_setup + "\n        with:\n          version: 1.2.3"
+        superseded_setup = "oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93"
+        expected_callers = {
+            "deploy-to-oss.yaml": 1,
+            "publish-plugin-release-provenance.yaml": 1,
+            "sync-plugin-snapshot.yaml": 1,
+        }
+        for name, expected in expected_callers.items():
+            workflow = (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+            self.assertNotIn(superseded_setup, workflow, name)
+            self.assertEqual(expected, workflow.count("version: 1.2.3"), name)
+            self.assertEqual(expected, workflow.count(oras_setup_with_cli), name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Pin Console OCI chart, provenance, and snapshot receiver workflows to the setup action metadata supporting their already-declared ORAS CLI 1.2.3.
- Add a regression test covering all three callers.

## Validation

- `python3 tools/test_publish_console_chart.py` (9 passing)
- actionlint v1.7.7 for three modified workflows
- YAML/static assertions and `git diff --check`

## Traceability

- Design: https://github.com/higress-group/higress/issues/4442
- TASK-4442013: https://github.com/higress-group/higress/issues/4442#issuecomment-5267888225

## Agent-assisted contribution

Implemented with Codex assistance and independently reviewed. No release or registry behavior changed.