### PR TITLE
fix: normalize plugin server repository refs

### DIFF
--- a/.github/workflows/sync-plugin-snapshot.yaml
+++ b/.github/workflows/sync-plugin-snapshot.yaml
@@ -104,6 +104,7 @@ jobs:
           oras manifest fetch "$PLUGIN_SERVER_IMAGE" >/tmp/plugin-server-index.json
           verify_plugin_server_index /tmp/plugin-server-index.json
           plugin_server_repo=${PLUGIN_SERVER_IMAGE%@*}
+          if [[ "${plugin_server_repo##*/}" == *:* ]]; then plugin_server_repo=${plugin_server_repo%:*}; fi
           while read -r platform; do
             manifest=$(oras manifest fetch "$plugin_server_repo@$platform")
             config=$(jq -r .config.digest <<<"$manifest")

--- a/tools/test_publish_console_chart.py
+++ b/tools/test_publish_console_chart.py
@@ -186,8 +186,26 @@ class ConsoleChartPublisherTest(unittest.TestCase):
         self.assertEqual(2, publisher.count('oras manifest fetch "$chart_ref@$digest"'))
         self.assertNotIn("oras manifest fetch \"$PLUGIN_SERVER_IMAGE\" --raw", receiver)
         self.assertIn('oras manifest fetch "$PLUGIN_SERVER_IMAGE" >/tmp/plugin-server-index.json', receiver)
+        self.assertIn('if [[ "${plugin_server_repo##*/}" == *:* ]]; then plugin_server_repo=${plugin_server_repo%:*}; fi', receiver)
         self.assertIn('oras blob fetch "$plugin_server_repo@$config" -o -', receiver)
         self.assertNotIn('oras blob fetch "$PLUGIN_SERVER_IMAGE@$platform" "$config"', receiver)
+
+    def test_plugin_server_repository_normalization_is_port_safe(self):
+        script = r'''
+set -euo pipefail
+PLUGIN_SERVER_IMAGE=$1
+plugin_server_repo=${PLUGIN_SERVER_IMAGE%@*}
+if [[ "${plugin_server_repo##*/}" == *:* ]]; then plugin_server_repo=${plugin_server_repo%:*}; fi
+printf '%s' "$plugin_server_repo"
+'''
+        fixtures = {
+            "registry.example/higress/plugin-server:2.2.4@sha256:" + "a" * 64: "registry.example/higress/plugin-server",
+            "registry.example:5000/higress/plugin-server:2.2.4@sha256:" + "a" * 64: "registry.example:5000/higress/plugin-server",
+            "registry.example:5000/higress/plugin-server@sha256:" + "a" * 64: "registry.example:5000/higress/plugin-server",
+        }
+        for image, expected in fixtures.items():
+            result = subprocess.run(["bash", "-c", script, "bash", image], text=True, capture_output=True, check=True)
+            self.assertEqual(expected, result.stdout)
 
     def test_plugin_server_receiver_accepts_only_runnable_pair_and_paired_attestations(self):
         receiver = (ROOT / ".github" / "workflows" / "sync-plugin-snapshot.yaml").read_text(encoding="utf-8")


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Follow-up to #758: normalize the dispatched plugin-server `name:tag@digest` into a pure repository before constructing child manifest and config blob references. The normalization is port-safe and also accepts an already untagged digest reference.

### Ⅱ. Does this pull request fix one issue?

Release-specific follow-up for higress-group/higress#4442 and review finding on #758.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

A behavioral test covers normal registry, registry with port, tagged digest, and untagged digest forms.

### Ⅳ. Describe how to verify it

Exact head: `185461caf7ede1bf61b2ea7e11653a093cadd418`. `python3 -m unittest tools/test_publish_console_chart.py tools/test_render_plugin_snapshot.py` passed 16 tests; `bash -n tools/publish_console_chart.sh` and `git diff --check` passed.

### Ⅴ. Special notes for reviews

AI coding disclosure: OpenAI Codex implemented this narrow follow-up from an independent reviewer finding. The maintainer authorized autonomous release-specific remediation and merge; unrelated CI need not block the release.