### PR TITLE
fix: use ORAS descriptor output directly

### DIFF
--- a/.github/workflows/publish-plugin-release-provenance.yaml
+++ b/.github/workflows/publish-plugin-release-provenance.yaml
@@ -44,7 +44,7 @@ jobs:
           chart_ref="$CHART_REGISTRY/higress-console:$version"
           chart_descriptor=""
           for attempt in $(seq 1 30); do
-            if chart_descriptor=$(oras manifest fetch "$chart_ref" --descriptor --format json 2>/tmp/chart-descriptor.err); then
+            if chart_descriptor=$(oras manifest fetch "$chart_ref" --descriptor 2>/tmp/chart-descriptor.err); then
               break
             fi
             sleep 10

--- a/.github/workflows/sync-plugin-snapshot.yaml
+++ b/.github/workflows/sync-plugin-snapshot.yaml
@@ -114,7 +114,7 @@ jobs:
           done < <(jq -r '.manifests[] | select(.platform.os == "linux" and (.platform.architecture == "amd64" or .platform.architecture == "arm64")) | .digest' /tmp/plugin-server-index.json)
           jq -c '.plugins[] | select(.consumers.console != null)' /tmp/snapshot.json | while read -r plugin; do
             ref=$(jq -r .ociRef <<<"$plugin"); digest=$(jq -r .digest <<<"$plugin")
-            test "$(oras manifest fetch "$ref" --descriptor --format json | jq -r .digest)" = "$digest"
+            test "$(oras manifest fetch "$ref" --descriptor | jq -r .digest)" = "$digest"
           done
           python3 tools/render_plugin_snapshot.py --snapshot /tmp/snapshot.json --sha256 "$SHA" --plugin-server-commit "$PLUGIN_SERVER_COMMIT" --plugin-server-image "$PLUGIN_SERVER_IMAGE" --base-sha "$BASE_SHA" --validate-rendered
           git diff --check

--- a/tools/publish_console_chart.sh
+++ b/tools/publish_console_chart.sh
@@ -49,7 +49,7 @@ printf '%s' "$CONSOLE_CHART_REGISTRY_PASSWORD" | helm registry login "$registry_
 printf '%s' "$CONSOLE_CHART_REGISTRY_PASSWORD" | oras login "$registry_host" --username "$CONSOLE_CHART_REGISTRY_USERNAME" --password-stdin
 
 descriptor_error=/tmp/console-chart-descriptor.err
-if descriptor=$(oras manifest fetch "$chart_ref" --descriptor --format json 2>"$descriptor_error"); then
+if descriptor=$(oras manifest fetch "$chart_ref" --descriptor 2>"$descriptor_error"); then
   digest=$(jq -er '.digest' <<<"$descriptor")
   [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
   manifest=$(oras manifest fetch "$chart_ref@$digest")
@@ -73,7 +73,7 @@ if ! grep -Eqi 'not found|404|manifest unknown|name unknown' "$descriptor_error"
 fi
 
 helm push "$CHART_PACKAGE" "oci://$CONSOLE_CHART_REGISTRY"
-published=$(oras manifest fetch "$chart_ref" --descriptor --format json)
+published=$(oras manifest fetch "$chart_ref" --descriptor)
 digest=$(jq -er '.digest' <<<"$published")
 [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
 manifest=$(oras manifest fetch "$chart_ref@$digest")

--- a/tools/test_publish_console_chart.py
+++ b/tools/test_publish_console_chart.py
@@ -182,6 +182,9 @@ class ConsoleChartPublisherTest(unittest.TestCase):
     def test_release_paths_use_oras_1_2_reference_syntax(self):
         publisher = PUBLISHER.read_text(encoding="utf-8")
         receiver = (ROOT / ".github" / "workflows" / "sync-plugin-snapshot.yaml").read_text(encoding="utf-8")
+        provenance = (ROOT / ".github" / "workflows" / "publish-plugin-release-provenance.yaml").read_text(encoding="utf-8")
+        for name, release_path in {"publisher": publisher, "receiver": receiver, "provenance": provenance}.items():
+            self.assertNotIn("--descriptor --format json", release_path, name)
         self.assertNotIn("oras manifest fetch \"$chart_ref@$digest\" --raw", publisher)
         self.assertEqual(2, publisher.count('oras manifest fetch "$chart_ref@$digest"'))
         self.assertNotIn("oras manifest fetch \"$PLUGIN_SERVER_IMAGE\" --raw", receiver)


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Remove all four unsupported ORAS 1.2.3 `--descriptor --format json` combinations from the immutable snapshot receiver, Console chart publisher, and release provenance workflow. `--descriptor` already emits JSON.

Baseline: https://github.com/higress-group/higress-console/actions/runs/31752573676 passed plugin-server index/attestation and both platform label checks, then failed on the first Console plugin descriptor with `--format, --descriptor cannot be used at the same time`.

### Ⅱ. Does this pull request fix one issue?

Release-specific remediation for higress-group/higress#4442.

### Ⅲ. Why don't you add test cases?

The existing release-path contract test now scans receiver, publisher, and provenance workflow and rejects this incompatible option combination.

### Ⅳ. Describe how to verify it

Exact head `52efa8903b8394b82a7ee722f4d6e3481799d9a1`. 16 Python tests, bash syntax, and diff check passed. A real anonymous ORAS 1.2.3 descriptor probe for `plugins/ai-agent:2.0.1` matched the immutable snapshot digest.

### Ⅴ. Special notes for reviews

AI coding disclosure: OpenAI Codex diagnosed the second formal Console receiver failure and audited all downstream Console release paths for the same option combination. The maintainer authorized autonomous release remediation and merge; unrelated CI need not block exact-head review and formal rerun.