### PR TITLE
fix: render Console Swagger Request Body schemas

### DIFF
--- a/backend/console/pom.xml
+++ b/backend/console/pom.xml
@@ -43,6 +43,20 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
+			<exclusions>
+				<!-- springdoc-openapi-ui 1.8.0 transitively ships swagger-ui 5.10.3,
+				     which leaves Request Body schemas blank (higress-group/higress#3207). -->
+				<exclusion>
+					<groupId>org.webjars</groupId>
+					<artifactId>swagger-ui</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- Direct pin so all-in-one / console images always serve a Swagger UI
+		     that can render requestBody schemas. Version is managed in the parent POM. -->
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>swagger-ui</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>

--- a/backend/console/src/main/java/com/alibaba/higress/console/config/OpenApiRequestBodyCustomizer.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/config/OpenApiRequestBodyCustomizer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.console.config;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+
+/**
+ * Makes requestBody entries renderable in Swagger UI.
+ *
+ * <p>
+ * springdoc may emit a request body whose only media type is the wildcard type when a controller
+ * method uses {@code @RequestBody} without an explicit {@code consumes} value. Older Swagger UI
+ * builds (and the 5.10.x webjar bundled by springdoc 1.8.0) then show an empty Request Body
+ * panel. Copying that media type onto {@code application/json} gives the UI a concrete schema
+ * to display, which is what all-in-one users hit in higress-group/higress#3207.
+ */
+public final class OpenApiRequestBodyCustomizer {
+
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String WILDCARD = "*/*";
+
+    private OpenApiRequestBodyCustomizer() {}
+
+    public static void normalize(OpenAPI openApi) {
+        if (openApi == null || openApi.getPaths() == null) {
+            return;
+        }
+        for (PathItem pathItem : openApi.getPaths().values()) {
+            normalizePathItem(pathItem);
+        }
+    }
+
+    static void normalizePathItem(PathItem pathItem) {
+        if (pathItem == null) {
+            return;
+        }
+        List<Operation> operations = pathItem.readOperations();
+        if (operations == null) {
+            return;
+        }
+        for (Operation operation : operations) {
+            normalizeOperation(operation);
+        }
+    }
+
+    static void normalizeOperation(Operation operation) {
+        if (operation == null) {
+            return;
+        }
+        RequestBody requestBody = operation.getRequestBody();
+        if (requestBody == null) {
+            return;
+        }
+        Content content = requestBody.getContent();
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        if (hasJsonMediaType(content)) {
+            return;
+        }
+        MediaType source = firstRenderableMediaType(content);
+        if (source == null) {
+            return;
+        }
+        content.addMediaType(APPLICATION_JSON, source);
+    }
+
+    private static boolean hasJsonMediaType(Content content) {
+        for (String mediaType : content.keySet()) {
+            if (mediaType != null && mediaType.startsWith(APPLICATION_JSON)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static MediaType firstRenderableMediaType(Content content) {
+        MediaType wildcard = content.get(WILDCARD);
+        if (wildcard != null) {
+            return wildcard;
+        }
+        for (Map.Entry<String, MediaType> entry : content.entrySet()) {
+            if (entry.getValue() != null) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/backend/console/src/main/java/com/alibaba/higress/console/config/SwaggerConfig.java
+++ b/backend/console/src/main/java/com/alibaba/higress/console/config/SwaggerConfig.java
@@ -92,6 +92,8 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = new SecurityRequirement();
         securityRequirement.addList("basicAuth");
         openApi.setSecurity(Collections.singletonList(securityRequirement));
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
     }
 
     private void registerClassSchema(OpenAPI openApi, Class<?> clazz) {

--- a/backend/console/src/main/resources/application.properties
+++ b/backend/console/src/main/resources/application.properties
@@ -15,6 +15,11 @@ springdoc.pathsToMatch=/v1/**,/session/**,/dashboard/**,/system/**,/user/**
 springdoc.swagger-ui.enabled=false
 springdoc.swagger-ui.operationsSorter=alpha
 springdoc.swagger-ui.tagsSorter=alpha
+# When Swagger is turned on (all-in-one / helm swagger.enabled), give every
+# requestBody a concrete JSON media type so Swagger UI can render the schema
+# instead of an empty "*/*" example. See higress-group/higress#3207.
+springdoc.default-consumes-media-type=application/json
+springdoc.default-produces-media-type=application/json
 
 higress-console.build.version=@app.build.version@
 higress-console.build.dev=@app.build.dev@

--- a/backend/console/src/test/java/com/alibaba/higress/console/config/OpenApiRequestBodyCustomizerTest.java
+++ b/backend/console/src/test/java/com/alibaba/higress/console/config/OpenApiRequestBodyCustomizerTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2022-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.console.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+
+/**
+ * Regression tests for the requestBody media-type rewrite that makes Swagger UI show body fields
+ * (higress-group/higress#3207).
+ */
+class OpenApiRequestBodyCustomizerTest {
+
+    @Test
+    void normalize_nullOpenApi_isNoOp() {
+        OpenApiRequestBodyCustomizer.normalize(null);
+    }
+
+    @Test
+    void normalize_emptyPaths_isNoOp() {
+        OpenAPI openApi = new OpenAPI();
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+        assertNull(openApi.getPaths());
+    }
+
+    @Test
+    void normalize_nullPathItem_isSkipped() {
+        OpenAPI openApi = new OpenAPI();
+        Paths paths = new Paths();
+        paths.put("/v1/routes", null);
+        openApi.setPaths(paths);
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+
+        assertTrue(openApi.getPaths().containsKey("/v1/routes"));
+        assertNull(openApi.getPaths().get("/v1/routes"));
+    }
+
+    @Test
+    void normalize_operationWithoutRequestBody_isUnchanged() {
+        Operation get = new Operation().operationId("listRoutes");
+        PathItem pathItem = new PathItem().get(get);
+        OpenAPI openApi = openApiWithPath("/v1/routes", pathItem);
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+
+        assertNull(get.getRequestBody());
+    }
+
+    @Test
+    void normalize_requestBodyWithoutContent_isUnchanged() {
+        RequestBody requestBody = new RequestBody().required(true);
+        Operation post = new Operation().operationId("addRoute").requestBody(requestBody);
+        OpenAPI openApi = openApiWithPath("/v1/routes", new PathItem().post(post));
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+
+        assertNull(post.getRequestBody().getContent());
+    }
+
+    @Test
+    void normalize_emptyContent_isUnchanged() {
+        RequestBody requestBody = new RequestBody().content(new Content());
+        Operation post = new Operation().operationId("addRoute").requestBody(requestBody);
+        OpenAPI openApi = openApiWithPath("/v1/routes", new PathItem().post(post));
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+
+        assertTrue(post.getRequestBody().getContent().isEmpty());
+    }
+
+    @Test
+    void normalize_wildcardOnly_copiesSchemaOntoApplicationJson() {
+        Schema<?> routeSchema = new ObjectSchema().addProperty("name", new StringSchema())
+            .addProperty("path", new ObjectSchema());
+        MediaType wildcard = new MediaType().schema(routeSchema);
+        Content content = new Content().addMediaType(OpenApiRequestBodyCustomizer.WILDCARD, wildcard);
+        Operation post = operationWithContent("addRoute", content);
+        OpenAPI openApi = openApiWithPath("/v1/routes", new PathItem().post(post).put(operationWithContent("updateRoute",
+            new Content().addMediaType(OpenApiRequestBodyCustomizer.WILDCARD, wildcard))));
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+
+        MediaType json = post.getRequestBody().getContent().get(OpenApiRequestBodyCustomizer.APPLICATION_JSON);
+        assertNotNull(json, "application/json must be added so Swagger UI can render the body");
+        assertSame(routeSchema, json.getSchema());
+        assertNotNull(json.getSchema().getProperties());
+        assertTrue(json.getSchema().getProperties().containsKey("name"));
+        assertTrue(json.getSchema().getProperties().containsKey("path"));
+
+        MediaType putJson = openApi.getPaths().get("/v1/routes").getPut().getRequestBody().getContent()
+            .get(OpenApiRequestBodyCustomizer.APPLICATION_JSON);
+        assertNotNull(putJson);
+        assertSame(routeSchema, putJson.getSchema());
+    }
+
+    @Test
+    void normalize_existingApplicationJson_isLeftAlone() {
+        Schema<?> original = new ObjectSchema().addProperty("name", new StringSchema());
+        MediaType json = new MediaType().schema(original);
+        Content content = new Content().addMediaType(OpenApiRequestBodyCustomizer.APPLICATION_JSON, json);
+        Operation post = operationWithContent("addRoute", content);
+
+        OpenApiRequestBodyCustomizer.normalize(openApiWithPath("/v1/routes", new PathItem().post(post)));
+
+        Content after = post.getRequestBody().getContent();
+        assertEquals(1, after.size());
+        assertSame(original, after.get(OpenApiRequestBodyCustomizer.APPLICATION_JSON).getSchema());
+    }
+
+    @Test
+    void normalize_jsonWithCharset_isTreatedAsAlreadyJson() {
+        MediaType json = new MediaType().schema(new ObjectSchema().addProperty("name", new StringSchema()));
+        Content content = new Content().addMediaType("application/json;charset=UTF-8", json);
+        Operation post = operationWithContent("addRoute", content);
+
+        OpenApiRequestBodyCustomizer.normalize(openApiWithPath("/v1/routes", new PathItem().post(post)));
+
+        assertNull(post.getRequestBody().getContent().get(OpenApiRequestBodyCustomizer.APPLICATION_JSON));
+        assertNotNull(post.getRequestBody().getContent().get("application/json;charset=UTF-8"));
+    }
+
+    @Test
+    void normalize_xmlOnly_copiesOntoApplicationJson() {
+        Schema<?> schema = new ObjectSchema().addProperty("name", new StringSchema());
+        MediaType xml = new MediaType().schema(schema);
+        Content content = new Content().addMediaType("application/xml", xml);
+        Operation post = operationWithContent("addRoute", content);
+
+        OpenApiRequestBodyCustomizer.normalize(openApiWithPath("/v1/routes", new PathItem().post(post)));
+
+        MediaType json = post.getRequestBody().getContent().get(OpenApiRequestBodyCustomizer.APPLICATION_JSON);
+        assertNotNull(json);
+        assertSame(schema, json.getSchema());
+        assertNotNull(post.getRequestBody().getContent().get("application/xml"));
+    }
+
+    @Test
+    void normalize_getAndDeleteAreStillVisitedButStayBodyless() {
+        PathItem pathItem = new PathItem().get(new Operation().operationId("getRoute"))
+            .delete(new Operation().operationId("deleteRoute"));
+        OpenAPI openApi = openApiWithPath("/v1/routes/{name}", pathItem);
+
+        OpenApiRequestBodyCustomizer.normalize(openApi);
+
+        assertNull(pathItem.getGet().getRequestBody());
+        assertNull(pathItem.getDelete().getRequestBody());
+    }
+
+    private static Operation operationWithContent(String operationId, Content content) {
+        return new Operation().operationId(operationId).requestBody(new RequestBody().required(true).content(content));
+    }
+
+    private static OpenAPI openApiWithPath(String path, PathItem pathItem) {
+        OpenAPI openApi = new OpenAPI();
+        Paths paths = new Paths();
+        paths.addPathItem(path, pathItem);
+        openApi.setPaths(paths);
+        return openApi;
+    }
+}

--- a/backend/console/src/test/java/com/alibaba/higress/console/config/OpenApiRequestBodySchemaTest.java
+++ b/backend/console/src/test/java/com/alibaba/higress/console/config/OpenApiRequestBodySchemaTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2022-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.console.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.alibaba.higress.sdk.model.Domain;
+import com.alibaba.higress.sdk.model.Route;
+import com.alibaba.higress.sdk.model.ServiceSource;
+import com.alibaba.higress.sdk.model.TlsCertificate;
+import com.alibaba.higress.sdk.model.WasmPlugin;
+import com.alibaba.higress.sdk.model.WasmPluginInstance;
+import com.alibaba.higress.sdk.model.ai.AiRoute;
+import com.alibaba.higress.sdk.model.ai.LlmProvider;
+import com.alibaba.higress.sdk.model.consumer.Consumer;
+import com.alibaba.higress.sdk.model.mcp.McpServer;
+import com.alibaba.higress.sdk.model.mcp.SwaggerContent;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+
+/**
+ * Ensures Console request DTOs still produce a non-empty OpenAPI schema.
+ *
+ * <p>
+ * Swagger UI can only paint Request Body fields when the generated schema has properties (or a
+ * usable $ref). An empty object schema reproduces the blank Request Body panel reported in
+ * higress-group/higress#3207, even with a fixed swagger-ui webjar.
+ */
+class OpenApiRequestBodySchemaTest {
+
+    private static final String CONTROLLER_PACKAGE = "com.alibaba.higress.console.controller";
+
+    private static final List<Class<?>> SAMPLE_BODY_TYPES = Arrays.asList(Route.class, Domain.class,
+        ServiceSource.class, TlsCertificate.class, WasmPlugin.class, WasmPluginInstance.class, AiRoute.class,
+        LlmProvider.class, Consumer.class, McpServer.class, SwaggerContent.class);
+
+    @Test
+    void sampleRequestDtos_exposeNamedProperties() {
+        for (Class<?> type : SAMPLE_BODY_TYPES) {
+            Schema<?> schema = resolveSchema(type);
+            assertNotNull(schema, type.getName() + " must resolve to an OpenAPI schema");
+            assertFalse(isEmptyObjectSchema(schema),
+                type.getName() + " resolved to an empty object schema; Swagger UI would hide Request Body fields");
+        }
+    }
+
+    @Test
+    void routeSchema_containsTheFieldsShownInSwagger() {
+        Schema<?> schema = resolveSchema(Route.class);
+        Map<String, Schema> properties = schema.getProperties();
+        assertNotNull(properties);
+        assertTrue(properties.containsKey("name"), "Route.name");
+        assertTrue(properties.containsKey("path"), "Route.path");
+        assertTrue(properties.containsKey("domains"), "Route.domains");
+        assertTrue(properties.containsKey("services"), "Route.services");
+        assertTrue(properties.containsKey("methods"), "Route.methods");
+    }
+
+    @Test
+    void llmProviderSchema_containsTheFieldsShownInSwagger() {
+        Schema<?> schema = resolveSchema(LlmProvider.class);
+        Map<String, Schema> properties = schema.getProperties();
+        assertNotNull(properties);
+        assertTrue(properties.containsKey("name"), "LlmProvider.name");
+        assertTrue(properties.containsKey("type"), "LlmProvider.type");
+    }
+
+    @Test
+    void everyControllerRequestBody_hasARenderableSchema() throws ClassNotFoundException {
+        ClassPathScanningCandidateComponentProvider scanner =
+            new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(RestController.class));
+        Set<BeanDefinition> controllers = scanner.findCandidateComponents(CONTROLLER_PACKAGE);
+        assertFalse(controllers.isEmpty(), "expected console REST controllers under " + CONTROLLER_PACKAGE);
+
+        int requestBodyCount = 0;
+        Set<String> emptySchemas = new HashSet<String>();
+        for (BeanDefinition definition : controllers) {
+            Class<?> controller = Class.forName(definition.getBeanClassName());
+            for (Method method : controller.getMethods()) {
+                for (Parameter parameter : method.getParameters()) {
+                    if (!hasRequestBody(parameter)) {
+                        continue;
+                    }
+                    requestBodyCount++;
+                    Class<?> bodyType = rawType(parameter.getParameterizedType());
+                    if (!isDocumentableBody(bodyType)) {
+                        continue;
+                    }
+                    Schema<?> schema = resolveSchema(bodyType);
+                    if (schema == null || isEmptyObjectSchema(schema)) {
+                        emptySchemas.add(controller.getSimpleName() + "." + method.getName() + "("
+                            + bodyType.getSimpleName() + ")");
+                    }
+                }
+            }
+        }
+
+        assertTrue(requestBodyCount >= 20,
+            "expected dozens of @RequestBody parameters, found " + requestBodyCount);
+        assertTrue(emptySchemas.isEmpty(),
+            "these @RequestBody types would render as a blank Request Body in Swagger UI: " + emptySchemas);
+    }
+
+    private static Schema<?> resolveSchema(Class<?> type) {
+        ResolvedSchema resolved = ModelConverters.getInstance().resolveAsResolvedSchema(new AnnotatedType(type));
+        if (resolved == null) {
+            return null;
+        }
+        return resolved.schema;
+    }
+
+    private static boolean isEmptyObjectSchema(Schema<?> schema) {
+        if (schema == null) {
+            return true;
+        }
+        if (schema.get$ref() != null && !schema.get$ref().isEmpty()) {
+            return false;
+        }
+        if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+            return false;
+        }
+        if (schema.getAdditionalProperties() != null) {
+            return false;
+        }
+        if (schema.getAllOf() != null && !schema.getAllOf().isEmpty()) {
+            return false;
+        }
+        if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+            return false;
+        }
+        if (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+            return false;
+        }
+        String schemaType = schema.getType();
+        return schemaType == null || "object".equals(schemaType);
+    }
+
+    private static boolean hasRequestBody(Parameter parameter) {
+        for (Annotation annotation : parameter.getAnnotations()) {
+            if (annotation instanceof RequestBody) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Class<?> rawType(Type type) {
+        if (type instanceof Class) {
+            return (Class<?>)type;
+        }
+        if (type instanceof ParameterizedType) {
+            Type raw = ((ParameterizedType)type).getRawType();
+            if (raw instanceof Class) {
+                return (Class<?>)raw;
+            }
+        }
+        return Object.class;
+    }
+
+    private static boolean isDocumentableBody(Class<?> type) {
+        if (type == null || type.isPrimitive() || type.isArray() || type.isEnum()) {
+            return false;
+        }
+        Package pkg = type.getPackage();
+        if (pkg != null && pkg.getName().startsWith("java.")) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/backend/console/src/test/java/com/alibaba/higress/console/config/SwaggerUiWebjarVersionTest.java
+++ b/backend/console/src/test/java/com/alibaba/higress/console/config/SwaggerUiWebjarVersionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.alibaba.higress.console.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.webjars.WebJarAssetLocator;
+
+/**
+ * Guards the swagger-ui webjar pin that fixes empty Request Body panels in Console Swagger UI
+ * (higress-group/higress#3207).
+ *
+ * <p>
+ * springdoc-openapi-ui 1.8.0 depends on swagger-ui 5.10.3. That build cannot render requestBody
+ * schemas. swagger-ui 5.11.10 is the first release that does; the parent POM pins a later 5.18.x
+ * webjar and {@code webjars-locator-core} must resolve it at runtime.
+ */
+class SwaggerUiWebjarVersionTest {
+
+    /**
+     * First swagger-ui release that renders requestBody schemas (see swagger-ui v5.11.10 notes).
+     */
+    static final String MIN_FIXED_VERSION = "5.11.10";
+
+    /**
+     * Default transitive version pulled by springdoc-openapi-ui 1.8.0. Serving this webjar is the
+     * regression we must never return to.
+     */
+    static final String SPRINGDOC_180_DEFAULT = "5.10.3";
+
+    private static final Pattern WEBJAR_VERSION = Pattern.compile("webjars/swagger-ui/([^/]+)/");
+
+    @Test
+    void mavenPomProperties_isAtLeastTheRequestBodyFix() throws IOException {
+        URL resource = Thread.currentThread().getContextClassLoader()
+            .getResource("META-INF/maven/org.webjars/swagger-ui/pom.properties");
+        assertNotNull(resource, "swagger-ui webjar must be on the console classpath");
+
+        Properties properties = new Properties();
+        InputStream in = resource.openStream();
+        try {
+            properties.load(in);
+        } finally {
+            in.close();
+        }
+
+        String version = properties.getProperty("version");
+        assertNotNull(version, "webjar pom.properties must declare version");
+        assertTrue(compareVersions(version, MIN_FIXED_VERSION) >= 0,
+            "swagger-ui webjar is " + version + ", need >=" + MIN_FIXED_VERSION
+                + " so Request Body schemas render");
+        assertTrue(compareVersions(version, SPRINGDOC_180_DEFAULT) > 0,
+            "swagger-ui webjar must override springdoc 1.8.0's default " + SPRINGDOC_180_DEFAULT
+                + ", got " + version);
+    }
+
+    @Test
+    void webJarAssetLocator_resolvesPinnedSwaggerUi() {
+        WebJarAssetLocator locator = new WebJarAssetLocator();
+        String fullPath = locator.getFullPath("swagger-ui", "swagger-ui.css");
+        assertNotNull(fullPath, "webjars-locator-core must find swagger-ui.css");
+        assertFalse(fullPath.contains("/" + SPRINGDOC_180_DEFAULT + "/"),
+            "locator must not serve springdoc's broken 5.10.3 webjar, path=" + fullPath);
+
+        Matcher matcher = WEBJAR_VERSION.matcher(fullPath);
+        assertTrue(matcher.find(), "unexpected webjar path: " + fullPath);
+        String version = matcher.group(1);
+        assertTrue(compareVersions(version, MIN_FIXED_VERSION) >= 0,
+            "locator resolved swagger-ui " + version + ", need >=" + MIN_FIXED_VERSION);
+    }
+
+    @Test
+    void compareVersions_coversBoundaryCases() {
+        assertTrue(compareVersions("5.11.10", "5.11.10") == 0);
+        assertTrue(compareVersions("5.11.10", "5.10.3") > 0);
+        assertTrue(compareVersions("5.10.3", "5.11.10") < 0);
+        assertTrue(compareVersions("5.18.2", "5.11.10") > 0);
+        assertTrue(compareVersions("5.18", "5.18.0") == 0);
+        assertTrue(compareVersions("5.18.2", "5.18") > 0);
+        assertTrue(compareVersions("5", "5.0.0") == 0);
+    }
+
+    /**
+     * Numeric dotted-version compare. Missing trailing segments are treated as 0.
+     */
+    static int compareVersions(String left, String right) {
+        if (left == null || right == null) {
+            fail("version must not be null");
+        }
+        String[] leftParts = left.split("\\.");
+        String[] rightParts = right.split("\\.");
+        int length = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < length; i++) {
+            int leftValue = i < leftParts.length ? parseSegment(leftParts[i]) : 0;
+            int rightValue = i < rightParts.length ? parseSegment(rightParts[i]) : 0;
+            if (leftValue != rightValue) {
+                return Integer.compare(leftValue, rightValue);
+            }
+        }
+        return 0;
+    }
+
+    private static int parseSegment(String segment) {
+        String digits = segment.replaceAll("[^0-9].*$", "");
+        if (digits.isEmpty()) {
+            return 0;
+        }
+        return Integer.parseInt(digits);
+    }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -72,7 +72,11 @@
 		<lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
 		<swagger-core.version>2.2.20</swagger-core.version>
 		<springdoc.version>1.8.0</springdoc.version>
-		<swagger-ui.version>5.11.10</swagger-ui.version>
+		<!-- springdoc 1.8.0 defaults to swagger-ui 5.10.3, which cannot render
+		     requestBody schemas. 5.11.10 is the first fixed release; pin a later
+		     5.18.x webjar (the same line springdoc 2.8.x uses) so Swagger UI
+		     shows Request Body fields. See higress-group/higress#3207. -->
+		<swagger-ui.version>5.18.2</swagger-ui.version>
 		<webjars-locator-core.version>0.52</webjars-locator-core.version>
 
 		<plugin.inputEncoding>${project.build.sourceEncoding}</plugin.inputEncoding>


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

When Console Swagger UI is enabled (all-in-one / helm `swagger.enabled`), Request Body panels stayed empty because:

1. `springdoc-openapi-ui` 1.8.0 transitively ships swagger-ui **5.10.3**, which cannot render requestBody schemas (fixed upstream in swagger-ui **5.11.10**).
2. Controllers often omit `consumes`, so springdoc emits only a `*/*` media type; Swagger UI then has nothing concrete to paint.

This PR:

- Excludes the transitive swagger-ui webjar and pins **5.18.2** directly on the console module
- Sets `springdoc.default-consumes/produces-media-type=application/json`
- Adds `OpenApiRequestBodyCustomizer` to copy wildcard requestBody schemas onto `application/json`
- Adds regression tests for the webjar pin, schema generation, and media-type rewrite

### Ⅱ. Does this pull request fix one issue?

Fixes higress-group/higress#3207

### Ⅲ. Why don't you add test cases (unit test/integration test)?

Added:

- `SwaggerUiWebjarVersionTest` — classpath / locator must serve swagger-ui >= 5.11.10
- `OpenApiRequestBodySchemaTest` — representative `@RequestBody` DTOs must resolve to non-empty schemas
- `OpenApiRequestBodyCustomizerTest` — wildcard / empty / already-json edge cases

`mvn -pl console -am test`: 20 tests, 0 failures.

### Ⅳ. Describe how to verify it

1. Build and run Console with Swagger enabled:
   `SPRINGDOC_API_DOCS_ENABLED=true SPRINGDOC_SWAGGER_UI_ENABLED=true`
2. Open `/swagger-ui/index.html`
3. Expand a POST/PUT such as `POST /v1/routes` — Request Body should list fields (`name`, `path`, `services`, ...)
4. Optionally run: `mvn -pl console -am test -Dfrontend.skip=true`

### Ⅴ. Special notes for reviews

Related earlier fix: higress-console#654 (swagger-ui 5.11.10). This PR hardens the override (explicit dependency + exclusion), bumps to 5.18.2, and closes the still-open higress#3207 with schema/media-type coverage.