### PR TITLE
fix(release): generalize guarded console image recovery

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -16,7 +16,7 @@ on:
     #     required: false
 
 concurrency:
-  # Serialize the normal tag publisher with the one-time v2.2.4 recovery.
+  # Serialize the normal tag publisher with guarded recovery for the same version.
   group: console-image-publish-${{ github.ref_name }}
   cancel-in-progress: false
 

--- a/.github/workflows/recover-console-image.yaml
+++ b/.github/workflows/recover-console-image.yaml
@@ -1,35 +1,47 @@
-name: Recover Console 2.2.4 Image
+name: Recover Console Image
 
 on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Build the approved hotfix candidate, or replace the exact 2.2.4 tag with its reviewed digest
+        description: Build a reviewed hotfix candidate, or replace the release tag with its approved digest
         required: true
         type: choice
         options: [build-candidate, replace]
+      version:
+        description: Released Console version without the v prefix (for example, 2.2.4)
+        required: true
+        type: string
       console_source_commit:
-        description: Exact approved merged higress-console commit containing PR 763
+        description: Exact merged higress-console commit to rebuild
         required: true
         type: string
       higress_commit:
-        description: Exact merged Higress commit containing the recovery manifest and resource bundles
+        description: Exact merged Higress commit containing plugins/release/console-recovery/<version>.json
         required: true
         type: string
       recovery_manifest_sha256:
-        description: SHA-256 of plugins/release/console-recovery/2.2.4.json at higress_commit
+        description: SHA-256 of the versioned recovery manifest at higress_commit
         required: true
         type: string
       expected_old_digest:
-        description: Fixed current 2.2.4 digest recorded by the previous recovery evidence
+        description: Exact current release image digest authorized by the manifest or previous recovery evidence
         required: true
+        type: string
+      previous_recovery_asset:
+        description: Previous recovery JSON asset name when this is not the first replacement
+        required: false
+        type: string
+      previous_recovery_sha256:
+        description: SHA-256 of previous_recovery_asset; required together with the asset name
+        required: false
         type: string
       expected_new_digest:
         description: Exact candidate digest; required only for replace and reported by build-candidate
         required: false
         type: string
       confirmation:
-        description: BUILD_APPROVED_HOTFIX_2.2.4 or REPLACE_APPROVED_HOTFIX_2.2.4
+        description: BUILD_APPROVED_HOTFIX_<version> or REPLACE_APPROVED_HOTFIX_<version>
         required: true
         type: string
 
@@ -37,7 +49,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: console-image-publish-v2.2.4
+  group: console-image-publish-v${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -45,17 +57,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: console-chart-production
     env:
-      VERSION: 2.2.4
+      VERSION: ${{ inputs.version }}
       IMAGE_REPOSITORY: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console
       REGISTRY: higress-registry.cn-hangzhou.cr.aliyuncs.com
-      MANIFEST_PATH: plugins/release/console-recovery/2.2.4.json
+      MANIFEST_PATH: plugins/release/console-recovery/${{ inputs.version }}.json
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.console_source_commit }}
           fetch-depth: 0
 
-      - name: Validate exact merged inputs and explicit operator confirmation
+      - name: Validate merged inputs, release tag, and operator confirmation
         env:
           OPERATION: ${{ inputs.operation }}
           SOURCE_COMMIT: ${{ inputs.console_source_commit }}
@@ -65,14 +77,15 @@ jobs:
           CONFIRMATION: ${{ inputs.confirmation }}
         run: |
           set -euo pipefail
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$HIGRESS_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]]
           test "$(git rev-parse HEAD^{commit})" = "$SOURCE_COMMIT"
-          git fetch origin main
-          test "$SOURCE_COMMIT" = "$(git rev-parse origin/main^{commit})"
+          git fetch origin main "refs/tags/v$VERSION:refs/tags/v$VERSION"
           git merge-base --is-ancestor "$SOURCE_COMMIT" origin/main
-          git merge-base --is-ancestor 1aa0c03da2279b8c7d2eec025d39f9951d329bf1 "$SOURCE_COMMIT"
+          tag_commit=$(git rev-parse "refs/tags/v$VERSION^{commit}")
+          [[ "$tag_commit" =~ ^[0-9a-f]{40}$ ]]
           higress_check=$(mktemp -d)
           git -C "$higress_check" init -q
           git -C "$higress_check" remote add canonical https://github.com/higress-group/higress.git
@@ -81,58 +94,89 @@ jobs:
           test "$(git -C "$higress_check" rev-parse "$HIGRESS_COMMIT^{commit}")" = "$HIGRESS_COMMIT"
           git -C "$higress_check" merge-base --is-ancestor "$HIGRESS_COMMIT" "$canonical_main"
           if [ "$OPERATION" = build-candidate ]; then
-            test "$CONFIRMATION" = BUILD_APPROVED_HOTFIX_2.2.4
+            test "$CONFIRMATION" = "BUILD_APPROVED_HOTFIX_$VERSION"
             test -z "$EXPECTED_NEW_DIGEST"
           else
             test "$OPERATION" = replace
-            test "$CONFIRMATION" = REPLACE_APPROVED_HOTFIX_2.2.4
+            test "$CONFIRMATION" = "REPLACE_APPROVED_HOTFIX_$VERSION"
             [[ "$EXPECTED_NEW_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
           fi
+          echo "RELEASE_TAG_COMMIT=$tag_commit" >> "$GITHUB_ENV"
 
       - uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
           version: 1.2.3
 
-      - name: Fetch exact recovery contract and verify merged marketplace inventory
+      - name: Verify recovery contract, release provenance, and previous evidence
         env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_COMMIT: ${{ inputs.console_source_commit }}
           HIGRESS_COMMIT: ${{ inputs.higress_commit }}
           MANIFEST_SHA256: ${{ inputs.recovery_manifest_sha256 }}
           EXPECTED_OLD_DIGEST: ${{ inputs.expected_old_digest }}
+          PREVIOUS_ASSET: ${{ inputs.previous_recovery_asset }}
+          PREVIOUS_SHA256: ${{ inputs.previous_recovery_sha256 }}
         run: |
           set -euo pipefail
+          [[ "$EXPECTED_OLD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
           curl --fail --silent --show-error \
             "https://raw.githubusercontent.com/higress-group/higress/$HIGRESS_COMMIT/$MANIFEST_PATH" \
             -o /tmp/console-recovery.json
           test "$(sha256sum /tmp/console-recovery.json | awk '{print $1}')" = "$MANIFEST_SHA256"
+          jq -e --arg version "$VERSION" --arg image "$IMAGE_REPOSITORY" \
+            '.schemaVersion == 1 and .gatewayVersion == $version and .imageRepository == $image and
+             .requiredSourceBranch == "main" and (.snapshotSha256 | test("^[0-9a-f]{64}$")) and
+             (.originalConsoleCommit | test("^[0-9a-f]{40}$")) and
+             (.originalImageDigest | test("^sha256:[0-9a-f]{64}$")) and (.plugins | type == "array")' \
+            /tmp/console-recovery.json >/dev/null
           original_commit=$(jq -er .originalConsoleCommit /tmp/console-recovery.json)
           manifest_old=$(jq -er .originalImageDigest /tmp/console-recovery.json)
-          required_branch=$(jq -er .requiredSourceBranch /tmp/console-recovery.json)
-          test "$original_commit" = 36aa9c67fb0057164dab9b1fe687b38fe5b8a022
-          test "$manifest_old" = sha256:c8cb47ad0a550e58df4cfee57f2f358eb0b1635a0812c77e04388dfb17bbebb6
-          test "$EXPECTED_OLD_DIGEST" = sha256:4a07fedf9925a2775e9e9b7dfdbf99194651e51a7ee2c0b6bb8fab62e61d2da8
-          test "$required_branch" = main
-          previous_evidence=/tmp/console-image-recovery-2.2.4.json
-          previous_checksum=/tmp/console-image-recovery-2.2.4.json.sha256
-          curl --fail --silent --show-error --location \
-            "https://github.com/higress-group/higress-console/releases/download/v2.2.4/console-image-recovery-2.2.4.json" \
-            -o "$previous_evidence"
-          curl --fail --silent --show-error --location \
-            "https://github.com/higress-group/higress-console/releases/download/v2.2.4/console-image-recovery-2.2.4.json.sha256" \
-            -o "$previous_checksum"
-          (cd /tmp && sha256sum -c "${previous_checksum##*/}")
-          test "$(jq -er .oldDigest "$previous_evidence")" = "$manifest_old"
-          test "$(jq -er .newDigest "$previous_evidence")" = "$EXPECTED_OLD_DIGEST"
-          test "$(jq -er .consoleSourceCommit "$previous_evidence")" = 7118cc192522deb144298175318b3ea91d94c715
-          previous_evidence_sha=$(sha256sum "$previous_evidence" | awk '{print $1}')
-          test "$previous_evidence_sha" = 6efb6fbbb7cb44198bfb503a7f8a93f1d1b7d86c85ed5f08909c453bd581dde4
-          jq -e --arg version "$VERSION" --arg image "$IMAGE_REPOSITORY" \
-            '.schemaVersion == 1 and .gatewayVersion == $version and .imageRepository == $image and (.plugins | length == 8)' \
-            /tmp/console-recovery.json >/dev/null
+          snapshot_sha=$(jq -er .snapshotSha256 /tmp/console-recovery.json)
+          test "$RELEASE_TAG_COMMIT" = "$original_commit"
+          git merge-base --is-ancestor "$original_commit" "$SOURCE_COMMIT"
+
+          mkdir -p /tmp/original-provenance
+          gh release download "v$VERSION" --pattern plugin-release-provenance.json \
+            --dir /tmp/original-provenance
+          gh release download "v$VERSION" --pattern plugin-release-provenance.json.sha256 \
+            --dir /tmp/original-provenance
+          (cd /tmp/original-provenance && sha256sum -c plugin-release-provenance.json.sha256)
+          provenance=/tmp/original-provenance/plugin-release-provenance.json
+          jq -e --arg version "v$VERSION" --arg commit "$original_commit" --arg snapshot "$snapshot_sha" \
+            '.schemaVersion == 1 and .tag == $version and .commit == $commit and
+             .pluginLock.snapshotSha256 == $snapshot' "$provenance" >/dev/null
+          provenance_sha=$(sha256sum "$provenance" | awk '{print $1}')
+
+          if [ -z "$PREVIOUS_ASSET" ] && [ -z "$PREVIOUS_SHA256" ]; then
+            test "$EXPECTED_OLD_DIGEST" = "$manifest_old"
+            previous_asset=""
+            previous_sha=""
+          else
+            test -n "$PREVIOUS_ASSET"
+            [[ "$PREVIOUS_SHA256" =~ ^[0-9a-f]{64}$ ]]
+            [[ "$PREVIOUS_ASSET" =~ ^console-image-recovery-[0-9]+\.[0-9]+\.[0-9]+(-[0-9a-f]{12}){0,2}\.json$ ]]
+            previous_dir=$(mktemp -d)
+            gh release download "v$VERSION" --pattern "$PREVIOUS_ASSET" --dir "$previous_dir"
+            gh release download "v$VERSION" --pattern "$PREVIOUS_ASSET.sha256" --dir "$previous_dir"
+            (cd "$previous_dir" && sha256sum -c "$PREVIOUS_ASSET.sha256")
+            previous_evidence="$previous_dir/$PREVIOUS_ASSET"
+            test "$(sha256sum "$previous_evidence" | awk '{print $1}')" = "$PREVIOUS_SHA256"
+            jq -e --arg version "$VERSION" --arg image "$IMAGE_REPOSITORY" \
+              --arg digest "$EXPECTED_OLD_DIGEST" --arg tagCommit "$original_commit" \
+              '.schemaVersion == 1 and .version == $version and .imageRepository == $image and
+               .newDigest == $digest and .unchangedRelease.tagCommit == $tagCommit' \
+              "$previous_evidence" >/dev/null
+            previous_asset="$PREVIOUS_ASSET"
+            previous_sha="$PREVIOUS_SHA256"
+          fi
           {
             echo "MANIFEST_ORIGINAL_CONSOLE_COMMIT=$original_commit"
             echo "MANIFEST_OLD_DIGEST=$manifest_old"
-            echo "PREVIOUS_RECOVERY_EVIDENCE_SHA256=$previous_evidence_sha"
+            echo "ORIGINAL_PROVENANCE_SHA256=$provenance_sha"
+            echo "PREVIOUS_RECOVERY_ASSET=$previous_asset"
+            echo "PREVIOUS_RECOVERY_EVIDENCE_SHA256=$previous_sha"
           } >> "$GITHUB_ENV"
+
           bundle_cache=/tmp/plugin-marketplace-bundles
           mkdir -p "$bundle_cache"
           while IFS=$'\t' read -r repository source_commit; do
@@ -147,9 +191,26 @@ jobs:
             --sha256 "$MANIFEST_SHA256" --higress-commit "$HIGRESS_COMMIT" --print-bundle-sources)
           inventory_sha=$(python3 tools/render_plugin_snapshot.py --root . \
             --recovery-manifest /tmp/console-recovery.json --sha256 "$MANIFEST_SHA256" \
-            --higress-commit "$HIGRESS_COMMIT" --bundle-cache "$bundle_cache" --validate-recovery-source)
+            --higress-commit "$HIGRESS_COMMIT" --bundle-cache "$bundle_cache" \
+            --expected-version "$VERSION" --validate-recovery-source)
           [[ "$inventory_sha" =~ ^[0-9a-f]{64}$ ]]
-          echo "INVENTORY_SHA256=$inventory_sha" >> "$GITHUB_ENV"
+
+          expected_parent=$(mktemp -d)
+          expected_root="$expected_parent/release"
+          git worktree add --detach "$expected_root" "refs/tags/v$VERSION"
+          python3 tools/render_plugin_snapshot.py --root "$expected_root" \
+            --recovery-manifest /tmp/console-recovery.json --sha256 "$MANIFEST_SHA256" \
+            --higress-commit "$HIGRESS_COMMIT" --bundle-cache "$bundle_cache" --validate-rendered
+          actual_plugins=backend/sdk/src/main/resources/plugins
+          expected_plugins="$expected_root/$actual_plugins"
+          test -z "$(find "$actual_plugins" "$expected_plugins" -type l -print -quit)"
+          actual_tree_sha=$(cd "$actual_plugins" && find . -type f ! -path './plugin-snapshot.lock.json' -print0 | LC_ALL=C sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')
+          expected_tree_sha=$(cd "$expected_plugins" && find . -type f ! -path './plugin-snapshot.lock.json' -print0 | LC_ALL=C sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')
+          test "$actual_tree_sha" = "$expected_tree_sha"
+          {
+            echo "INVENTORY_SHA256=$inventory_sha"
+            echo "PLUGIN_RESOURCES_SHA256=$actual_tree_sha"
+          } >> "$GITHUB_ENV"
 
       - name: Login to the approved production image repository
         env:
@@ -163,11 +224,8 @@ jobs:
           printf '%s' "$REGISTRY_PASSWORD" | oras login "$REGISTRY" --username "$REGISTRY_USERNAME" --password-stdin
 
       - name: Resolve exact current tag state
-        env:
-          EXPECTED_OLD_DIGEST: ${{ inputs.expected_old_digest }}
         run: |
           set -euo pipefail
-          [[ "$EXPECTED_OLD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
           current=$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)
           [[ "$current" =~ ^sha256:[0-9a-f]{64}$ ]]
           echo "CURRENT_DIGEST=$current" >> "$GITHUB_ENV"
@@ -184,7 +242,8 @@ jobs:
             --higress-commit "$HIGRESS_COMMIT" \
             --manifest-original-console-commit "$MANIFEST_ORIGINAL_CONSOLE_COMMIT" \
             --manifest-old-digest "$MANIFEST_OLD_DIGEST" --expected-old-digest "$EXPECTED_OLD_DIGEST" \
-            --current-digest "$CURRENT_DIGEST" --source-is-merged true
+            --current-digest "$CURRENT_DIGEST" --source-is-merged true --source-descends-release true \
+            --release-tag-matches-manifest true --old-digest-is-authorized true
 
       - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         if: ${{ inputs.operation == 'build-candidate' }}
@@ -198,7 +257,7 @@ jobs:
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         if: ${{ inputs.operation == 'build-candidate' }}
 
-      - name: Build reviewed hotfix candidate without touching 2.2.4
+      - name: Build reviewed hotfix candidate without touching the release tag
         if: ${{ inputs.operation == 'build-candidate' }}
         env:
           SOURCE_COMMIT: ${{ inputs.console_source_commit }}
@@ -207,7 +266,7 @@ jobs:
         run: |
           set -euo pipefail
           mvn clean package -DskipTests=true -Dapp.build.version="$VERSION" -Dapp.build.dev=false -f ./backend/pom.xml
-          candidate_tag="recovery-candidate-2.2.4-${SOURCE_COMMIT:0:12}"
+          candidate_tag="recovery-candidate-$VERSION-${SOURCE_COMMIT:0:12}"
           docker buildx build ./backend --platform linux/amd64,linux/arm64 --push \
             --tag "$IMAGE_REPOSITORY:$candidate_tag" \
             --label "org.opencontainers.image.revision=$SOURCE_COMMIT" \
@@ -217,9 +276,9 @@ jobs:
           candidate_digest=$(oras manifest fetch "$IMAGE_REPOSITORY:$candidate_tag" --descriptor | jq -er .digest)
           [[ "$candidate_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
           {
-            echo "## Console 2.2.4 recovery candidate"
+            echo "## Console $VERSION recovery candidate"
             echo "Candidate: \`$IMAGE_REPOSITORY@$candidate_digest\`"
-            echo "This step did not write \`$IMAGE_REPOSITORY:$VERSION\`. Re-run with operation=replace and expected_new_digest=$candidate_digest after review."
+            echo "The release tag was not changed. Re-run with operation=replace and expected_new_digest=$candidate_digest after review."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate approved candidate and replacement state
@@ -238,7 +297,8 @@ jobs:
             --manifest-original-console-commit "$MANIFEST_ORIGINAL_CONSOLE_COMMIT" \
             --manifest-old-digest "$MANIFEST_OLD_DIGEST" --expected-old-digest "$EXPECTED_OLD_DIGEST" \
             --expected-new-digest "$EXPECTED_NEW_DIGEST" --current-digest "$CURRENT_DIGEST" \
-            --candidate-digest "$candidate" --source-is-merged true | jq -er .mode)
+            --candidate-digest "$candidate" --source-is-merged true --source-descends-release true \
+            --release-tag-matches-manifest true --old-digest-is-authorized true | jq -er .mode)
           echo "RECOVERY_MODE=$mode" >> "$GITHUB_ENV"
 
       - name: Verify candidate platform labels
@@ -262,7 +322,7 @@ jobs:
                ."io.higress.marketplace-recovery-higress-commit" == $higress' <<<"$labels" >/dev/null
           done </tmp/candidate-runnable-digests
 
-      - name: Replace only the exact approved 2.2.4 tag
+      - name: Replace only the exact approved release tag
         if: ${{ inputs.operation == 'replace' && env.RECOVERY_MODE == 'replace' }}
         env:
           EXPECTED_OLD_DIGEST: ${{ inputs.expected_old_digest }}
@@ -271,9 +331,7 @@ jobs:
           set -euo pipefail
           pre_copy_current=$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)
           python3 tools/verify_console_image_recovery.py --pre-copy-mode "$RECOVERY_MODE" \
-            --pre-copy-current-digest "$pre_copy_current" \
-            --manifest-old-digest "$MANIFEST_OLD_DIGEST" \
-            --expected-old-digest "$EXPECTED_OLD_DIGEST" >/dev/null
+            --pre-copy-current-digest "$pre_copy_current" --expected-old-digest "$EXPECTED_OLD_DIGEST" >/dev/null
           oras cp "$IMAGE_REPOSITORY@$EXPECTED_NEW_DIGEST" "$IMAGE_REPOSITORY:$VERSION"
           test "$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)" = "$EXPECTED_NEW_DIGEST"
 
@@ -290,25 +348,30 @@ jobs:
           set -euo pipefail
           final=$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)
           test "$final" = "$EXPECTED_NEW_DIGEST"
-          mkdir -p /tmp/original-provenance
-          gh release download "v$VERSION" --pattern plugin-release-provenance.json --dir /tmp/original-provenance
-          provenance_sha=$(sha256sum /tmp/original-provenance/plugin-release-provenance.json | awk '{print $1}')
-          chart_ref=$(jq -er .chart.ref /tmp/original-provenance/plugin-release-provenance.json)
-          chart_digest=$(jq -er .chart.digest /tmp/original-provenance/plugin-release-provenance.json)
-          tag_commit=$(jq -er .commit /tmp/original-provenance/plugin-release-provenance.json)
-          evidence_basename="console-image-recovery-2.2.4-${SOURCE_COMMIT:0:12}"
+          provenance=/tmp/original-provenance/plugin-release-provenance.json
+          chart_ref=$(jq -er .chart.ref "$provenance")
+          chart_digest=$(jq -er .chart.digest "$provenance")
+          tag_commit=$(jq -er .commit "$provenance")
+          evidence_basename="console-image-recovery-$VERSION-${SOURCE_COMMIT:0:12}-${EXPECTED_NEW_DIGEST:7:12}"
+          test "$PREVIOUS_RECOVERY_ASSET" != "$evidence_basename.json"
+          previous=null
+          if [ -n "$PREVIOUS_RECOVERY_ASSET" ]; then
+            previous=$(jq -cn --arg asset "$PREVIOUS_RECOVERY_ASSET" \
+              --arg sha "$PREVIOUS_RECOVERY_EVIDENCE_SHA256" --arg resulting "$EXPECTED_OLD_DIGEST" \
+              '{asset:$asset,sha256:$sha,resultingDigest:$resulting}')
+          fi
           jq -cnS --arg version "$VERSION" --arg image "$IMAGE_REPOSITORY" \
             --arg old "$EXPECTED_OLD_DIGEST" --arg new "$EXPECTED_NEW_DIGEST" \
             --arg source "$SOURCE_COMMIT" --arg higress "$HIGRESS_COMMIT" --arg manifest "$MANIFEST_SHA256" \
-            --arg inventory "$INVENTORY_SHA256" --arg provenance "$provenance_sha" \
-            --arg previousEvidenceSha "$PREVIOUS_RECOVERY_EVIDENCE_SHA256" \
+            --arg inventory "$INVENTORY_SHA256" --arg resources "$PLUGIN_RESOURCES_SHA256" \
+            --arg provenance "$ORIGINAL_PROVENANCE_SHA256" \
             --arg tagCommit "$tag_commit" --arg chartRef "$chart_ref" --arg chartDigest "$chart_digest" \
+            --argjson previous "$previous" \
             '{schemaVersion:1,version:$version,imageRepository:$image,oldDigest:$old,newDigest:$new,
               consoleSourceCommit:$source,higressCommit:$higress,recoveryManifestSha256:$manifest,
-              marketplaceInventorySha256:$inventory,unchangedRelease:{tagCommit:$tagCommit,chartRef:$chartRef,
-              chartDigest:$chartDigest,pluginReleaseProvenanceSha256:$provenance},
-              previousRecovery:{asset:"console-image-recovery-2.2.4.json",sha256:$previousEvidenceSha,
-              resultingDigest:$old}}' \
+              marketplaceInventorySha256:$inventory,pluginResourcesSha256:$resources,
+              unchangedRelease:{tagCommit:$tagCommit,chartRef:$chartRef,
+              chartDigest:$chartDigest,pluginReleaseProvenanceSha256:$provenance},previousRecovery:$previous}' \
             > "$evidence_basename.json"
           sha256sum "$evidence_basename.json" > "$evidence_basename.json.sha256"
           mkdir -p /tmp/existing-recovery
@@ -321,4 +384,4 @@ jobs:
               gh release upload "v$VERSION" "$asset"
             fi
           done
-          echo "Recovered \`$IMAGE_REPOSITORY:$VERSION@$EXPECTED_NEW_DIGEST\`; the Git release tag, chart, and plugin provenance asset were not modified." >> "$GITHUB_STEP_SUMMARY"
+          echo "Recovered \`$IMAGE_REPOSITORY:$VERSION@$EXPECTED_NEW_DIGEST\`; the Git tag, chart, and plugin provenance asset were not modified." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -28,7 +28,7 @@ Configure these protected Environments in `higress-group/higress-console`:
 
 | Environment | Allowed deployment refs | Variables | Secrets |
 | --- | --- | --- | --- |
-| `console-chart-production` | Release tags matching `v*.*.*` | `CONSOLE_CHART_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com/higress`; `CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS=true` | `CONSOLE_CHART_REGISTRY_USERNAME`, `CONSOLE_CHART_REGISTRY_PASSWORD`; existing OSS publisher secrets `ACCESS_KEYID`, `ACCESS_KEYSECRET` if they are not retained as repository secrets |
+| `console-chart-production` | `main` and release tags matching `v*.*.*` | `CONSOLE_CHART_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com/higress`; `CONSOLE_CHART_REGISTRY_IMMUTABLE_TAGS=true` | `CONSOLE_CHART_REGISTRY_USERNAME`, `CONSOLE_CHART_REGISTRY_PASSWORD`; existing OSS publisher secrets `ACCESS_KEYID`, `ACCESS_KEYSECRET` if they are not retained as repository secrets |
 | `console-plugin-sync` | `main` | `CONSOLE_RELEASE_APP_ID` | `CONSOLE_RELEASE_APP_PRIVATE_KEY` |
 
 The OCI publisher credential must write only the
@@ -37,13 +37,13 @@ publisher credential. The snapshot receiver uses the release automation GitHub
 App private key only from `console-plugin-sync`; its dry run never requests an
 App token or creates a branch/PR.
 
-The one-time, not-yet-public `2.2.4` Console image repair reuses the existing
-`console-chart-production` reviewers and the repository-level
+Guarded Console image recovery reuses the existing `console-chart-production`
+reviewers and the repository-level
 `PRODUCTION_REGISTRY_USERNAME` / `PRODUCTION_REGISTRY_PASSWORD` image
-credentials. It does not use the chart registry credentials. Before that
-manual dispatch, temporarily add the exact `main` branch to the Environment's
-allowed deployment refs; the existing `v*` tag rule alone does not admit a
-merged source commit. The temporary branch rule may be removed after recovery.
+credentials. It does not use the chart registry credentials. Keep `main` in
+the Environment's allowed deployment refs because manual recovery dispatches
+run from the protected default branch while checking out an exact merged
+source commit.
 
 The Standalone receiver has a separate protected Environment in
 `higress-group/higress-standalone`: `standalone-release-sync` (normally limited
@@ -68,47 +68,51 @@ neither OCI nor OSS artifacts. A tagged release is the only path that enters
 `<CONSOLE_CHART_REGISTRY>/higress-console:<version>` before the release
 provenance workflow resolves and records its digest.
 
-## One-time not-yet-public Console 2.2.4 image recovery
+## Guarded Console image recovery
 
-This exception replaces only
-`higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console:2.2.4`. It does
-not rebuild or overwrite the `v2.2.4` Git tag, GitHub Release, Helm chart,
-plugin-server image, plugin images, or the existing
-`plugin-release-provenance.json` asset.
+Prefer a new patch release for a released Console defect. `Recover Console
+Image` is the generic emergency path for an explicitly approved replacement of
+`higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console:<version>`. It
+does not move the Git tag or modify the GitHub Release, Helm chart,
+plugin-server image, plugin images, or `plugin-release-provenance.json`.
 
-1. Merge the Higress marketplace bundle/catalog PR, then merge the Console
-   resource/renderer PR. Record both exact merged `main` commits and the
-   SHA-256 of
-   `plugins/release/console-recovery/2.2.4.json` from the Higress commit.
-2. Confirm that the manifest fixes the original Console commit to
-   `36aa9c67fb0057164dab9b1fe687b38fe5b8a022` and the original
-   `higress/console:2.2.4` multi-platform digest to
-   `sha256:c8cb47ad0a550e58df4cfee57f2f358eb0b1635a0812c77e04388dfb17bbebb6`.
-   The workflow accepts only this digest as `expected_old_digest`; changing
-   the input cannot authorize a second replacement. Keep the ACR immutable-tag
-   rule enabled.
-3. Run `Recover Not-Yet-Public Console 2.2.4 Image` with operation
-   `build-candidate`, both exact commits, the manifest hash, the fixed original
-   manifest digest as `expected_old_digest`, no new digest, and confirmation
-   `BUILD_NOT_YET_PUBLIC_2.2.4`. The workflow verifies merged marketplace
-   bytes and publishes only a source-addressed recovery candidate. Copy its
-   reported digest from the run summary.
-4. Independently inspect the candidate digest and marketplace inventory. Only
-   then temporarily relax the ACR immutable rule that covers the single
+Before dispatching it, merge a reviewed Higress recovery manifest at
+`plugins/release/console-recovery/<version>.json`. The manifest binds the
+stable release version, original Console tag commit and image digest, plugin
+snapshot, marketplace source files and hashes, and the production Console
+repository. The exact manifest commit must be on canonical Higress `main`.
+The Console hotfix source must likewise be an exact commit already merged into
+canonical Console `main` and must descend from the release tag.
+
+1. Record the version, exact Console hotfix commit, exact Higress manifest
+   commit, manifest SHA-256, and current Console image digest. Keep the ACR
+   immutable-tag rule enabled.
+2. For the first replacement, set `expected_old_digest` to the manifest's
+   `originalImageDigest` and leave both previous-recovery inputs empty. For a
+   later replacement, set it to the current digest and provide the immediately
+   preceding `console-image-recovery-*.json` release asset name and exact
+   SHA-256. The workflow requires that evidence's `newDigest` to equal the
+   expected old digest.
+3. Run `Recover Console Image` with operation `build-candidate`, no new digest,
+   and confirmation `BUILD_APPROVED_HOTFIX_<version>`. The protected job
+   verifies the release provenance and evidence chain, reconstructs the full
+   plugin resource tree from the release tag plus the reviewed manifest,
+   compares it with the merged source, and publishes only a source-addressed
+   multi-platform candidate.
+4. Independently inspect the candidate digest, platforms, labels, and plugin
+   inventory. Only then temporarily relax the immutable rule for the single
    `higress/console` repository.
-5. Run the same workflow with operation `replace`, the same commits, manifest
-   hash and the same fixed old digest, the reviewed candidate as
-   `expected_new_digest`, and confirmation `REPLACE_NOT_YET_PUBLIC_2.2.4`.
-   The protected job refuses a
-   non-2.2.4 target, unmerged source, stale current digest, candidate-label
-   drift, or a different candidate digest.
-6. Verify the new `higress/console:2.2.4` digest and the eight-plugin market
-   inventory, then immediately restore the ACR immutable rule. The workflow
-   uploads separately named immutable recovery evidence to the existing
-   `v2.2.4` release and records the unchanged tag/chart/provenance identity.
+5. Run the same workflow with operation `replace`, identical contract inputs,
+   the reviewed candidate digest as `expected_new_digest`, and confirmation
+   `REPLACE_APPROVED_HOTFIX_<version>`. Immediately before copying the digest,
+   the workflow repeats the current-tag comparison to reject concurrent or
+   stale updates.
+6. Verify the stable tag digest and restore the ACR immutable rule. The
+   workflow appends content-addressed recovery evidence to the existing
+   release, including the previous evidence link when present and the
+   unchanged tag/chart/provenance identity.
 
-An identical retry accepts the already-replaced digest and reuses byte-equal
-recovery evidence. A later different digest fails because the operator's old
-digest must still equal the immutable original digest in the manifest. All
-subsequent Console versions use the normal immutable tag
-path; this workflow remains hard-coded to `2.2.4`.
+An identical retry recognizes the already-replaced digest and requires the
+existing evidence assets to be byte-identical. A different follow-up digest
+must extend the evidence chain; an arbitrary `expected_old_digest` cannot
+authorize an overwrite.

--- a/tools/render_plugin_snapshot.py
+++ b/tools/render_plugin_snapshot.py
@@ -30,9 +30,10 @@ ALLOWED_TARGETS = {"spec.yaml", "README.md", "README_EN.md", "icon.png"}
 REQUIRED_TARGETS = {"spec.yaml", "README.md", "README_EN.md"}
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 SAFE_ID_RE = re.compile(r"^[a-z0-9]+(?:[a-z0-9._-]*[a-z0-9])?$")
-ORIGINAL_CONSOLE_COMMIT = "36aa9c67fb0057164dab9b1fe687b38fe5b8a022"
-ORIGINAL_IMAGE_DIGEST = "sha256:c8cb47ad0a550e58df4cfee57f2f358eb0b1635a0812c77e04388dfb17bbebb6"
+CONSOLE_IMAGE_REPOSITORY = "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console"
 PLUGIN_RESOURCE_PARTS = ("backend", "sdk", "src", "main", "resources", "plugins")
 DIRECTORY_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
 
@@ -59,13 +60,27 @@ def replace_version(spec, version):
     return updated
 
 
-def validate_recovery_manifest_contract(manifest):
-    if (manifest.get("schemaVersion") != 1 or manifest.get("gatewayVersion") != "2.2.4" or
-            manifest.get("imageRepository") != "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console" or
-            manifest.get("originalConsoleCommit") != ORIGINAL_CONSOLE_COMMIT or
-            manifest.get("originalImageDigest") != ORIGINAL_IMAGE_DIGEST or
-            manifest.get("requiredSourceBranch") != "main"):
-        raise ValueError("recovery manifest is restricted to the fixed original higress/console:2.2.4 image")
+def validate_recovery_manifest_contract(manifest, expected_version=None):
+    version = manifest.get("gatewayVersion")
+    if manifest.get("schemaVersion") != 1:
+        raise ValueError("unsupported recovery manifest schema")
+    if not VERSION_RE.fullmatch(version or "") or (expected_version and version != expected_version):
+        raise ValueError("recovery manifest gateway version is invalid or unexpected")
+    if manifest.get("snapshotPath") != "plugins/release/snapshots/" + version + ".json":
+        raise ValueError("recovery manifest snapshot path does not match its gateway version")
+    if not SHA_RE.fullmatch(manifest.get("snapshotSha256", "")):
+        raise ValueError("recovery manifest snapshot SHA-256 is invalid")
+    if manifest.get("imageRepository") != CONSOLE_IMAGE_REPOSITORY:
+        raise ValueError("recovery manifest targets an unsupported image repository")
+    if not COMMIT_RE.fullmatch(manifest.get("originalConsoleCommit", "")):
+        raise ValueError("recovery manifest original Console commit is invalid")
+    if not DIGEST_RE.fullmatch(manifest.get("originalImageDigest", "")):
+        raise ValueError("recovery manifest original image digest is invalid")
+    if manifest.get("requiredSourceBranch") != "main":
+        raise ValueError("recovery manifest must require the canonical main branch")
+    if not isinstance(manifest.get("plugins"), list):
+        raise ValueError("recovery manifest plugins must be a list")
+    return version
 
 
 def validate_spec(spec, resource):
@@ -408,7 +423,7 @@ def render_recovery(root, manifest_path, expected_sha256, bundle_cache, higress_
     if sha256(raw) != expected_sha256:
         raise ValueError("recovery manifest SHA-256 mismatch")
     manifest = json.loads(raw)
-    validate_recovery_manifest_contract(manifest)
+    version = validate_recovery_manifest_contract(manifest)
     with PluginResourceStore(root) as store:
         store.preflight_file("plugins.properties")
         store.preflight_file("plugin-snapshot.lock.json")
@@ -417,7 +432,7 @@ def render_recovery(root, manifest_path, expected_sha256, bundle_cache, higress_
             raise ValueError("recovery manifest does not match the unchanged Console snapshot lock")
         lock["schemaVersion"] = 2
         lock["marketplaceRecovery"] = {
-            "gatewayVersion": "2.2.4", "manifestSha256": expected_sha256,
+            "gatewayVersion": version, "manifestSha256": expected_sha256,
             "higressCommit": higress_commit, "imageRepository": manifest["imageRepository"],
             "originalConsoleCommit": manifest["originalConsoleCommit"],
             "originalImageDigest": manifest["originalImageDigest"],
@@ -427,10 +442,13 @@ def render_recovery(root, manifest_path, expected_sha256, bundle_cache, higress_
         store.write_text("plugin-snapshot.lock.json", json.dumps(lock, indent=2, sort_keys=True) + "\n")
 
 
-def validate_recovery_source(root, manifest, bundle_cache, higress_commit):
+def validate_recovery_source(root, manifest, bundle_cache, higress_commit, expected_version=None):
     """Prove merged Console bytes match the reviewed recovery manifest without mutation."""
-    validate_recovery_manifest_contract(manifest)
+    validate_recovery_manifest_contract(manifest, expected_version)
     with PluginResourceStore(root) as store:
+        lock = json.loads(store.read_text("plugin-snapshot.lock.json"))
+        if lock.get("snapshotSha256") != manifest.get("snapshotSha256"):
+            raise ValueError("recovery manifest does not match the merged Console snapshot lock")
         properties = store.read_text("plugins.properties").splitlines()
         property_map = dict(line.split("=", 1) for line in properties if line and not line.startswith("#"))
         inventory = []
@@ -447,6 +465,10 @@ def validate_recovery_source(root, manifest, bundle_cache, higress_commit):
             seen_resources.add(resource)
             mappings.append((plugin, mapping, key, resource))
         for plugin, mapping, key, resource in mappings:
+            if (not VERSION_RE.fullmatch(plugin.get("version", "")) or
+                    not DIGEST_RE.fullmatch(plugin.get("digest", "")) or
+                    not plugin.get("ociRef", "").endswith(":" + plugin.get("version", ""))):
+                raise ValueError(key + " recovery plugin identity is malformed")
             if property_map.get(key) != "oci://" + plugin.get("ociRef", ""):
                 raise ValueError(key + " merged properties do not match recovery artifact")
             bundle = mapping.get("marketplace")
@@ -517,6 +539,7 @@ def main():
     parser.add_argument("--base-sha")
     parser.add_argument("--print-bundle-sources", action="store_true")
     parser.add_argument("--validate-recovery-source", action="store_true")
+    parser.add_argument("--expected-version")
     parser.add_argument("--validate-rendered", action="store_true")
     args = parser.parse_args()
     try:
@@ -535,7 +558,8 @@ def main():
         if args.validate_recovery_source:
             if not args.recovery_manifest:
                 raise ValueError("recovery source validation requires --recovery-manifest")
-            print(validate_recovery_source(root, document, cache, args.higress_commit))
+            print(validate_recovery_source(root, document, cache, args.higress_commit,
+                                           args.expected_version))
             return 0
         if args.snapshot:
             render(root, document_path, args.sha256, args.plugin_server_commit, args.plugin_server_image,

--- a/tools/test_render_plugin_snapshot.py
+++ b/tools/test_render_plugin_snapshot.py
@@ -242,30 +242,31 @@ class RenderTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "immutable"):
                 renderer.bundle_sources({"plugins": [self.plugin(bundle)]}, HIGRESS_COMMIT)
 
-    def test_recovery_is_exactly_224_and_binds_existing_snapshot_lock(self):
+    def test_recovery_contract_is_version_independent_and_binds_snapshot_lock(self):
         with tempfile.TemporaryDirectory() as temp:
             work = self.workspace(temp)
             cache, bundle = self.cache_bundle(temp, renderer.HIGRESS_REPOSITORY, HIGRESS_COMMIT)
             current = json.loads((work / "backend/sdk/src/main/resources/plugins/plugin-snapshot.lock.json").read_text())
-            manifest = {"schemaVersion": 1, "gatewayVersion": "2.2.4",
+            manifest = {"schemaVersion": 1, "gatewayVersion": "3.1.0",
+                        "snapshotPath": "plugins/release/snapshots/3.1.0.json",
                         "snapshotSha256": current["snapshotSha256"],
-                        "imageRepository": "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console",
-                        "originalConsoleCommit": renderer.ORIGINAL_CONSOLE_COMMIT,
-                        "originalImageDigest": renderer.ORIGINAL_IMAGE_DIGEST,
+                        "imageRepository": renderer.CONSOLE_IMAGE_REPOSITORY,
+                        "originalConsoleCommit": "c" * 40,
+                        "originalImageDigest": "sha256:" + "d" * 64,
                         "requiredSourceBranch": "main",
                         "plugins": [dict(self.plugin(bundle), console=self.plugin(bundle)["consumers"]["console"])]}
             manifest["plugins"][0].pop("consumers")
             path = pathlib.Path(temp) / "recovery.json"; path.write_text(json.dumps(manifest))
             digest = hashlib.sha256(path.read_bytes()).hexdigest()
             renderer.render_recovery(work, path, digest, cache, HIGRESS_COMMIT)
-            self.assertEqual(renderer.validate_rendered(work)["marketplaceRecovery"]["gatewayVersion"], "2.2.4")
-            manifest["gatewayVersion"] = "2.2.5"; path.write_text(json.dumps(manifest))
-            with self.assertRaisesRegex(ValueError, "restricted"):
+            self.assertEqual(renderer.validate_rendered(work)["marketplaceRecovery"]["gatewayVersion"], "3.1.0")
+            manifest["gatewayVersion"] = "3.1.1"; path.write_text(json.dumps(manifest))
+            with self.assertRaisesRegex(ValueError, "snapshot path"):
                 renderer.render_recovery(work, path, hashlib.sha256(path.read_bytes()).hexdigest(), cache, HIGRESS_COMMIT)
-            manifest["gatewayVersion"] = "2.2.4"
-            manifest["originalImageDigest"] = "sha256:" + "0" * 64
+            manifest["gatewayVersion"] = "3.1.0"
+            manifest["originalImageDigest"] = "invalid"
             path.write_text(json.dumps(manifest))
-            with self.assertRaisesRegex(ValueError, "fixed original"):
+            with self.assertRaisesRegex(ValueError, "original image digest"):
                 renderer.render_recovery(work, path, hashlib.sha256(path.read_bytes()).hexdigest(), cache, HIGRESS_COMMIT)
 
     def test_real_224_marketplace_inventory_contains_all_recovered_plugins(self):

--- a/tools/test_verify_console_image_recovery.py
+++ b/tools/test_verify_console_image_recovery.py
@@ -30,75 +30,63 @@ SPEC.loader.exec_module(recovery)
 
 class RecoveryContractTest(unittest.TestCase):
     def values(self):
-        return dict(operation="replace", version="2.2.4", image_repository=recovery.IMAGE_REPOSITORY,
+        return dict(operation="replace", version="3.1.0", image_repository=recovery.IMAGE_REPOSITORY,
                     source_commit="a" * 40, higress_commit="b" * 40,
-                    manifest_original_console_commit=recovery.ORIGINAL_CONSOLE_COMMIT,
-                    manifest_old_digest=recovery.ORIGINAL_IMAGE_DIGEST,
-                    expected_old_digest=recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
+                    manifest_original_console_commit="c" * 40,
+                    manifest_old_digest="sha256:" + "c" * 64,
+                    expected_old_digest="sha256:" + "c" * 64,
                     expected_new_digest="sha256:" + "d" * 64,
-                    current_digest=recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                    candidate_digest="sha256:" + "d" * 64, source_is_merged=True)
+                    current_digest="sha256:" + "c" * 64,
+                    candidate_digest="sha256:" + "d" * 64, source_is_merged=True,
+                    source_descends_release=True, release_tag_matches_manifest=True,
+                    old_digest_is_authorized=True)
 
-    def test_exact_replacement_and_idempotent_retry(self):
+    def test_exact_replacement_and_idempotent_retry_are_version_independent(self):
         values = self.values()
         self.assertEqual(recovery.validate(**values), "replace")
         values["current_digest"] = values["expected_new_digest"]
         self.assertEqual(recovery.validate(**values), "already-replaced")
+        values.update(version="2.2.4", current_digest=values["expected_old_digest"])
+        self.assertEqual(recovery.validate(**values), "replace")
 
-    def test_rejects_other_version_stale_digest_unmerged_source_and_candidate_drift(self):
-        for field, value in (("version", "2.2.5"), ("source_commit", "invalid"),
+    def test_rejects_invalid_version_stale_digest_unmerged_source_and_candidate_drift(self):
+        for field, value in (("version", "latest"), ("version", "3.1.0-rc1"),
+                             ("source_commit", "invalid"),
                              ("current_digest", "sha256:" + "e" * 64),
-                             ("source_is_merged", False), ("candidate_digest", "sha256:" + "e" * 64)):
+                             ("source_is_merged", False), ("source_descends_release", False),
+                             ("release_tag_matches_manifest", False),
+                             ("old_digest_is_authorized", False),
+                             ("candidate_digest", "sha256:" + "e" * 64)):
             with self.subTest(field=field):
                 values = self.values(); values[field] = value
                 with self.assertRaises(ValueError):
                     recovery.validate(**values)
 
-    def test_candidate_build_requires_old_digest_and_cannot_preapprove_new_digest(self):
+    def test_candidate_build_requires_current_authorized_digest_and_cannot_preapprove_new_digest(self):
         values = self.values(); values.update(operation="build-candidate", expected_new_digest="", candidate_digest="")
         self.assertEqual(recovery.validate(**values), "build")
         values["expected_new_digest"] = "sha256:" + "d" * 64
         with self.assertRaises(ValueError):
             recovery.validate(**values)
 
-    def test_approved_replacement_base_prevents_an_unreviewed_chain(self):
+    def test_rejects_malformed_manifest_digest_without_hardcoded_release_values(self):
         values = self.values()
-        values["expected_old_digest"] = values["expected_new_digest"]
-        values["current_digest"] = values["expected_new_digest"]
-        values["expected_new_digest"] = "sha256:" + "e" * 64
-        values["candidate_digest"] = values["expected_new_digest"]
-        with self.assertRaisesRegex(ValueError, "approved replacement base"):
+        values["manifest_old_digest"] = "invalid"
+        with self.assertRaisesRegex(ValueError, "manifest old digest"):
             recovery.validate(**values)
-
-    def test_rejects_mismatched_fixed_old_manifest(self):
         values = self.values()
         values["manifest_old_digest"] = "sha256:" + "f" * 64
-        values["expected_old_digest"] = values["manifest_old_digest"]
-        values["current_digest"] = values["manifest_old_digest"]
-        with self.assertRaisesRegex(ValueError, "fixed original image digest"):
-            recovery.validate(**values)
+        self.assertEqual(recovery.validate(**values), "replace")
 
-    def test_pre_copy_recheck_requires_the_approved_replacement_base(self):
-        self.assertEqual(recovery.validate_pre_copy("replace", recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                                                    recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                                                    recovery.ORIGINAL_IMAGE_DIGEST), "copy")
+    def test_pre_copy_recheck_is_generic_and_race_safe(self):
+        old = "sha256:" + "c" * 64
+        self.assertEqual(recovery.validate_pre_copy("replace", old, old), "copy")
         with self.assertRaisesRegex(ValueError, "tag changed after validation"):
-            recovery.validate_pre_copy("replace", "sha256:" + "e" * 64,
-                                       recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                                       recovery.ORIGINAL_IMAGE_DIGEST)
-        with self.assertRaisesRegex(ValueError, "approved replacement base"):
-            recovery.validate_pre_copy("replace", "sha256:" + "e" * 64,
-                                       "sha256:" + "e" * 64,
-                                       recovery.ORIGINAL_IMAGE_DIGEST)
-        with self.assertRaisesRegex(ValueError, "fixed original image digest"):
-            recovery.validate_pre_copy("replace", recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                                       recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                                       "sha256:" + "e" * 64)
+            recovery.validate_pre_copy("replace", "sha256:" + "e" * 64, old)
 
     def test_already_replaced_mode_remains_an_idempotent_no_copy(self):
         self.assertEqual(recovery.validate_pre_copy("already-replaced", "sha256:" + "d" * 64,
-                                                    recovery.REPLACEMENT_BASE_IMAGE_DIGEST,
-                                                    recovery.ORIGINAL_IMAGE_DIGEST), "skip")
+                                                    "sha256:" + "c" * 64), "skip")
 
     def descriptor(self, architecture, digest_char, *, os_name="linux"):
         return {"mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -151,40 +139,38 @@ class RecoveryContractTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.splitlines(), ["sha256:" + "a" * 64, "sha256:" + "b" * 64])
 
-    def test_workflow_uses_existing_protected_environment_and_production_image_secrets(self):
-        workflow_path = ROOT / ".github/workflows/recover-console-image-2.2.4.yaml"
+    def test_workflow_is_generic_guarded_and_uses_production_secrets(self):
+        workflow_path = ROOT / ".github/workflows/recover-console-image.yaml"
         raw = workflow_path.read_text(encoding="utf-8")
         self.assertIn("environment: console-chart-production", raw)
         self.assertIn("secrets.PRODUCTION_REGISTRY_USERNAME", raw)
         self.assertIn("secrets.PRODUCTION_REGISTRY_PASSWORD", raw)
         self.assertNotIn("CONSOLE_CHART_REGISTRY_USERNAME", raw)
         self.assertNotIn("CONSOLE_CHART_REGISTRY_PASSWORD", raw)
-        self.assertIn("higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console", raw)
-        self.assertIn("REPLACE_APPROVED_HOTFIX_2.2.4", raw)
+        self.assertIn("VERSION: ${{ inputs.version }}", raw)
+        self.assertIn("plugins/release/console-recovery/${{ inputs.version }}.json", raw)
+        self.assertIn('test "$CONFIRMATION" = "REPLACE_APPROVED_HOTFIX_$VERSION"', raw)
         self.assertIn("git merge-base --is-ancestor", raw)
         self.assertIn("https://github.com/higress-group/higress.git", raw)
-        self.assertIn(recovery.ORIGINAL_CONSOLE_COMMIT, raw)
-        self.assertIn(recovery.ORIGINAL_IMAGE_DIGEST, raw)
-        self.assertIn(recovery.REQUIRED_HOTFIX_COMMIT, raw)
-        self.assertIn('test "$SOURCE_COMMIT" = "$(git rev-parse origin/main^{commit})"', raw)
-        self.assertIn('git merge-base --is-ancestor 1aa0c03da2279b8c7d2eec025d39f9951d329bf1 "$SOURCE_COMMIT"', raw)
-        self.assertIn(recovery.REPLACEMENT_BASE_IMAGE_DIGEST, raw)
-        self.assertIn("6efb6fbbb7cb44198bfb503a7f8a93f1d1b7d86c85ed5f08909c453bd581dde4", raw)
-        self.assertIn('test "$(jq -er .newDigest "$previous_evidence")" = "$EXPECTED_OLD_DIGEST"', raw)
-        self.assertIn('--manifest-old-digest "$MANIFEST_OLD_DIGEST"', raw)
-        self.assertIn('evidence_basename="console-image-recovery-2.2.4-${SOURCE_COMMIT:0:12}"', raw)
-        self.assertIn('previousRecovery:{asset:"console-image-recovery-2.2.4.json"', raw)
+        self.assertNotIn("1aa0c03da2279b8c7d2eec025d39f9951d329bf1", raw)
+        self.assertNotIn("sha256:4a07fedf9925a2775e9e9b7dfdbf99194651e51a7ee2c0b6bb8fab62e61d2da8", raw)
+        self.assertIn("previous_recovery_asset", raw)
+        self.assertIn('.newDigest == $digest', raw)
+        self.assertIn('--expected-version "$VERSION"', raw)
+        self.assertIn('git worktree add --detach "$expected_root" "refs/tags/v$VERSION"', raw)
+        self.assertIn('test "$actual_tree_sha" = "$expected_tree_sha"', raw)
+        self.assertIn('pluginResourcesSha256:$resources', raw)
+        self.assertIn('evidence_basename="console-image-recovery-$VERSION-${SOURCE_COMMIT:0:12}-${EXPECTED_NEW_DIGEST:7:12}"', raw)
         self.assertIn("--index-file /tmp/candidate-index.json", raw)
-        copy_start = raw.index("- name: Replace only the exact approved 2.2.4 tag")
+        copy_start = raw.index("- name: Replace only the exact approved release tag")
         copy_end = raw.index("- name: Publish separate immutable recovery evidence", copy_start)
         copy_step = raw[copy_start:copy_end]
         recheck = 'pre_copy_current=$(oras manifest fetch "$IMAGE_REPOSITORY:$VERSION" --descriptor | jq -er .digest)'
         self.assertIn(recheck, copy_step)
         self.assertIn('--pre-copy-current-digest "$pre_copy_current"', copy_step)
-        self.assertIn('--manifest-old-digest "$MANIFEST_OLD_DIGEST"', copy_step)
         self.assertIn('--expected-old-digest "$EXPECTED_OLD_DIGEST"', copy_step)
         self.assertLess(copy_step.index(recheck), copy_step.index('oras cp "$IMAGE_REPOSITORY@$EXPECTED_NEW_DIGEST"'))
-        self.assertIn("group: console-image-publish-v2.2.4", raw)
+        self.assertIn("group: console-image-publish-v${{ inputs.version }}", raw)
         publisher = (ROOT / ".github/workflows/deploy-to-k8s.yaml").read_text(encoding="utf-8")
         self.assertIn("group: console-image-publish-${{ github.ref_name }}", publisher)
         actions = re.findall(r"(?m)^\s*- uses:\s*[^@\s]+@([^\s#]+)", raw)

--- a/tools/verify_console_image_recovery.py
+++ b/tools/verify_console_image_recovery.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Fail-closed contract checks for the approved Console 2.2.4 image repair."""
+"""Fail-closed contract checks for guarded Console image recovery."""
 import argparse
 import json
 import re
@@ -21,12 +21,9 @@ import sys
 
 
 IMAGE_REPOSITORY = "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/console"
-ORIGINAL_CONSOLE_COMMIT = "36aa9c67fb0057164dab9b1fe687b38fe5b8a022"
-ORIGINAL_IMAGE_DIGEST = "sha256:c8cb47ad0a550e58df4cfee57f2f358eb0b1635a0812c77e04388dfb17bbebb6"
-REQUIRED_HOTFIX_COMMIT = "1aa0c03da2279b8c7d2eec025d39f9951d329bf1"
-REPLACEMENT_BASE_IMAGE_DIGEST = "sha256:4a07fedf9925a2775e9e9b7dfdbf99194651e51a7ee2c0b6bb8fab62e61d2da8"
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 ATTESTATION_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
 
 
@@ -74,25 +71,30 @@ def validate_platform_index(document):
 def validate(operation, version, image_repository, source_commit, higress_commit,
              manifest_original_console_commit, manifest_old_digest,
              expected_old_digest, expected_new_digest, current_digest,
-             candidate_digest, source_is_merged):
+             candidate_digest, source_is_merged, source_descends_release,
+             release_tag_matches_manifest, old_digest_is_authorized):
     if operation not in {"build-candidate", "replace"}:
         raise ValueError("unsupported recovery operation")
-    if version != "2.2.4" or image_repository != IMAGE_REPOSITORY:
-        raise ValueError("recovery is restricted to higress/console:2.2.4")
-    if not COMMIT_RE.fullmatch(source_commit or "") or not COMMIT_RE.fullmatch(higress_commit or ""):
-        raise ValueError("exact lowercase source commits are required")
+    if not VERSION_RE.fullmatch(version or ""):
+        raise ValueError("release version is not a supported image tag")
+    if image_repository != IMAGE_REPOSITORY:
+        raise ValueError("recovery is restricted to the production higress/console repository")
+    for name, value in (("source", source_commit), ("Higress", higress_commit),
+                        ("original Console", manifest_original_console_commit)):
+        if not COMMIT_RE.fullmatch(value or ""):
+            raise ValueError(name + " commit must be an exact lowercase SHA")
     if not source_is_merged:
         raise ValueError("Console recovery source must already be merged into main")
-    if manifest_original_console_commit != ORIGINAL_CONSOLE_COMMIT:
-        raise ValueError("recovery manifest does not bind the fixed original Console commit")
-    if manifest_old_digest != ORIGINAL_IMAGE_DIGEST:
-        raise ValueError("recovery manifest does not bind the fixed original image digest")
+    if not source_descends_release:
+        raise ValueError("Console recovery source must descend from the release commit")
+    if not release_tag_matches_manifest:
+        raise ValueError("release tag commit differs from the reviewed recovery manifest")
+    if not old_digest_is_authorized:
+        raise ValueError("expected-old digest is not authorized by the recovery evidence chain")
     for name, value in (("manifest old", manifest_old_digest), ("expected old", expected_old_digest),
                         ("current", current_digest)):
         if not DIGEST_RE.fullmatch(value or ""):
             raise ValueError(name + " digest is invalid")
-    if expected_old_digest != REPLACEMENT_BASE_IMAGE_DIGEST:
-        raise ValueError("operator expected-old digest differs from the approved replacement base")
     if operation == "build-candidate":
         if expected_new_digest or candidate_digest:
             raise ValueError("candidate build must not pre-authorize a replacement digest")
@@ -112,15 +114,11 @@ def validate(operation, version, image_repository, source_commit, higress_commit
     return "replace"
 
 
-def validate_pre_copy(mode, current_digest, expected_old_digest, manifest_old_digest):
+def validate_pre_copy(mode, current_digest, expected_old_digest):
     """Recheck the mutable tag immediately before the authorized replacement."""
-    if manifest_old_digest != ORIGINAL_IMAGE_DIGEST:
-        raise ValueError("pre-copy check does not bind the fixed original image digest")
     for name, value in (("pre-copy current", current_digest), ("expected old", expected_old_digest)):
         if not DIGEST_RE.fullmatch(value or ""):
             raise ValueError(name + " digest is invalid")
-    if expected_old_digest != REPLACEMENT_BASE_IMAGE_DIGEST:
-        raise ValueError("pre-copy check does not bind the approved replacement base")
     if mode == "already-replaced":
         return "skip"
     if mode != "replace":
@@ -147,6 +145,9 @@ def main():
     parser.add_argument("--current-digest")
     parser.add_argument("--candidate-digest", default="")
     parser.add_argument("--source-is-merged", choices=["true", "false"])
+    parser.add_argument("--source-descends-release", choices=["true", "false"])
+    parser.add_argument("--release-tag-matches-manifest", choices=["true", "false"])
+    parser.add_argument("--old-digest-is-authorized", choices=["true", "false"])
     args = parser.parse_args()
     try:
         if args.index_file:
@@ -156,13 +157,16 @@ def main():
             return 0
         if args.pre_copy_mode:
             mode = validate_pre_copy(args.pre_copy_mode, args.pre_copy_current_digest,
-                                     args.expected_old_digest, args.manifest_old_digest)
+                                     args.expected_old_digest)
             print(json.dumps({"mode": mode}, sort_keys=True))
             return 0
-        mode = validate(args.operation, args.version, args.image_repository, args.source_commit,
-                        args.higress_commit, args.manifest_original_console_commit, args.manifest_old_digest,
-                        args.expected_old_digest, args.expected_new_digest,
-                        args.current_digest, args.candidate_digest, args.source_is_merged == "true")
+        mode = validate(
+            args.operation, args.version, args.image_repository, args.source_commit,
+            args.higress_commit, args.manifest_original_console_commit, args.manifest_old_digest,
+            args.expected_old_digest, args.expected_new_digest, args.current_digest,
+            args.candidate_digest, args.source_is_merged == "true",
+            args.source_descends_release == "true", args.release_tag_matches_manifest == "true",
+            args.old_digest_is_authorized == "true")
         print(json.dumps({"mode": mode}, sort_keys=True))
     except ValueError as error:
         print("Console image recovery rejected: " + str(error), file=sys.stderr)


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Replace the one-off Console 2.2.4 image recovery workflow with a generic, guarded stable-release recovery workflow.

- Parameterize the stable version and remove the hard-coded #763 commit and 2.2.4 digest values.
- Require a reviewed, versioned Higress recovery manifest on canonical `main` and verify it against the Console release tag and immutable plugin release provenance.
- Authorize the first replacement only from the manifest's original digest; require every later replacement to extend a verified release-evidence chain.
- Reconstruct the complete plugin resource tree from the release tag plus the reviewed recovery manifest and compare it with the merged Console source before building.
- Keep candidate build and tag replacement separate, validate the candidate digest/platform labels, perform an immediate pre-copy CAS check, and append content-addressed recovery evidence.
- Preserve compatibility with the existing 2.2.4 evidence assets while documenting the generic operator procedure.

A normal patch release remains the preferred fix path; this workflow is an approved emergency replacement mechanism.

### Ⅱ. Does this pull request fix one issue?

Follow-up hardening and generalization of the recovery path introduced for #763 and #764.

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Tests are updated for generic versions, stable-version validation, manifest/tag/source ancestry checks, evidence-chain authorization, candidate digest drift, idempotent retry, pre-copy CAS, platform/attestation validation, full plugin-tree reconstruction, pinned actions, protected environment use, and production registry secrets.

### Ⅳ. Describe how to verify it

```bash
PYTHONDONTWRITEBYTECODE=1 env -u GH_TOKEN -u GITHUB_TOKEN python3 -m unittest discover -s tools -p 'test_*.py'
env -u GH_TOKEN -u GITHUB_TOKEN go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/recover-console-image.yaml
```

Both commands pass at exact commit `96875e1f502d635c72741ae039c543006e28d829`; 37 Python tests pass. A local 2.2.4 compatibility exercise also accepted the existing previous evidence SHA-256 `0a403dc2f19ca3fa525b3fa3db4ea52c6a6da847b275a8d10e19acd5b0ba3733` and reproduced matching actual/expected plugin resource tree SHA-256 `77e650c37d19fda22cafb0b72a86ef2a391df4c4fe6d892b77cbf2ff484810dc` without accessing or modifying ACR.

### Ⅴ. Special notes for reviews

The workflow still cannot overwrite an arbitrary tag from arbitrary inputs. Each version needs a reviewed `plugins/release/console-recovery/<version>.json` in Higress, protected-environment approval, an exact current digest, and (after the first replacement) the immediately preceding immutable recovery evidence.

AI-assisted implementation: OpenAI Codex reviewed the existing 2.2.4 workflow, generalized and tested it, and performed the read-only compatibility exercise. No credentials are included.

