### PR TITLE
fix(frontend): logout lands on /; 401 redirect preserves query safely

### DIFF
--- a/frontend/src/components/AvatarDropdown/index.tsx
+++ b/frontend/src/components/AvatarDropdown/index.tsx
@@ -20,11 +20,7 @@ const AvatarDropdown: React.FC<AvatarDropdownProps> = ({ name, avatar }) => {
 
   const doLogout = async () => {
     await logout();
-    const pathname = history?.location?.pathname;
-    history?.push({
-      pathname: '/login',
-      search: pathname ? `redirect=${pathname}` : '',
-    });
+    history?.push('/login');
   };
 
   const onLogoutClick = useCallback((event: MenuInfo) => {

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -4,6 +4,7 @@ import { LOGIN_PROMPT, SYSTEM_INITIALIZED } from '@/interfaces/config';
 import type { LoginParams, UserInfo } from '@/interfaces/user';
 import { login } from '@/services';
 import store from '@/store';
+import { sanitizeRedirectValue } from '@/utils/redirect';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { LoginForm, ProFormCheckbox, ProFormText } from '@ant-design/pro-form';
 import { Alert, message } from 'antd';
@@ -46,10 +47,7 @@ const Login: React.FC = () => {
       });
       await updateUserInfo(user);
       const urlParams = new URL(window.location.href).searchParams;
-      let redirectUrl = urlParams.get('redirect');
-      if (!redirectUrl || redirectUrl === '/login') {
-        redirectUrl = '/';
-      }
+      const redirectUrl = sanitizeRedirectValue(urlParams.get('redirect'));
       history?.push(redirectUrl);
       return;
     } catch (error) {

--- a/frontend/src/services/request.tsx
+++ b/frontend/src/services/request.tsx
@@ -1,6 +1,7 @@
 import { Modal } from "antd";
 import axios from "axios";
 import i18next from 'i18next';
+import { buildRedirectSearch } from "@/utils/redirect";
 import { ErrorComp } from './exception';
 import { resolveRequestTimeout } from './timeout';
 
@@ -55,7 +56,8 @@ request.interceptors.response.use(
         // Unauthorized. Jump to the login page.
         Promise.reject(error);
         if (window.location.href.indexOf('/init') === -1 && window.location.href.indexOf('/login') === -1) {
-          window.location.href = `/login?redirect=${window.location.pathname}`;
+          const search = buildRedirectSearch(window.location.pathname, window.location.search);
+          window.location.href = search ? `/login?${search}` : '/login';
         }
         return;
       }

--- a/frontend/src/utils/redirect.test.ts
+++ b/frontend/src/utils/redirect.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  sanitizeRedirectValue,
+  buildRedirectSearch,
+} from './redirect.ts';
+
+// --- sanitizeRedirectValue ---
+
+test('sanitizeRedirectValue: null returns /', () => {
+  assert.equal(sanitizeRedirectValue(null), '/');
+});
+
+test('sanitizeRedirectValue: undefined returns /', () => {
+  assert.equal(sanitizeRedirectValue(undefined), '/');
+});
+
+test('sanitizeRedirectValue: empty string returns /', () => {
+  assert.equal(sanitizeRedirectValue(''), '/');
+});
+
+test('sanitizeRedirectValue: root path returns /', () => {
+  assert.equal(sanitizeRedirectValue('/'), '/');
+});
+
+test('sanitizeRedirectValue: simple path passes through', () => {
+  assert.equal(sanitizeRedirectValue('/users'), '/users');
+});
+
+test('sanitizeRedirectValue: path with query passes through', () => {
+  assert.equal(
+    sanitizeRedirectValue('/users?tab=profile&id=42'),
+    '/users?tab=profile&id=42',
+  );
+});
+
+test('sanitizeRedirectValue: path with hash passes through', () => {
+  assert.equal(sanitizeRedirectValue('/users#section'), '/users#section');
+});
+
+test('sanitizeRedirectValue: /login is collapsed to / (anti self-loop)', () => {
+  assert.equal(sanitizeRedirectValue('/login'), '/');
+});
+
+test('sanitizeRedirectValue: /login with query is collapsed (anti self-loop)', () => {
+  assert.equal(sanitizeRedirectValue('/login?next=1'), '/');
+});
+
+test('sanitizeRedirectValue: case-variant /LOGIN is collapsed (anti self-loop)', () => {
+  assert.equal(sanitizeRedirectValue('/LOGIN'), '/');
+  assert.equal(sanitizeRedirectValue('/Login'), '/');
+});
+
+test('sanitizeRedirectValue: protocol-relative URL is rejected', () => {
+  assert.equal(sanitizeRedirectValue('//evil.com/x'), '/');
+  assert.equal(sanitizeRedirectValue('///evil.com'), '/');
+});
+
+test('sanitizeRedirectValue: absolute http(s) URL is rejected', () => {
+  assert.equal(sanitizeRedirectValue('https://evil.com'), '/');
+  // eslint-disable-next-line @iceworks/best-practices/no-http-url
+  assert.equal(sanitizeRedirectValue('http://evil.com'), '/');
+});
+
+test('sanitizeRedirectValue: javascript: scheme is rejected', () => {
+  // eslint-disable-next-line no-script-url
+  assert.equal(sanitizeRedirectValue('javascript:alert(1)'), '/');
+});
+
+test('sanitizeRedirectValue: data: scheme is rejected', () => {
+  assert.equal(sanitizeRedirectValue('data:text/html,<x>'), '/');
+});
+
+test('sanitizeRedirectValue: leading whitespace is rejected', () => {
+  assert.equal(sanitizeRedirectValue(' /foo'), '/');
+});
+
+test('sanitizeRedirectValue: ASCII tab in path is rejected (open-redirect bypass)', () => {
+  // URLSearchParams decodes %09 to '\t'. WHATWG strips C0 controls before parsing,
+  // so '/\t/evil.com' resolves to '//evil.com' = protocol-relative. Reject.
+  assert.equal(sanitizeRedirectValue('/\t/evil.com'), '/');
+});
+
+test('sanitizeRedirectValue: ASCII LF in path is rejected (open-redirect bypass)', () => {
+  assert.equal(sanitizeRedirectValue('/\n/evil.com'), '/');
+});
+
+test('sanitizeRedirectValue: ASCII CR in path is rejected (open-redirect bypass)', () => {
+  assert.equal(sanitizeRedirectValue('/\r/evil.com'), '/');
+});
+
+test('sanitizeRedirectValue: backslash-leading is rejected', () => {
+  assert.equal(sanitizeRedirectValue('\\foo'), '/');
+});
+
+test('sanitizeRedirectValue: slash-backslash prefix is rejected (open-redirect)', () => {
+  assert.equal(sanitizeRedirectValue('/\\evil.com'), '/');
+  assert.equal(sanitizeRedirectValue('/\\'), '/');
+});
+
+test('sanitizeRedirectValue: path with internal space passes through', () => {
+  assert.equal(sanitizeRedirectValue('/foo bar'), '/foo bar');
+});
+
+test('sanitizeRedirectValue: non-string input returns /', () => {
+  assert.equal(sanitizeRedirectValue(123 as unknown as string), '/');
+  assert.equal(sanitizeRedirectValue({} as unknown as string), '/');
+});
+
+// --- buildRedirectSearch ---
+
+test('buildRedirectSearch: root path with no search returns empty', () => {
+  assert.equal(buildRedirectSearch('/', ''), '');
+});
+
+test('buildRedirectSearch: empty pathname returns empty', () => {
+  assert.equal(buildRedirectSearch('', ''), '');
+});
+
+test('buildRedirectSearch: pathname only', () => {
+  assert.equal(buildRedirectSearch('/users', ''), 'redirect=%2Fusers');
+});
+
+test('buildRedirectSearch: pathname with query (question mark encoded)', () => {
+  assert.equal(
+    buildRedirectSearch('/users/123', '?tab=profile'),
+    'redirect=%2Fusers%2F123%3Ftab%3Dprofile',
+  );
+});
+
+test('buildRedirectSearch: query with space', () => {
+  assert.equal(
+    buildRedirectSearch('/x', '?q=a b'),
+    'redirect=%2Fx%3Fq%3Da%20b',
+  );
+});
+
+test('buildRedirectSearch: query with ampersand is correctly encoded', () => {
+  assert.equal(
+    buildRedirectSearch('/x', '?q=a&b=c'),
+    'redirect=%2Fx%3Fq%3Da%26b%3Dc',
+  );
+});
+
+test('buildRedirectSearch: empty search string still produces redirect=', () => {
+  assert.equal(buildRedirectSearch('/x', ''), 'redirect=%2Fx');
+});
+
+test('buildRedirectSearch: non-string pathname returns empty', () => {
+  assert.equal(buildRedirectSearch(null as unknown as string, ''), '');
+});
+
+test('buildRedirectSearch: protocol-relative pathname is encoded (NOT validated)', () => {
+  // The function only encodes; safety validation is the consumer's job.
+  assert.equal(
+    buildRedirectSearch('//evil.com', ''),
+    'redirect=%2F%2Fevil.com',
+  );
+});

--- a/frontend/src/utils/redirect.ts
+++ b/frontend/src/utils/redirect.ts
@@ -1,0 +1,69 @@
+/**
+ * Validate and sanitize a `redirect` query-string value to prevent open-redirect
+ * attacks and self-loops on /login. Returns a safe path suitable for
+ * `history.push(...)`.
+ *
+ * Rules:
+ *  - Non-string / null / undefined / empty → '/'
+ *  - Must start with a single '/' (rejects whitespace, backslash-leading or
+ *    slash-backslash '/\', URL schemes like 'http://', 'javascript:', 'data:',
+ *    and protocol-relative '//evil.com')
+ *  - Must NOT be '/login' (case-insensitive path-segment match, with or
+ *    without query/hash suffix)
+ *  - Must NOT contain ASCII control characters (WHATWG URL parsing strips
+ *    C0 controls and DEL before parsing, so e.g. '/\t/evil.com' becomes
+ *    '//evil.com' = protocol-relative)
+ *
+ * Otherwise the input is returned as-is (may include query / hash fragments).
+ */
+export function sanitizeRedirectValue(raw: string | null | undefined): string {
+  if (typeof raw !== 'string') {
+    return '/';
+  }
+  // Trim is intentionally NOT applied: a leading-space value is suspicious.
+  if (raw.length === 0) {
+    return '/';
+  }
+  // WHATWG URL parsing strips ASCII tab/LF/CR (and other C0 controls) BEFORE parsing,
+  // so '/\t/evil.com' resolves to '//evil.com' = protocol-relative.
+  // Reject any control character to close this open-redirect bypass.
+  if (/[\x00-\x1F\x7F]/.test(raw)) {
+    return '/';
+  }
+  // Self-loop guard: catch '/login', '/LOGIN', '/login?next=1', '/login#foo'.
+  // Anything whose path segment (case-insensitive) is '/login' is the login page.
+  const pathSegment = raw.split(/[?#]/, 1)[0];
+  if (pathSegment.toLowerCase() === '/login') {
+    return '/';
+  }
+  // Must start with exactly one '/' (rejects backslash, whitespace, scheme prefixes
+  // like 'http://', 'javascript:', 'data:', and protocol-relative '//evil.com').
+  if (raw[0] !== '/' || raw[1] === '/' || raw[1] === '\\') {
+    return '/';
+  }
+  return raw;
+}
+
+/**
+ * Build the `redirect=...` portion (without the leading '?') for a /login URL
+ * when forcing a user back to their original page after a 401.
+ *
+ * Returns an empty string when the resulting target is just the root path
+ * (no need to round-trip '/' back to itself). Otherwise returns
+ * `redirect=<encodeURIComponent(pathname+search)>` so that '?', '&' and '='
+ * inside pathname+search are correctly escaped as data inside the outer query.
+ *
+ * This function ONLY encodes; safety validation is the consumer's job
+ * (use sanitizeRedirectValue on the read-back value in the login page).
+ */
+export function buildRedirectSearch(pathname: string, search: string): string {
+  if (typeof pathname !== 'string' || pathname.length === 0) {
+    return '';
+  }
+  // location.search already includes the leading '?' when present.
+  const combined = pathname + (search || '');
+  if (combined === '/') {
+    return '';
+  }
+  return `redirect=${encodeURIComponent(combined)}`;
+}


### PR DESCRIPTION
Fixes #772

## Problem

Clicking "logout" in the avatar dropdown navigates the user to `/login?redirect=<pathname>`. This has two defects:

1. **Query string is dropped.** `redirect` uses `pathname` only, not `pathname + search`. On `/users?tab=profile`, after login the user lands on `/users` and loses `tab=profile`, breaking page state.
2. **No URL encoding.** Special characters in the path are not escaped, leading to parsing errors.

User request: after logout, default to landing on the root page after re-login.

## Solution

Extract two pure functions into `frontend/src/utils/redirect.ts`:

- **`sanitizeRedirectValue(raw)`** — validates and sanitizes a `redirect` query value. Rejects `//host`, `http(s)://`, `javascript:`, the `/login` self-loop (case-insensitive, with or without query/hash suffix), `/\host`, and C0 control characters. All open-redirect defenses live here.
- **`buildRedirectSearch(pathname, search)`** — used in the 401 flow. Combines `pathname + search`, runs `encodeURIComponent` over the result, and returns `redirect=<encoded>` (without the leading `?`). The caller decides whether to add `?`.

Three call sites share the helpers:

- `AvatarDropdown/index.tsx` — active logout now calls `history.push('/login')`, no `redirect` param.
- `services/request.tsx` — 401 interceptor uses `buildRedirectSearch(pathname, search)` so `pathname + search` round-trip cleanly.
- `pages/login/index.tsx` — after successful login, `sanitizeRedirectValue(urlParams.get('redirect'))` validates the value before navigation.

## Additional Security Hardening (from code review)

Bugs that code review caught before the fix landed:

1. **`/\evil.com` protocol-relative bypass.** WHATWG URL parsing treats `\` as `/` inside the authority, so `/\evil.com` resolves to `//evil.com`. Closed by adding `raw[1] === '\'` to the leading-slash guard.
2. **ASCII control-character bypass.** C0 controls (TAB, LF, CR) are stripped by URL parsing *before* parsing, so `/\t/evil.com`, `/\n/evil.com`, `/\r/evil.com` all become `//evil.com`. Closed by adding `/[\x00-\x1F\x7F]/` rejection.
3. **`/login` self-loop guard was exact-match.** The original `===` check could be bypassed by `/login?next=1`, `/LOGIN`, etc. Tightened to a path-segment match.

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/utils/redirect.ts` | New. `sanitizeRedirectValue` + `buildRedirectSearch` |
| `frontend/src/utils/redirect.test.ts` | New. 31 `node:test` cases |
| `frontend/src/components/AvatarDropdown/index.tsx` | Drop `redirect=<pathname>` in `doLogout` |
| `frontend/src/services/request.tsx` | Use `buildRedirectSearch` in 401 handler |
| `frontend/src/pages/login/index.tsx` | Use `sanitizeRedirectValue` post-login |

## Verification

- 31 `node:test` cases all green (covers normal paths, all known bypass vectors).
- ESLint clean (`eslint-disable-next-line` suppressions are scoped to attack-vector test fixtures only).
- `tsc --noEmit` introduces no new errors (only the pre-existing `dompurify` typing issue remains).
- Backwards-compatible: legitimate paths still flow through unchanged; the login page's existing fallback to `/` is preserved.

## Test Plan (manual e2e)

- [ ] Login → visit `/users?tab=profile` → click logout → after re-login land on `/` (not `/users`)
- [ ] Login → visit `/users?tab=profile` → clear `localStorage.token` and make any API call → after re-login return to `/users?tab=profile`
- [ ] Open `/login?redirect=https://example.com` directly → login → land on `/`
- [ ] Open `/login?redirect=//example.com` directly → login → land on `/`
- [ ] Open `/login?redirect=/login` or `/login?redirect=/LOGIN` directly → login → land on `/`