### PR TITLE
fix: always show product-covered badge on plugin cards

### DIFF
--- a/frontend/src/pages/plugin/components/PluginList/index.tsx
+++ b/frontend/src/pages/plugin/components/PluginList/index.tsx
@@ -213,7 +213,7 @@ const PluginList = forwardRef((props: Props, ref) => {
                   )
                 }
                 {
-                  item.productCovered && !item.enabled && (
+                  item.productCovered && (
                     <Tooltip title={t('plugins.productCoveredTip')}>
                       <Tag
                         color="orange"


### PR DESCRIPTION
## Summary
- follow-up to #767
- show the "not recommended" badge for product-covered plugins regardless of the enabled state; previously it was hidden once a user-level instance was enabled, which is exactly the risky case (manually enabled while the product feature is also in use)

## Test Plan
- eslint on the changed file (clean)