### PR TITLE
fix: move ai-load-balancer to AUTHN phase ahead of ai-proxy

### DIFF
--- a/backend/sdk/src/main/resources/plugins/ai-load-balancer/spec.yaml
+++ b/backend/sdk/src/main/resources/plugins/ai-load-balancer/spec.yaml
@@ -20,8 +20,8 @@ info:
   contact:
     name: johnlanni
 spec:
-  phase: default
-  priority: 50
+  phase: AUTHN
+  priority: 901
   configSchema:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
## Summary

Move the `ai-load-balancer` built-in plugin from the default phase (priority 50) to the **AUTHN phase with priority 901**, so it executes **before** `ai-proxy` and `model-router` (AUTHN/900).

### Why

Reported in higress-group/higress#4610: with AI model routing + cross-service load balancing enabled, previously-working requests return 404.

Root cause (execution-order problem, not a plugin logic bug):

- The plugin currently runs in the default phase with priority 50, i.e. **after** ai-proxy (default phase, priority 100).
- With cross-service load balancing, ai-load-balancer writes the `x-higress-target-cluster` request header on every request. In Higress, a wasm plugin modifying request headers triggers Envoy route re-matching.
- Since ai-proxy has already rewritten the Host/path by then, the re-match runs against the already-rewritten Host/path and fails, producing 404.

Moving the plugin to AUTHN/901 makes it run before all AI traffic-mutating plugins, so the header write happens on the original route context and re-matching is harmless.

### Changes

- `backend/sdk/src/main/resources/plugins/ai-load-balancer/spec.yaml`: `phase: default` → `phase: AUTHN`, `priority: 50` → `priority: 901`

## Test Plan

- [x] `./mvnw -pl sdk validate`
- [x] `./mvnw -pl sdk test -Dtest='WasmPlugin*Test'` — 33 tests pass
- [ ] CI

For higress-group/higress#4610