### PR TITLE
fix(release): allow approved console 2.2.4 rebuild

### DIFF
--- a/.github/workflows/recover-console-image-2.2.4.yaml
+++ b/.github/workflows/recover-console-image-2.2.4.yaml
@@ -1,15 +1,15 @@
-name: Recover Not-Yet-Public Console 2.2.4 Image
+name: Recover Console 2.2.4 Image
 
 on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Build the reviewed candidate, or replace the exact 2.2.4 tag with its approved digest
+        description: Build the approved hotfix candidate, or replace the exact 2.2.4 tag with its reviewed digest
         required: true
         type: choice
         options: [build-candidate, replace]
       console_source_commit:
-        description: Exact merged higress-console main commit containing the reviewed resources
+        description: Exact approved merged higress-console commit containing PR 763
         required: true
         type: string
       higress_commit:
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       expected_old_digest:
-        description: Fixed original 2.2.4 digest recorded in the reviewed recovery manifest
+        description: Fixed current 2.2.4 digest recorded by the previous recovery evidence
         required: true
         type: string
       expected_new_digest:
@@ -29,7 +29,7 @@ on:
         required: false
         type: string
       confirmation:
-        description: BUILD_NOT_YET_PUBLIC_2.2.4 or REPLACE_NOT_YET_PUBLIC_2.2.4
+        description: BUILD_APPROVED_HOTFIX_2.2.4 or REPLACE_APPROVED_HOTFIX_2.2.4
         required: true
         type: string
 
@@ -70,7 +70,9 @@ jobs:
           [[ "$MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]]
           test "$(git rev-parse HEAD^{commit})" = "$SOURCE_COMMIT"
           git fetch origin main
+          test "$SOURCE_COMMIT" = "$(git rev-parse origin/main^{commit})"
           git merge-base --is-ancestor "$SOURCE_COMMIT" origin/main
+          git merge-base --is-ancestor 1aa0c03da2279b8c7d2eec025d39f9951d329bf1 "$SOURCE_COMMIT"
           higress_check=$(mktemp -d)
           git -C "$higress_check" init -q
           git -C "$higress_check" remote add canonical https://github.com/higress-group/higress.git
@@ -79,11 +81,11 @@ jobs:
           test "$(git -C "$higress_check" rev-parse "$HIGRESS_COMMIT^{commit}")" = "$HIGRESS_COMMIT"
           git -C "$higress_check" merge-base --is-ancestor "$HIGRESS_COMMIT" "$canonical_main"
           if [ "$OPERATION" = build-candidate ]; then
-            test "$CONFIRMATION" = BUILD_NOT_YET_PUBLIC_2.2.4
+            test "$CONFIRMATION" = BUILD_APPROVED_HOTFIX_2.2.4
             test -z "$EXPECTED_NEW_DIGEST"
           else
             test "$OPERATION" = replace
-            test "$CONFIRMATION" = REPLACE_NOT_YET_PUBLIC_2.2.4
+            test "$CONFIRMATION" = REPLACE_APPROVED_HOTFIX_2.2.4
             [[ "$EXPECTED_NEW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
           fi
 
@@ -107,14 +109,29 @@ jobs:
           required_branch=$(jq -er .requiredSourceBranch /tmp/console-recovery.json)
           test "$original_commit" = 36aa9c67fb0057164dab9b1fe687b38fe5b8a022
           test "$manifest_old" = sha256:c8cb47ad0a550e58df4cfee57f2f358eb0b1635a0812c77e04388dfb17bbebb6
-          test "$EXPECTED_OLD_DIGEST" = "$manifest_old"
+          test "$EXPECTED_OLD_DIGEST" = sha256:4a07fedf9925a2775e9e9b7dfdbf99194651e51a7ee2c0b6bb8fab62e61d2da8
           test "$required_branch" = main
+          previous_evidence=/tmp/console-image-recovery-2.2.4.json
+          previous_checksum=/tmp/console-image-recovery-2.2.4.json.sha256
+          curl --fail --silent --show-error --location \
+            "https://github.com/higress-group/higress-console/releases/download/v2.2.4/console-image-recovery-2.2.4.json" \
+            -o "$previous_evidence"
+          curl --fail --silent --show-error --location \
+            "https://github.com/higress-group/higress-console/releases/download/v2.2.4/console-image-recovery-2.2.4.json.sha256" \
+            -o "$previous_checksum"
+          (cd /tmp && sha256sum -c "${previous_checksum##*/}")
+          test "$(jq -er .oldDigest "$previous_evidence")" = "$manifest_old"
+          test "$(jq -er .newDigest "$previous_evidence")" = "$EXPECTED_OLD_DIGEST"
+          test "$(jq -er .consoleSourceCommit "$previous_evidence")" = 7118cc192522deb144298175318b3ea91d94c715
+          previous_evidence_sha=$(sha256sum "$previous_evidence" | awk '{print $1}')
+          test "$previous_evidence_sha" = 6efb6fbbb7cb44198bfb503a7f8a93f1d1b7d86c85ed5f08909c453bd581dde4
           jq -e --arg version "$VERSION" --arg image "$IMAGE_REPOSITORY" \
             '.schemaVersion == 1 and .gatewayVersion == $version and .imageRepository == $image and (.plugins | length == 8)' \
             /tmp/console-recovery.json >/dev/null
           {
             echo "MANIFEST_ORIGINAL_CONSOLE_COMMIT=$original_commit"
             echo "MANIFEST_OLD_DIGEST=$manifest_old"
+            echo "PREVIOUS_RECOVERY_EVIDENCE_SHA256=$previous_evidence_sha"
           } >> "$GITHUB_ENV"
           bundle_cache=/tmp/plugin-marketplace-bundles
           mkdir -p "$bundle_cache"
@@ -181,7 +198,7 @@ jobs:
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         if: ${{ inputs.operation == 'build-candidate' }}
 
-      - name: Build reviewed recovery candidate without touching 2.2.4
+      - name: Build reviewed hotfix candidate without touching 2.2.4
         if: ${{ inputs.operation == 'build-candidate' }}
         env:
           SOURCE_COMMIT: ${{ inputs.console_source_commit }}
@@ -245,16 +262,18 @@ jobs:
                ."io.higress.marketplace-recovery-higress-commit" == $higress' <<<"$labels" >/dev/null
           done </tmp/candidate-runnable-digests
 
-      - name: Replace only the exact not-yet-public 2.2.4 tag
+      - name: Replace only the exact approved 2.2.4 tag
         if: ${{ inputs.operation == 'replace' && env.RECOVERY_MODE == 'replace' }}
         env:
+          EXPECTED_OLD_DIGEST: ${{ inputs.expected_old_digest }}
           EXPECTED_NEW_DIGEST: ${{ inputs.expected_new_digest }}
         run: |
           set -euo pipefail
           pre_copy_current=$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)
           python3 tools/verify_console_image_recovery.py --pre-copy-mode "$RECOVERY_MODE" \
             --pre-copy-current-digest "$pre_copy_current" \
-            --manifest-old-digest "$MANIFEST_OLD_DIGEST" >/dev/null
+            --manifest-old-digest "$MANIFEST_OLD_DIGEST" \
+            --expected-old-digest "$EXPECTED_OLD_DIGEST" >/dev/null
           oras cp "$IMAGE_REPOSITORY@$EXPECTED_NEW_DIGEST" "$IMAGE_REPOSITORY:$VERSION"
           test "$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)" = "$EXPECTED_NEW_DIGEST"
 
@@ -277,20 +296,24 @@ jobs:
           chart_ref=$(jq -er .chart.ref /tmp/original-provenance/plugin-release-provenance.json)
           chart_digest=$(jq -er .chart.digest /tmp/original-provenance/plugin-release-provenance.json)
           tag_commit=$(jq -er .commit /tmp/original-provenance/plugin-release-provenance.json)
+          evidence_basename="console-image-recovery-2.2.4-${SOURCE_COMMIT:0:12}"
           jq -cnS --arg version "$VERSION" --arg image "$IMAGE_REPOSITORY" \
             --arg old "$EXPECTED_OLD_DIGEST" --arg new "$EXPECTED_NEW_DIGEST" \
             --arg source "$SOURCE_COMMIT" --arg higress "$HIGRESS_COMMIT" --arg manifest "$MANIFEST_SHA256" \
             --arg inventory "$INVENTORY_SHA256" --arg provenance "$provenance_sha" \
+            --arg previousEvidenceSha "$PREVIOUS_RECOVERY_EVIDENCE_SHA256" \
             --arg tagCommit "$tag_commit" --arg chartRef "$chart_ref" --arg chartDigest "$chart_digest" \
             '{schemaVersion:1,version:$version,imageRepository:$image,oldDigest:$old,newDigest:$new,
               consoleSourceCommit:$source,higressCommit:$higress,recoveryManifestSha256:$manifest,
               marketplaceInventorySha256:$inventory,unchangedRelease:{tagCommit:$tagCommit,chartRef:$chartRef,
-              chartDigest:$chartDigest,pluginReleaseProvenanceSha256:$provenance}}' \
-            > console-image-recovery-2.2.4.json
-          sha256sum console-image-recovery-2.2.4.json > console-image-recovery-2.2.4.json.sha256
+              chartDigest:$chartDigest,pluginReleaseProvenanceSha256:$provenance},
+              previousRecovery:{asset:"console-image-recovery-2.2.4.json",sha256:$previousEvidenceSha,
+              resultingDigest:$old}}' \
+            > "$evidence_basename.json"
+          sha256sum "$evidence_basename.json" > "$evidence_basename.json.sha256"
           mkdir -p /tmp/existing-recovery
           asset_names=$(gh release view "v$VERSION" --json assets --jq '.assets[].name')
-          for asset in console-image-recovery-2.2.4.json console-image-recovery-2.2.4.json.sha256; do
+          for asset in "$evidence_basename.json" "$evidence_basename.json.sha256"; do
             if grep -Fxq "$asset" <<<"$asset_names"; then
               gh release download "v$VERSION" --pattern "$asset" --dir /tmp/existing-recovery
               cmp "/tmp/existing-recovery/$asset" "$asset"
@@ -298,4 +321,4 @@ jobs:
               gh release upload "v$VERSION" "$asset"
             fi
           done
-          echo "Recovered \`$IMAGE_REPOSITORY:$VERSION@$EXPECTED_NEW_DIGEST\`; the existing tag, chart, and plugin provenance asset were not modified." >> "$GITHUB_STEP_SUMMARY"
+          echo "Recovered \`$IMAGE_REPOSITORY:$VERSION@$EXPECTED_NEW_DIGEST\`; the Git release tag, chart, and plugin provenance asset were not modified." >> "$GITHUB_STEP_SUMMARY"

--- a/tools/test_verify_console_image_recovery.py
+++ b/tools/test_verify_console_image_recovery.py
@@ -34,9 +34,9 @@ class RecoveryContractTest(unittest.TestCase):
                     source_commit="a" * 40, higress_commit="b" * 40,
                     manifest_original_console_commit=recovery.ORIGINAL_CONSOLE_COMMIT,
                     manifest_old_digest=recovery.ORIGINAL_IMAGE_DIGEST,
-                    expected_old_digest=recovery.ORIGINAL_IMAGE_DIGEST,
+                    expected_old_digest=recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
                     expected_new_digest="sha256:" + "d" * 64,
-                    current_digest=recovery.ORIGINAL_IMAGE_DIGEST,
+                    current_digest=recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
                     candidate_digest="sha256:" + "d" * 64, source_is_merged=True)
 
     def test_exact_replacement_and_idempotent_retry(self):
@@ -46,7 +46,8 @@ class RecoveryContractTest(unittest.TestCase):
         self.assertEqual(recovery.validate(**values), "already-replaced")
 
     def test_rejects_other_version_stale_digest_unmerged_source_and_candidate_drift(self):
-        for field, value in (("version", "2.2.5"), ("current_digest", "sha256:" + "e" * 64),
+        for field, value in (("version", "2.2.5"), ("source_commit", "invalid"),
+                             ("current_digest", "sha256:" + "e" * 64),
                              ("source_is_merged", False), ("candidate_digest", "sha256:" + "e" * 64)):
             with self.subTest(field=field):
                 values = self.values(); values[field] = value
@@ -60,13 +61,13 @@ class RecoveryContractTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             recovery.validate(**values)
 
-    def test_fixed_original_digest_prevents_a_second_different_replacement(self):
+    def test_approved_replacement_base_prevents_an_unreviewed_chain(self):
         values = self.values()
         values["expected_old_digest"] = values["expected_new_digest"]
         values["current_digest"] = values["expected_new_digest"]
         values["expected_new_digest"] = "sha256:" + "e" * 64
         values["candidate_digest"] = values["expected_new_digest"]
-        with self.assertRaisesRegex(ValueError, "fixed recovery manifest"):
+        with self.assertRaisesRegex(ValueError, "approved replacement base"):
             recovery.validate(**values)
 
     def test_rejects_mismatched_fixed_old_manifest(self):
@@ -77,18 +78,26 @@ class RecoveryContractTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "fixed original image digest"):
             recovery.validate(**values)
 
-    def test_pre_copy_recheck_requires_the_unchanged_fixed_original_digest(self):
-        self.assertEqual(recovery.validate_pre_copy("replace", recovery.ORIGINAL_IMAGE_DIGEST,
+    def test_pre_copy_recheck_requires_the_approved_replacement_base(self):
+        self.assertEqual(recovery.validate_pre_copy("replace", recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
+                                                    recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
                                                     recovery.ORIGINAL_IMAGE_DIGEST), "copy")
         with self.assertRaisesRegex(ValueError, "tag changed after validation"):
             recovery.validate_pre_copy("replace", "sha256:" + "e" * 64,
+                                       recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
+                                       recovery.ORIGINAL_IMAGE_DIGEST)
+        with self.assertRaisesRegex(ValueError, "approved replacement base"):
+            recovery.validate_pre_copy("replace", "sha256:" + "e" * 64,
+                                       "sha256:" + "e" * 64,
                                        recovery.ORIGINAL_IMAGE_DIGEST)
         with self.assertRaisesRegex(ValueError, "fixed original image digest"):
-            recovery.validate_pre_copy("replace", "sha256:" + "e" * 64,
+            recovery.validate_pre_copy("replace", recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
+                                       recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
                                        "sha256:" + "e" * 64)
 
     def test_already_replaced_mode_remains_an_idempotent_no_copy(self):
         self.assertEqual(recovery.validate_pre_copy("already-replaced", "sha256:" + "d" * 64,
+                                                    recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
                                                     recovery.ORIGINAL_IMAGE_DIGEST), "skip")
 
     def descriptor(self, architecture, digest_char, *, os_name="linux"):
@@ -151,23 +160,29 @@ class RecoveryContractTest(unittest.TestCase):
         self.assertNotIn("CONSOLE_CHART_REGISTRY_USERNAME", raw)
         self.assertNotIn("CONSOLE_CHART_REGISTRY_PASSWORD", raw)
         self.assertIn("higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console", raw)
-        self.assertIn("REPLACE_NOT_YET_PUBLIC_2.2.4", raw)
+        self.assertIn("REPLACE_APPROVED_HOTFIX_2.2.4", raw)
         self.assertIn("git merge-base --is-ancestor", raw)
         self.assertIn("https://github.com/higress-group/higress.git", raw)
         self.assertIn(recovery.ORIGINAL_CONSOLE_COMMIT, raw)
         self.assertIn(recovery.ORIGINAL_IMAGE_DIGEST, raw)
-        self.assertIn('test "$EXPECTED_OLD_DIGEST" = "$manifest_old"', raw)
+        self.assertIn(recovery.REQUIRED_HOTFIX_COMMIT, raw)
+        self.assertIn('test "$SOURCE_COMMIT" = "$(git rev-parse origin/main^{commit})"', raw)
+        self.assertIn('git merge-base --is-ancestor 1aa0c03da2279b8c7d2eec025d39f9951d329bf1 "$SOURCE_COMMIT"', raw)
+        self.assertIn(recovery.REPLACEMENT_BASE_IMAGE_DIGEST, raw)
+        self.assertIn("6efb6fbbb7cb44198bfb503a7f8a93f1d1b7d86c85ed5f08909c453bd581dde4", raw)
+        self.assertIn('test "$(jq -er .newDigest "$previous_evidence")" = "$EXPECTED_OLD_DIGEST"', raw)
         self.assertIn('--manifest-old-digest "$MANIFEST_OLD_DIGEST"', raw)
-        self.assertIn("console-image-recovery-2.2.4.json", raw)
+        self.assertIn('evidence_basename="console-image-recovery-2.2.4-${SOURCE_COMMIT:0:12}"', raw)
+        self.assertIn('previousRecovery:{asset:"console-image-recovery-2.2.4.json"', raw)
         self.assertIn("--index-file /tmp/candidate-index.json", raw)
-        copy_start = raw.index("- name: Replace only the exact not-yet-public 2.2.4 tag")
+        copy_start = raw.index("- name: Replace only the exact approved 2.2.4 tag")
         copy_end = raw.index("- name: Publish separate immutable recovery evidence", copy_start)
         copy_step = raw[copy_start:copy_end]
         recheck = 'pre_copy_current=$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)'
         self.assertIn(recheck, copy_step)
         self.assertIn('--pre-copy-current-digest "$pre_copy_current"', copy_step)
         self.assertIn('--manifest-old-digest "$MANIFEST_OLD_DIGEST"', copy_step)
-        self.assertNotIn("EXPECTED_OLD_DIGEST", copy_step)
+        self.assertIn('--expected-old-digest "$EXPECTED_OLD_DIGEST"', copy_step)
         self.assertLess(copy_step.index(recheck), copy_step.index('oras cp "$IMAGE_REPOSITORY@$EXPECTED_NEW_DIGEST"'))
         self.assertIn("group: console-image-publish-v2.2.4", raw)
         publisher = (ROOT / ".github/workflows/deploy-to-k8s.yaml").read_text(encoding="utf-8")

--- a/tools/verify_console_image_recovery.py
+++ b/tools/verify_console_image_recovery.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Fail-closed contract checks for the one-time Console 2.2.4 image repair."""
+"""Fail-closed contract checks for the approved Console 2.2.4 image repair."""
 import argparse
 import json
 import re
@@ -23,6 +23,8 @@ import sys
 IMAGE_REPOSITORY = "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console"
 ORIGINAL_CONSOLE_COMMIT = "36aa9c67fb0057164dab9b1fe687b38fe5b8a022"
 ORIGINAL_IMAGE_DIGEST = "sha256:c8cb47ad0a550e58df4cfee57f2f358eb0b1635a0812c77e04388dfb17bbebb6"
+REQUIRED_HOTFIX_COMMIT = "1aa0c03da2279b8c7d2eec025d39f9951d329bf1"
+REPLACEMENT_BASE_IMAGE_DIGEST = "sha256:4a07fedf9925a2775e9e9b7dfdbf99194651e51a7ee2c0b6bb8fab62e61d2da8"
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 ATTESTATION_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
@@ -89,8 +91,8 @@ def validate(operation, version, image_repository, source_commit, higress_commit
                         ("current", current_digest)):
         if not DIGEST_RE.fullmatch(value or ""):
             raise ValueError(name + " digest is invalid")
-    if expected_old_digest != manifest_old_digest:
-        raise ValueError("operator expected-old digest differs from the fixed recovery manifest")
+    if expected_old_digest != REPLACEMENT_BASE_IMAGE_DIGEST:
+        raise ValueError("operator expected-old digest differs from the approved replacement base")
     if operation == "build-candidate":
         if expected_new_digest or candidate_digest:
             raise ValueError("candidate build must not pre-authorize a replacement digest")
@@ -110,17 +112,20 @@ def validate(operation, version, image_repository, source_commit, higress_commit
     return "replace"
 
 
-def validate_pre_copy(mode, current_digest, manifest_old_digest):
-    """Recheck the mutable tag immediately before the one authorized replacement."""
+def validate_pre_copy(mode, current_digest, expected_old_digest, manifest_old_digest):
+    """Recheck the mutable tag immediately before the authorized replacement."""
     if manifest_old_digest != ORIGINAL_IMAGE_DIGEST:
         raise ValueError("pre-copy check does not bind the fixed original image digest")
-    if not DIGEST_RE.fullmatch(current_digest or ""):
-        raise ValueError("pre-copy current digest is invalid")
+    for name, value in (("pre-copy current", current_digest), ("expected old", expected_old_digest)):
+        if not DIGEST_RE.fullmatch(value or ""):
+            raise ValueError(name + " digest is invalid")
+    if expected_old_digest != REPLACEMENT_BASE_IMAGE_DIGEST:
+        raise ValueError("pre-copy check does not bind the approved replacement base")
     if mode == "already-replaced":
         return "skip"
     if mode != "replace":
         raise ValueError("pre-copy check requires a validated replacement mode")
-    if current_digest != manifest_old_digest:
+    if current_digest != expected_old_digest:
         raise ValueError("tag changed after validation; replacement refused")
     return "copy"
 
@@ -151,7 +156,7 @@ def main():
             return 0
         if args.pre_copy_mode:
             mode = validate_pre_copy(args.pre_copy_mode, args.pre_copy_current_digest,
-                                     args.manifest_old_digest)
+                                     args.expected_old_digest, args.manifest_old_digest)
             print(json.dumps({"mode": mode}, sort_keys=True))
             return 0
         mode = validate(args.operation, args.version, args.image_repository, args.source_commit,


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Extend the existing guarded Console 2.2.4 recovery workflow for the post-release fix merged in #763.

The workflow remains deliberately one-time and fail-closed:

- the source must equal the live `main` HEAD and contain merge commit `1aa0c03da2279b8c7d2eec025d39f9951d329bf1`;
- the current `console:2.2.4` digest must still be `sha256:4a07fedf9925a2775e9e9b7dfdbf99194651e51a7ee2c0b6bb8fab62e61d2da8`;
- the prior recovery evidence and its SHA-256 are verified before rebuilding;
- the reviewed 2.2.4 plugin marketplace inventory is rendered again before the release-mode build;
- replacement requires a separately built candidate digest, validates both platforms and labels, and rechecks the stable tag immediately before `oras cp`;
- a source-specific immutable recovery evidence asset is appended without moving `v2.2.4` or changing the chart/provenance assets.

### Ⅱ. Does this pull request fix one issue?

Follow-up release operation for #763.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Tests are included for the approved source/base digest, stale-tag refusal, candidate validation, idempotent retry, pre-copy CAS, platform/attestation validation, workflow secrets/environment, evidence chaining, and pinned actions.

### Ⅳ. Describe how to verify it

```bash
PYTHONDONTWRITEBYTECODE=1 env -u GH_TOKEN -u GITHUB_TOKEN python3 -m unittest discover -s tools -p 'test_*.py'
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/recover-console-image-2.2.4.yaml
```

Exact tested commit: `fd5a3ffb83973fb96d138001184c9e6228a67d61`.

### Ⅴ. Special notes for reviews

A normal rerun of the `v2.2.4` tag workflow would rebuild the old release commit and cannot include #763. The previous recovery workflow also intentionally refuses because the stable image has already moved once. After this PR merges, the workflow will be run in two phases: build candidate first, inspect its digest, then explicitly replace the stable tag.

AI-assisted implementation: OpenAI Codex analyzed the existing release/recovery state, implemented the guarded evidence chain, and ran the commands above. No credentials are included.
