### PR TITLE
fix: retry conflicting WasmPlugin instance updates

### DIFF
--- a/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
+++ b/backend/sdk/src/main/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -51,6 +52,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
+
+    private static final int MAX_UPDATE_ATTEMPTS = 3;
+    private static final long UPDATE_RETRY_DELAY_MILLIS = 10L;
 
     private final WasmPluginService wasmPluginService;
     private final KubernetesClientService kubernetesClientService;
@@ -192,38 +196,6 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
                 continue;
             }
 
-            V1alpha1WasmPlugin existedCr = null;
-            try {
-                // Internal CRs use a stable name independent of the plugin version, so they are looked up by name
-                // only to stay compatible with CRs created from older plugin versions.
-                List<V1alpha1WasmPlugin> existedCrs = internal ? kubernetesClientService.listWasmPlugin(name)
-                    : kubernetesClientService.listWasmPlugin(name, version);
-                if (CollectionUtils.isNotEmpty(existedCrs)) {
-                    existedCr = existedCrs.stream().filter(cr -> internal == KubernetesUtil.isInternalResource(cr))
-                        .findFirst().orElse(null);
-                }
-            } catch (ApiException e) {
-                throw new BusinessException("Error occurs when getting WasmPlugin.", e);
-            }
-
-            V1alpha1WasmPlugin result;
-            if (existedCr != null) {
-                result = existedCr;
-                String existedVersion = KubernetesUtil.getLabel(existedCr.getMetadata(),
-                    KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY);
-                if (internal && Boolean.TRUE.equals(plugin.getBuiltIn())
-                    && !plugin.getPluginVersion().equals(existedVersion)) {
-                    V1alpha1WasmPlugin currentCr = kubernetesModelConverter.wasmPluginToCr(plugin, true);
-                    currentCr.getMetadata().setResourceVersion(existedCr.getMetadata().getResourceVersion());
-                    kubernetesModelConverter.mergeWasmPluginSpec(existedCr, currentCr);
-                    result = currentCr;
-                }
-            } else if (version.equals(plugin.getPluginVersion())) {
-                result = kubernetesModelConverter.wasmPluginToCr(plugin, internal);
-            } else {
-                throw new IllegalArgumentException("Add operation is only allowed for the current plugin version.");
-            }
-
             for (WasmPluginInstance instance : instancesToUpdate) {
                 if (instance.getConfigurations() == null && StringUtils.isNotEmpty(instance.getRawConfigurations())) {
                     try {
@@ -242,22 +214,9 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
                     configurations = pluginConfig.validateAndCleanUp(configurations);
                 }
                 instance.setConfigurations(configurations);
-                kubernetesModelConverter.setWasmPluginInstanceToCr(result, instance);
             }
 
-            try {
-                if (existedCr == null) {
-                    result = kubernetesClientService.createWasmPlugin(result);
-                } else {
-                    result = kubernetesClientService.replaceWasmPlugin(result);
-                }
-            } catch (ApiException e) {
-                if (e.getCode() == HttpStatus.CONFLICT) {
-                    throw new ResourceConflictException();
-                }
-                throw new BusinessException(
-                    "Error occurs when adding or updating the WasmPlugin CR with name: " + plugin.getName(), e);
-            }
+            V1alpha1WasmPlugin result = addOrUpdateGroupWithRetry(name, version, internal, plugin, instancesToUpdate);
 
             for (WasmPluginInstance instance : instancesToUpdate) {
                 beforeToAfterMap.put(instance,
@@ -266,6 +225,82 @@ class WasmPluginInstanceServiceImpl implements WasmPluginInstanceService {
         }
 
         return instances.stream().map(beforeToAfterMap::get).collect(Collectors.toList());
+    }
+
+    private V1alpha1WasmPlugin addOrUpdateGroupWithRetry(String name, String version, boolean internal,
+        WasmPlugin plugin, List<WasmPluginInstance> instancesToUpdate) {
+        for (int attempt = 1; attempt <= MAX_UPDATE_ATTEMPTS; attempt++) {
+            V1alpha1WasmPlugin existedCr = getExistingCr(name, version, internal);
+            V1alpha1WasmPlugin result = buildCrForUpdate(version, internal, plugin, existedCr);
+            for (WasmPluginInstance instance : instancesToUpdate) {
+                kubernetesModelConverter.setWasmPluginInstanceToCr(result, instance);
+            }
+
+            try {
+                return existedCr == null ? kubernetesClientService.createWasmPlugin(result)
+                    : kubernetesClientService.replaceWasmPlugin(result);
+            } catch (ApiException e) {
+                if (e.getCode() != HttpStatus.CONFLICT) {
+                    throw new BusinessException(
+                        "Error occurs when adding or updating the WasmPlugin CR with name: " + plugin.getName(), e);
+                }
+                if (attempt == MAX_UPDATE_ATTEMPTS) {
+                    throw new ResourceConflictException("Failed to add or update WasmPlugin " + name + " (internal="
+                        + internal + ") after " + MAX_UPDATE_ATTEMPTS + " attempts due to concurrent updates.");
+                }
+                log.warn("Conflict while updating WasmPlugin {} on attempt {}. Retrying with the latest resource.",
+                    name, attempt);
+                waitBeforeRetry(name, attempt);
+            }
+        }
+        throw new IllegalStateException("Unreachable WasmPlugin update retry state.");
+    }
+
+    private V1alpha1WasmPlugin getExistingCr(String name, String version, boolean internal) {
+        try {
+            // Internal CRs use a stable name independent of the plugin version, so they are looked up by name
+            // only to stay compatible with CRs created from older plugin versions.
+            List<V1alpha1WasmPlugin> existedCrs = internal ? kubernetesClientService.listWasmPlugin(name)
+                : kubernetesClientService.listWasmPlugin(name, version);
+            if (CollectionUtils.isEmpty(existedCrs)) {
+                return null;
+            }
+            return existedCrs.stream().filter(cr -> internal == KubernetesUtil.isInternalResource(cr)).findFirst()
+                .orElse(null);
+        } catch (ApiException e) {
+            throw new BusinessException("Error occurs when getting WasmPlugin.", e);
+        }
+    }
+
+    private V1alpha1WasmPlugin buildCrForUpdate(String version, boolean internal, WasmPlugin plugin,
+        V1alpha1WasmPlugin existedCr) {
+        if (existedCr == null) {
+            if (version.equals(plugin.getPluginVersion())) {
+                return kubernetesModelConverter.wasmPluginToCr(plugin, internal);
+            }
+            throw new IllegalArgumentException("Add operation is only allowed for the current plugin version.");
+        }
+
+        String existedVersion = KubernetesUtil.getLabel(existedCr.getMetadata(),
+            KubernetesConstants.Label.WASM_PLUGIN_VERSION_KEY);
+        if (!internal || !Boolean.TRUE.equals(plugin.getBuiltIn())
+            || plugin.getPluginVersion().equals(existedVersion)) {
+            return existedCr;
+        }
+
+        V1alpha1WasmPlugin currentCr = kubernetesModelConverter.wasmPluginToCr(plugin, true);
+        currentCr.getMetadata().setResourceVersion(existedCr.getMetadata().getResourceVersion());
+        kubernetesModelConverter.mergeWasmPluginSpec(existedCr, currentCr);
+        return currentCr;
+    }
+
+    private void waitBeforeRetry(String name, int attempt) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(UPDATE_RETRY_DELAY_MILLIS * attempt);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException("Interrupted while retrying WasmPlugin update for: " + name, e);
+        }
     }
 
     @Override

--- a/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
+++ b/backend/sdk/src/test/java/com/alibaba/higress/sdk/service/WasmPluginInstanceServiceTest.java
@@ -37,7 +37,9 @@ import com.alibaba.higress.sdk.constant.HigressConstants;
 import com.alibaba.higress.sdk.constant.KubernetesConstants;
 import com.alibaba.higress.sdk.constant.Separators;
 import com.alibaba.higress.sdk.exception.BusinessException;
+import com.alibaba.higress.sdk.exception.ResourceConflictException;
 import com.alibaba.higress.sdk.exception.ValidationException;
+import com.alibaba.higress.sdk.http.HttpStatus;
 import com.alibaba.higress.sdk.model.WasmPlugin;
 import com.alibaba.higress.sdk.model.WasmPluginInstance;
 import com.alibaba.higress.sdk.model.WasmPluginInstanceScope;
@@ -495,6 +497,100 @@ public class WasmPluginInstanceServiceTest {
     }
 
     @Test
+    public void addOrUpdateRetriesConflictAndMergesLatestCr() throws Exception {
+        V1alpha1WasmPlugin staleCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
+        staleCr.getMetadata().setResourceVersion("10");
+
+        V1alpha1WasmPlugin latestCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
+        latestCr.getMetadata().setResourceVersion("11");
+        WasmPluginInstance concurrentInstance = WasmPluginInstance.builder()
+            .pluginName(TEST_BUILT_IN_PLUGIN_NAME).pluginVersion(DEFAULT_VERSION)
+            .targets(MapUtil.of(WasmPluginInstanceScope.ROUTE, "concurrent-route")).enabled(true)
+            .configurations(MapUtil.of("concurrent", "config")).internal(true).build();
+        kubernetesModelConverter.setWasmPluginInstanceToCr(latestCr, concurrentInstance);
+
+        when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME)))
+            .thenReturn(Lists.newArrayList(staleCr), Lists.newArrayList(latestCr));
+        when(kubernetesClientService.replaceWasmPlugin(any()))
+            .thenThrow(new ApiException(HttpStatus.CONFLICT, "Conflict"))
+            .thenAnswer(i -> i.getArguments()[0]);
+
+        WasmPluginInstance requestedInstance = WasmPluginInstance.builder()
+            .pluginName(TEST_BUILT_IN_PLUGIN_NAME).pluginVersion(DEFAULT_VERSION)
+            .targets(MapUtil.of(WasmPluginInstanceScope.ROUTE, "requested-route")).enabled(true)
+            .configurations(MapUtil.of("requested", "config")).internal(true).build();
+
+        WasmPluginInstance result = service.addOrUpdate(requestedInstance);
+
+        Assertions.assertEquals(requestedInstance.getConfigurations(), result.getConfigurations());
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(2)).replaceWasmPlugin(crCaptor.capture());
+        V1alpha1WasmPlugin retriedCr = crCaptor.getAllValues().get(1);
+        Assertions.assertEquals("11", retriedCr.getMetadata().getResourceVersion());
+        Assertions.assertNotNull(kubernetesModelConverter.getWasmPluginInstanceFromCr(retriedCr,
+            MapUtil.of(WasmPluginInstanceScope.ROUTE, "concurrent-route")));
+        Assertions.assertNotNull(kubernetesModelConverter.getWasmPluginInstanceFromCr(retriedCr,
+            MapUtil.of(WasmPluginInstanceScope.ROUTE, "requested-route")));
+    }
+
+    @Test
+    public void addOrUpdateRecoversFromCreateConflict() throws Exception {
+        V1alpha1WasmPlugin concurrentlyCreatedCr =
+            buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
+        concurrentlyCreatedCr.getMetadata().setResourceVersion("11");
+        WasmPluginInstance concurrentInstance = WasmPluginInstance.builder()
+            .pluginName(TEST_BUILT_IN_PLUGIN_NAME).pluginVersion(DEFAULT_VERSION)
+            .targets(MapUtil.of(WasmPluginInstanceScope.ROUTE, "concurrent-route")).enabled(true)
+            .configurations(MapUtil.of("concurrent", "config")).internal(true).build();
+        kubernetesModelConverter.setWasmPluginInstanceToCr(concurrentlyCreatedCr, concurrentInstance);
+
+        when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME)))
+            .thenReturn(Collections.emptyList(), Lists.newArrayList(concurrentlyCreatedCr));
+        when(kubernetesClientService.createWasmPlugin(any()))
+            .thenThrow(new ApiException(HttpStatus.CONFLICT, "Conflict"));
+        when(kubernetesClientService.replaceWasmPlugin(any())).thenAnswer(i -> i.getArguments()[0]);
+
+        WasmPluginInstance requestedInstance = WasmPluginInstance.builder()
+            .pluginName(TEST_BUILT_IN_PLUGIN_NAME).pluginVersion(DEFAULT_VERSION)
+            .targets(MapUtil.of(WasmPluginInstanceScope.ROUTE, "requested-route")).enabled(true)
+            .configurations(MapUtil.of("requested", "config")).internal(true).build();
+
+        WasmPluginInstance result = service.addOrUpdate(requestedInstance);
+
+        Assertions.assertEquals(requestedInstance.getConfigurations(), result.getConfigurations());
+        verify(kubernetesClientService, times(1)).createWasmPlugin(any());
+        ArgumentCaptor<V1alpha1WasmPlugin> crCaptor = ArgumentCaptor.forClass(V1alpha1WasmPlugin.class);
+        verify(kubernetesClientService, times(1)).replaceWasmPlugin(crCaptor.capture());
+        V1alpha1WasmPlugin retriedCr = crCaptor.getValue();
+        Assertions.assertNotNull(kubernetesModelConverter.getWasmPluginInstanceFromCr(retriedCr,
+            MapUtil.of(WasmPluginInstanceScope.ROUTE, "concurrent-route")));
+        Assertions.assertNotNull(kubernetesModelConverter.getWasmPluginInstanceFromCr(retriedCr,
+            MapUtil.of(WasmPluginInstanceScope.ROUTE, "requested-route")));
+    }
+
+    @Test
+    public void addOrUpdateStopsAfterRepeatedConflicts() throws Exception {
+        V1alpha1WasmPlugin existedCr = buildWasmPluginResource(TEST_BUILT_IN_PLUGIN_NAME, true, true);
+        when(kubernetesClientService.listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME)))
+            .thenReturn(Lists.newArrayList(existedCr));
+        when(kubernetesClientService.replaceWasmPlugin(any()))
+            .thenThrow(new ApiException(HttpStatus.CONFLICT, "Conflict"));
+
+        WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(TEST_BUILT_IN_PLUGIN_NAME)
+            .pluginVersion(DEFAULT_VERSION).targets(MapUtil.of(WasmPluginInstanceScope.ROUTE, "requested-route"))
+            .enabled(true).configurations(MapUtil.of("requested", "config")).internal(true).build();
+
+        ResourceConflictException exception =
+            Assertions.assertThrows(ResourceConflictException.class, () -> service.addOrUpdate(instance));
+
+        Assertions.assertTrue(exception.getMessage().contains(TEST_BUILT_IN_PLUGIN_NAME));
+        Assertions.assertTrue(exception.getMessage().contains("internal=true"));
+        Assertions.assertTrue(exception.getMessage().contains("3 attempts"));
+        verify(kubernetesClientService, times(3)).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME));
+        verify(kubernetesClientService, times(3)).replaceWasmPlugin(any());
+    }
+
+    @Test
     public void addOrUpdateAllTestVersionMismatch() {
         WasmPluginInstance instance = WasmPluginInstance.builder().pluginName(TEST_BUILT_IN_PLUGIN_NAME)
             .pluginVersion("2.0.0").targets(MapUtil.of(WasmPluginInstanceScope.GLOBAL, null)).enabled(true)
@@ -538,6 +634,8 @@ public class WasmPluginInstanceServiceTest {
 
         Assertions
             .assertTrue(exception.getMessage().contains("Error occurs when adding or updating the WasmPlugin CR"));
+        verify(kubernetesClientService, times(1)).listWasmPlugin(eq(TEST_BUILT_IN_PLUGIN_NAME), anyString());
+        verify(kubernetesClientService, times(1)).replaceWasmPlugin(any());
     }
 
     private V1alpha1WasmPlugin buildWasmPluginResource(String name, boolean builtIn, boolean internal) {


### PR DESCRIPTION
## Summary

- retry the complete WasmPlugin read, merge, and create/replace operation when Kubernetes returns HTTP 409
- reread the latest CR before each retry so concurrently added plugin instances are preserved
- recover from create races, stop after three attempts, and include the plugin group in exhaustion diagnostics
- add regression coverage for replace conflicts, create conflicts, retry exhaustion, and non-409 failures

## Problem

OpenAPI MCP Servers store route-scoped configurations in the shared internal
`mcp-server` WasmPlugin CR. Concurrent operations can read the same
`resourceVersion`; after one update succeeds, the other receives 409 and was
previously surfaced as `ResourceConflictException: null` and HTTP 500.

The retry is scoped to one `WasmPluginInstanceGroupKey`. It does not retry the
complete MCP save flow, which may already have written the route and
authorization resources.

## Validation

- `cd backend && ./mvnw -pl sdk -Dtest=WasmPluginInstanceServiceTest,McpServerServiceTest test`
- `cd backend && ./mvnw -pl sdk test`
- `git diff --check origin/main...HEAD`

The primary regression test was observed failing on the original code with
`ResourceConflictException`, then passing after the retry implementation.

Fixes #775

## Agent assistance

Codex assisted with diagnosis, implementation, tests, and PR preparation. The
change was independently reviewed against the exact commit before submission.
