### PR TITLE
feat: mark product-covered plugins in the plugin market

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/ProductCoveredPlugin.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/ProductCoveredPlugin.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.alibaba.higress.sdk.constant.plugin;
+
+/**
+ * Built-in plugins whose configuration is automatically managed by dedicated
+ * Console product features. Manually enabling such a plugin while the
+ * corresponding product feature is in use can cause conflicts.
+ */
+public final class ProductCoveredPlugin {
+
+    private ProductCoveredPlugin() {
+    }
+
+    /**
+     * Plugin covered by the AI Route product feature.
+     */
+    public static final String AI_PROXY = "ai-proxy";
+
+    /**
+     * Plugin covered by the MCP Server product feature.
+     */
+    public static final String MCP_SERVER = "mcp-server";
+}

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/ProductCoveredPlugin.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/constant/plugin/ProductCoveredPlugin.java
@@ -31,7 +31,22 @@ public final class ProductCoveredPlugin {
     public static final String AI_PROXY = "ai-proxy";
 
     /**
+     * Plugin covered by the AI Route product feature.
+     */
+    public static final String MODEL_ROUTER = "model-router";
+
+    /**
+     * Plugin covered by the AI Route product feature.
+     */
+    public static final String MODEL_MAPPER = "model-mapper";
+
+    /**
      * Plugin covered by the MCP Server product feature.
      */
     public static final String MCP_SERVER = "mcp-server";
+
+    /**
+     * Plugin covered by the Consumer product feature.
+     */
+    public static final String KEY_AUTH = "key-auth";
 }

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/WasmPlugin.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/model/WasmPlugin.java
@@ -53,6 +53,10 @@ public class WasmPlugin implements VersionedDto {
     @Schema(description = "Whether the plugin is built-in")
     private Boolean builtIn;
 
+    @Schema(description = "Whether the plugin configuration is managed by a dedicated Console product feature. "
+        + "Manually enabling such a plugin is not recommended while the corresponding product feature is in use.")
+    private Boolean productCovered;
+
     @Schema(description = "Plugin icon URL")
     private String icon;
 

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginServiceImpl.java
@@ -44,6 +44,7 @@ import com.alibaba.higress.sdk.exception.NotFoundException;
 import com.alibaba.higress.sdk.exception.ResourceConflictException;
 import com.alibaba.higress.sdk.http.HttpStatus;
 import com.alibaba.higress.sdk.model.PaginatedResult;
+import com.alibaba.higress.sdk.constant.plugin.ProductCoveredPlugin;
 import com.alibaba.higress.sdk.model.WasmPlugin;
 import com.alibaba.higress.sdk.model.WasmPluginConfig;
 import com.alibaba.higress.sdk.model.WasmPluginPageQuery;
@@ -722,6 +723,8 @@ class WasmPluginServiceImpl implements WasmPluginService {
             wasmPlugin.setImagePullSecret(imagePullSecret);
             wasmPlugin.setImagePullPolicy(imagePullPolicy);
             wasmPlugin.setBuiltIn(true);
+            wasmPlugin.setProductCovered(ProductCoveredPlugin.AI_PROXY.equals(name)
+                || ProductCoveredPlugin.MCP_SERVER.equals(name));
 
             PluginInfo info = plugin.getInfo();
             if (info != null) {

--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginServiceImpl.java
@@ -704,6 +704,14 @@ class WasmPluginServiceImpl implements WasmPluginService {
             return readmes.get(language);
         }
 
+        private boolean isProductCoveredPlugin(String pluginName) {
+            return ProductCoveredPlugin.AI_PROXY.equals(pluginName)
+                || ProductCoveredPlugin.MODEL_ROUTER.equals(pluginName)
+                || ProductCoveredPlugin.MODEL_MAPPER.equals(pluginName)
+                || ProductCoveredPlugin.MCP_SERVER.equals(pluginName)
+                || ProductCoveredPlugin.KEY_AUTH.equals(pluginName);
+        }
+
         public void setReadme(String language, String content) {
             if (StringUtils.isNotEmpty(content)) {
                 readmes.put(language, content);
@@ -723,8 +731,7 @@ class WasmPluginServiceImpl implements WasmPluginService {
             wasmPlugin.setImagePullSecret(imagePullSecret);
             wasmPlugin.setImagePullPolicy(imagePullPolicy);
             wasmPlugin.setBuiltIn(true);
-            wasmPlugin.setProductCovered(ProductCoveredPlugin.AI_PROXY.equals(name)
-                || ProductCoveredPlugin.MCP_SERVER.equals(name));
+            wasmPlugin.setProductCovered(isProductCoveredPlugin(name));
 
             PluginInfo info = plugin.getInfo();
             if (info != null) {

--- a/frontend/src/interfaces/wasm-plugin.ts
+++ b/frontend/src/interfaces/wasm-plugin.ts
@@ -7,6 +7,7 @@ export interface WasmPluginData {
   description?: string;
   icon?: string;
   builtIn?: boolean;
+  productCovered?: boolean;
   imageRepository?: string;
   imageVersion?: string;
   phase?: string;

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -437,6 +437,8 @@
       "custom": "Custom"
     },
     "enabled": "Enabled",
+    "productCovered": "Not Recommended",
+    "productCoveredTip": "This plugin is managed by a dedicated product feature (e.g. AI Route, MCP Server). Manually enabling it here is not recommended. If you must use it, do not enable it together with the corresponding product feature, or conflicts may occur.",
     "emptyPlugins": "No plugins configured.",
     "addPlugin": "Add Plugin",
     "editPlugin": "Edit Plugin",

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -438,7 +438,7 @@
     },
     "enabled": "Enabled",
     "productCovered": "Not Recommended",
-    "productCoveredTip": "This plugin is managed by a dedicated product feature (e.g. AI Route, MCP Server). Manually enabling it here is not recommended. If you must use it, do not enable it together with the corresponding product feature, or conflicts may occur.",
+    "productCoveredTip": "This plugin is managed by a dedicated product feature (e.g. AI Route, MCP Server, Consumer). Manually enabling it here is not recommended. If you must use it, do not enable it together with the corresponding product feature, or conflicts may occur.",
     "emptyPlugins": "No plugins configured.",
     "addPlugin": "Add Plugin",
     "editPlugin": "Edit Plugin",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -437,6 +437,8 @@
       "custom": "自定义"
     },
     "enabled": "已启用",
+    "productCovered": "不建议使用",
+    "productCoveredTip": "该插件的配置已由对应的产品功能管理（如 AI 路由、MCP 服务）。不建议在此手动启用；如确需使用，请勿与对应产品功能同时启用，否则可能产生冲突。",
     "emptyPlugins": "未启用策略",
     "addPlugin": "添加插件",
     "editPlugin": "编辑插件",

--- a/frontend/src/locales/zh-CN/translation.json
+++ b/frontend/src/locales/zh-CN/translation.json
@@ -438,7 +438,7 @@
     },
     "enabled": "已启用",
     "productCovered": "不建议使用",
-    "productCoveredTip": "该插件的配置已由对应的产品功能管理（如 AI 路由、MCP 服务）。不建议在此手动启用；如确需使用，请勿与对应产品功能同时启用，否则可能产生冲突。",
+    "productCoveredTip": "该插件的配置已由对应的产品功能管理（如 AI 路由、MCP 服务、消费者管理）。不建议在此手动启用；如确需使用，请勿与对应产品功能同时启用，否则可能产生冲突。",
     "emptyPlugins": "未启用策略",
     "addPlugin": "添加插件",
     "editPlugin": "编辑插件",

--- a/frontend/src/pages/plugin/components/PluginList/index.tsx
+++ b/frontend/src/pages/plugin/components/PluginList/index.tsx
@@ -4,14 +4,13 @@ import { WasmPluginData } from '@/interfaces/wasm-plugin';
 import { getDomainPluginInstances, getGatewayRouteDetail, getGlobalPluginInstances, getWasmPlugins } from '@/services';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { useRequest } from 'ahooks';
-import { Avatar, Button, Card, Col, Dropdown, Popconfirm, Tag, Typography } from 'antd';
+import { Avatar, Button, Card, Col, Dropdown, Popconfirm, Tag, Tooltip, Typography } from 'antd';
 import { useSearchParams } from 'ice';
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getI18nValue, QueryType } from '../../utils';
 import PluginCategory from '../PluginCategory';
 import { BUILTIN_ROUTE_PLUGIN_LIST, DEFAULT_PLUGIN_IMG } from './constant';
-import { Tooltip } from 'antd';
 
 const { Paragraph } = Typography;
 const { Meta } = Card;
@@ -219,7 +218,9 @@ const PluginList = forwardRef((props: Props, ref) => {
                       <Tag
                         color="orange"
                         style={{ marginLeft: 6, fontSize: '10px', lineHeight: '16px', padding: '0 4px', borderRadius: '2px' }}
-                      >{t('plugins.productCovered')}</Tag>
+                      >
+                      {t('plugins.productCovered')}
+                    </Tag>
                     </Tooltip>
                   )
                 }

--- a/frontend/src/pages/plugin/components/PluginList/index.tsx
+++ b/frontend/src/pages/plugin/components/PluginList/index.tsx
@@ -219,8 +219,8 @@ const PluginList = forwardRef((props: Props, ref) => {
                         color="orange"
                         style={{ marginLeft: 6, fontSize: '10px', lineHeight: '16px', padding: '0 4px', borderRadius: '2px' }}
                       >
-                      {t('plugins.productCovered')}
-                    </Tag>
+                        {t('plugins.productCovered')}
+                      </Tag>
                     </Tooltip>
                   )
                 }

--- a/frontend/src/pages/plugin/components/PluginList/index.tsx
+++ b/frontend/src/pages/plugin/components/PluginList/index.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { getI18nValue, QueryType } from '../../utils';
 import PluginCategory from '../PluginCategory';
 import { BUILTIN_ROUTE_PLUGIN_LIST, DEFAULT_PLUGIN_IMG } from './constant';
+import { Tooltip } from 'antd';
 
 const { Paragraph } = Typography;
 const { Meta } = Card;
@@ -210,6 +211,16 @@ const PluginList = forwardRef((props: Props, ref) => {
                       style={{ marginLeft: 6, fontSize: '10px', lineHeight: '16px', padding: '0 4px', borderRadius: '2px' }}
                     >{t('plugins.enabled')}
                     </Tag>
+                  )
+                }
+                {
+                  item.productCovered && !item.enabled && (
+                    <Tooltip title={t('plugins.productCoveredTip')}>
+                      <Tag
+                        color="orange"
+                        style={{ marginLeft: 6, fontSize: '10px', lineHeight: '16px', padding: '0 4px', borderRadius: '2px' }}
+                      >{t('plugins.productCovered')}</Tag>
+                    </Tooltip>
                   )
                 }
                 {


### PR DESCRIPTION
## Summary
- add a `productCovered` flag to built-in plugin definitions (ai-proxy → AI Route, mcp-server → MCP Server)
- plugin market cards show a "Not Recommended" badge with a tooltip explaining the plugin is covered by the corresponding product feature and should not be enabled manually alongside it
- zh-CN / en-US translations included

## Test Plan
- `cd backend && ./mvnw -pl sdk validate && ./mvnw -pl sdk -Dtest=WasmPluginServiceTest test` (13/13)
- i18n key parity check between zh-CN and en-US locales