### PR TITLE
fix: preserve internal plugin CRs across version upgrades

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -193,7 +193,10 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
 
             V1alpha1WasmPlugin existedCr = null;
             try {
-                List<V1alpha1WasmPlugin> existedCrs = kubernetesClientService.listWasmPlugin(name, version);
+                // Internal CRs use a stable name independent of the plugin version, so they are looked up by name
+                // only to stay compatible with CRs created from older plugin versions.
+                List<V1alpha1WasmPlugin> existedCrs = internal ? kubernetesClientService.listWasmPlugin(name)
+                    : kubernetesClientService.listWasmPlugin(name, version);
                 if (CollectionUtils.isNotEmpty(existedCrs)) {
                     existedCr = existedCrs.stream().filter(cr -> internal == KubernetesUtil.isInternalResource(cr))
                         .findFirst().orElse(null);

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.alibaba.higress.sdk.constant.HigressConstants;
+import com.alibaba.higress.sdk.constant.KubernetesConstants;
 import com.alibaba.higress.sdk.constant.Separators;
 import com.alibaba.higress.sdk.exception.BusinessException;
 import com.alibaba.higress.sdk.exception.ValidationException;
@@ -43,6 +44,7 @@ import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
 import com.alibaba.higress.sdk.model.wasmplugin.WasmPluginServiceConfig;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
+import com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.MatchRule;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.PluginPhase;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
@@ -55,6 +57,7 @@ public class WasmPluginInstanceServiceTest {
 
     private static final String TEST_BUILT_IN_PLUGIN_NAME = "basic-auth";
     private static final String DEFAULT_VERSION = "1.0.0";
+    private static final String OLD_VERSION = "0.9.0";
     private static final String TEST_BUILT_IN_PLUGIN_USER_CR_NAME =
         TEST_BUILT_IN_PLUGIN_NAME + Separators.DASH + DEFAULT_VERSION;
     private static final String TEST_BUILT_IN_PLUGIN_INTERNAL_CR_NAME =
@@ -372,6 +375,66 @@ public class WasmPluginInstanceServiceTest {
         V1alpha1WasmPlugin cr = crCaptor.getValue();
         Assertions.assertNotNull(cr);
         Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_INTERNAL_CR_NAME, cr.getMetadata().getName());
+        Assertions.assertNotEquals(instance.getEnabled(), cr.getSpec().getDefaultConfigDisable());
+        Assertions.assertEquals(instance.getConfigurations(), cr.getSpec().getDefaultConfig());
+        Assertions.assertTrue(CollectionUtils.isEmpty(cr.getSpec().getMatchRules()));
+    }
+
+    @Test
+    public void addOrUpdateTestUpdateInternalConfigFromOldVersion() throws Exception {
+        V1alpha1WasmPlugin existedCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
+        KubernetesUtil.setLabel(existedCr.getMetadata(), KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY,
+            OLD_VERSION);
+        when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME)))
+            .thenReturn(Lists.newArrayList(existedCr));
+
+        WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(TEST_BUILT_IN_PLUGIN_NAME)
+            .pluginVersion(DEFAULT_VERSION).scope(WasmPluginInstanceScope.GLOBAL).enabled(false)
+            .configurations(MapUtil.of("k2", "v2")).internal(true).build();
+        WasmPluginInstance updatedInstance = service.addOrUpdate(instance);
+
+        Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_NAME, updatedInstance.getPluginName());
+        Assertions.assertEquals(OLD_VERSION, updatedInstance.getPluginVersion());
+        Assertions.assertEquals(instance.getEnabled(), updatedInstance.getEnabled());
+        Assertions.assertEquals(instance.getConfigurations(), updatedInstance.getConfigurations());
+        Assertions.assertTrue(updatedInstance.getInternal());
+
+        verify(kubernetesClientService, times(1)).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME));
+        verify(kubernetesClientService, never()).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME), anyString());
+        verify(kubernetesClientService, never()).createWasmPlugin(any());
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(1)).replaceWasmPlugin(crCaptor.capture());
+        V1alpha1WasmPlugin cr = crCaptor.getValue();
+        Assertions.assertNotNull(cr);
+        Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_INTERNAL_CR_NAME, cr.getMetadata().getName());
+        Assertions.assertEquals(OLD_VERSION,
+            KubernetesUtil.getLabel(cr.getMetadata(), KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY));
+        Assertions.assertNotEquals(instance.getEnabled(), cr.getSpec().getDefaultConfigDisable());
+        Assertions.assertEquals(instance.getConfigurations(), cr.getSpec().getDefaultConfig());
+        Assertions.assertTrue(CollectionUtils.isEmpty(cr.getSpec().getMatchRules()));
+    }
+
+    @Test
+    public void addOrUpdateTestUpdateUserConfigWithVersionedLookup() throws Exception {
+        V1alpha1WasmPlugin existedCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, false);
+        when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME), eq(DEFAULT_VERSION)))
+            .thenReturn(Lists.newArrayList(existedCr));
+
+        WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(TEST_BUILT_IN_PLUGIN_NAME)
+            .pluginVersion(DEFAULT_VERSION).scope(WasmPluginInstanceScope.GLOBAL).enabled(false)
+            .configurations(MapUtil.of("k2", "v2")).internal(false).build();
+        WasmPluginInstance updatedInstance = service.addOrUpdate(instance);
+        updatedInstance.setRawConfigurations(null);
+        Assertions.assertEquals(instance, updatedInstance);
+
+        verify(kubernetesClientService, times(1)).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME), eq(DEFAULT_VERSION));
+        verify(kubernetesClientService, never()).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME));
+        verify(kubernetesClientService, never()).createWasmPlugin(any());
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(1)).replaceWasmPlugin(crCaptor.capture());
+        V1alpha1WasmPlugin cr = crCaptor.getValue();
+        Assertions.assertNotNull(cr);
+        Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_USER_CR_NAME, cr.getMetadata().getName());
         Assertions.assertNotEquals(instance.getEnabled(), cr.getSpec().getDefaultConfigDisable());
         Assertions.assertEquals(instance.getConfigurations(), cr.getSpec().getDefaultConfig());
         Assertions.assertTrue(CollectionUtils.isEmpty(cr.getSpec().getMatchRules()));


### PR DESCRIPTION
## Summary
- find Console-managed internal WasmPlugin CRs by plugin name instead of the plugin-version label
- preserve version-qualified lookup for user-managed plugin resources
- add regressions for legacy internal CR labels and non-internal versioned lookup

## Test Plan
- `cd backend && ./mvnw -pl sdk -Dtest=WasmPluginInstanceServiceTest test`

Fixes the 409 conflict encountered after built-in plugin spec versions are upgraded.