### PR TITLE
fix: refresh internal plugin CR metadata to current built-in spec

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -38,6 +38,7 @@ import com.alibaba.higress.sdk.model.WasmPluginConfig;
 import com.alibaba.higress.sdk.model.WasmPluginInstance;
 import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesClientService;
+import com.alibaba.higress.sdk.constant.KubernetesConstants;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesModelConverter;
 import com.alibaba.higress.sdk.service.kubernetes.KubernetesUtil;
 import com.alibaba.higress.sdk.service.kubernetes.crd.wasm.V1alpha1WasmPlugin;
@@ -208,7 +209,10 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
             V1alpha1WasmPlugin result;
             if (existedCr != null) {
                 result = existedCr;
-                if (internal && Boolean.TRUE.equals(plugin.getBuiltIn())) {
+                String existedVersion = KubernetesUtil.getLabel(existedCr.getMetadata(),
+                    KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY);
+                if (internal && Boolean.TRUE.equals(plugin.getBuiltIn())
+                    && !plugin.getPluginVersion().equals(existedVersion)) {
                     V1alpha1WasmPlugin currentCr = kubernetesModelConverter.wasmPluginToCr(plugin, true);
                     currentCr.getMetadata().setResourceVersion(existedCr.getMetadata().getResourceVersion());
                     kubernetesModelConverter.mergeWasmPluginSpec(existedCr, currentCr);

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -208,6 +208,12 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
             V1alpha1WasmPlugin result;
             if (existedCr != null) {
                 result = existedCr;
+                if (internal && Boolean.TRUE.equals(plugin.getBuiltIn())) {
+                    V1alpha1WasmPlugin currentCr = kubernetesModelConverter.wasmPluginToCr(plugin, true);
+                    currentCr.getMetadata().setResourceVersion(existedCr.getMetadata().getResourceVersion());
+                    kubernetesModelConverter.mergeWasmPluginSpec(existedCr, currentCr);
+                    result = currentCr;
+                }
             } else if (version.equals(plugin.getPluginVersion())) {
                 result = kubernetesModelConverter.wasmPluginToCr(plugin, internal);
             } else {

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
@@ -385,6 +385,7 @@ public class WasmPluginInstanceServiceTest {
         V1alpha1WasmPlugin existedCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
         KubernetesUtil.setLabel(existedCr.getMetadata(), KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY,
             OLD_VERSION);
+        existedCr.getSpec().setUrl("oci://docker.io/basic-auth:" + OLD_VERSION);
         when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME)))
             .thenReturn(Lists.newArrayList(existedCr));
 
@@ -394,7 +395,7 @@ public class WasmPluginInstanceServiceTest {
         WasmPluginInstance updatedInstance = service.addOrUpdate(instance);
 
         Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_NAME, updatedInstance.getPluginName());
-        Assertions.assertEquals(OLD_VERSION, updatedInstance.getPluginVersion());
+        Assertions.assertEquals(DEFAULT_VERSION, updatedInstance.getPluginVersion());
         Assertions.assertEquals(instance.getEnabled(), updatedInstance.getEnabled());
         Assertions.assertEquals(instance.getConfigurations(), updatedInstance.getConfigurations());
         Assertions.assertTrue(updatedInstance.getInternal());
@@ -407,8 +408,10 @@ public class WasmPluginInstanceServiceTest {
         V1alpha1WasmPlugin cr = crCaptor.getValue();
         Assertions.assertNotNull(cr);
         Assertions.assertEquals(TEST_BUILT_IN_PLUGIN_INTERNAL_CR_NAME, cr.getMetadata().getName());
-        Assertions.assertEquals(OLD_VERSION,
+        Assertions.assertEquals(DEFAULT_VERSION,
             KubernetesUtil.getLabel(cr.getMetadata(), KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY));
+        Assertions.assertEquals("oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/basic-auth:2.0.0",
+            cr.getSpec().getUrl());
         Assertions.assertNotEquals(instance.getEnabled(), cr.getSpec().getDefaultConfigDisable());
         Assertions.assertEquals(instance.getConfigurations(), cr.getSpec().getDefaultConfig());
         Assertions.assertTrue(CollectionUtils.isEmpty(cr.getSpec().getMatchRules()));

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
@@ -444,6 +444,31 @@ public class WasmPluginInstanceServiceTest {
     }
 
     @Test
+    public void addOrUpdateTestKeepInternalConfigWithCustomImageOnCurrentVersion() throws Exception {
+        V1alpha1WasmPlugin existedCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
+        existedCr.getSpec().setUrl("oci://private-registry.example.com/plugins/basic-auth:custom");
+        when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME)))
+            .thenReturn(Lists.newArrayList(existedCr));
+
+        WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(TEST_BUILT_IN_PLUGIN_NAME)
+            .pluginVersion(DEFAULT_VERSION).scope(WasmPluginInstanceScope.GLOBAL).enabled(true)
+            .configurations(MapUtil.of("k", "v")).internal(true).build();
+        WasmPluginInstance updatedInstance = service.addOrUpdate(instance);
+
+        Assertions.assertTrue(updatedInstance.getInternal());
+
+        verify(kubernetesClientService, times(1)).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME));
+        verify(kubernetesClientService, never()).createWasmPlugin(any());
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(1)).replaceWasmPlugin(crCaptor.capture());
+        V1alpha1WasmPlugin cr = crCaptor.getValue();
+        Assertions.assertNotNull(cr);
+        Assertions.assertSame(existedCr, cr);
+        Assertions.assertEquals("oci://private-registry.example.com/plugins/basic-auth:custom", cr.getSpec().getUrl());
+        Assertions.assertEquals(instance.getConfigurations(), cr.getSpec().getDefaultConfig());
+    }
+
+    @Test
     public void addOrUpdateAllTestEmptyInput() {
         List<WasmPluginInstance> result = service.addOrUpdateAll(Collections.emptyList());
         Assertions.assertTrue(result.isEmpty(), "Result should be empty for empty input.");


### PR DESCRIPTION
## Summary
- follow-up to #763
- when updating an existing internal WasmPlugin CR, rebuild it from the current built-in plugin spec so the image URL, phase, priority, pull policy and version label follow the latest built-in release instead of staying on the version recorded when the CR was first created
- preserve existing instance configurations (defaultConfig / matchRules) and the resourceVersion for optimistic locking

## Test Plan
- `cd backend && ./mvnw -pl sdk test` (259 tests, 0 failures)